### PR TITLE
fix default for cluster_type

### DIFF
--- a/roles/configurations/tasks/human_readableid.yml
+++ b/roles/configurations/tasks/human_readableid.yml
@@ -1,5 +1,5 @@
 ---
-- name: Apply Human ReadableID on {{ cluster }}
+- name: Apply Human ReadableID on {{ cluster }} in {{ org }}
   axonops.axonops.human_readableid:
     org: "{{ org }}"
     cluster: "{{ cluster }}"

--- a/roles/configurations/tasks/main.yml
+++ b/roles/configurations/tasks/main.yml
@@ -10,8 +10,10 @@
 
 - name: Get cluster type
   ansible.builtin.set_fact:
-    cluster_type: "{{ lookup('env', 'AXONOPS_CLUSTER_TYPE') | default('cassandra') }}"
-  when: cluster_type is not defined
+    cluster_type: "{{  lookup('env', 'AXONOPS_CLUSTER_TYPE') 
+     if lookup('env', 'AXONOPS_CLUSTER_TYPE') | length > 0 
+     else 'cassandra' }}"
+  when: cluster_type is not defined or cluster_type | length == 0
 
 - name: Assert all required variables are set
   ansible.builtin.assert:


### PR DESCRIPTION
`lookup('env', 'AXONOPS_CLUSTER_TYPE')` can return `""` if the env is not defined, which avoids the `| default('cassandra')`. 

This PR adds the `| length > 0` to be more specific.