### PR TITLE
feat: add opensearch role and CI path filters

### DIFF
--- a/.github/workflows/agent-molecule.yml
+++ b/.github/workflows/agent-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/agent/**'
+      - '.github/workflows/agent-molecule.yml'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'roles/agent/**'
+      - '.github/workflows/agent-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/cassandra-molecule.yml
+++ b/.github/workflows/cassandra-molecule.yml
@@ -5,7 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/cassandra/**'
+      - '.github/workflows/cassandra-molecule.yml'
   pull_request:
+    paths:
+      - 'roles/cassandra/**'
+      - '.github/workflows/cassandra-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/dash-molecule.yml
+++ b/.github/workflows/dash-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/dash/**'
+      - '.github/workflows/dash-molecule.yml'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'roles/dash/**'
+      - '.github/workflows/dash-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/elastic-molecule.yml
+++ b/.github/workflows/elastic-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/elastic/**'
+      - '.github/workflows/elastic-molecule.yml'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'roles/elastic/**'
+      - '.github/workflows/elastic-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/java-molecule.yml
+++ b/.github/workflows/java-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/java/**'
+      - '.github/workflows/java-molecule.yml'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'roles/java/**'
+      - '.github/workflows/java-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/k8ssandra-molecule.yml
+++ b/.github/workflows/k8ssandra-molecule.yml
@@ -5,7 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/k8ssandra/**'
+      - '.github/workflows/k8ssandra-molecule.yml'
   pull_request:
+    paths:
+      - 'roles/k8ssandra/**'
+      - '.github/workflows/k8ssandra-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/opensearch-molecule.yml
+++ b/.github/workflows/opensearch-molecule.yml
@@ -1,0 +1,56 @@
+---
+name: OpenSearch Molecule
+
+on:
+  push:
+    branches:
+      - main
+      - feat/k8ssandra
+  pull_request:
+
+defaults:
+  run:
+    working-directory: roles/opensearch
+
+jobs:
+  molecule:
+    name: Molecule OpenSearch (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - rockylinux9
+          - ubuntu2204
+          - ubuntu2404
+          - debian12
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule molecule-plugins[docker] docker
+
+      - name: Run Molecule destroy (ignore failures)
+        run: molecule -v destroy
+        continue-on-error: true
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: opensearch-${{ matrix.distro }}
+
+      - name: Run Molecule converge
+        run: molecule -v converge
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: opensearch-${{ matrix.distro }}

--- a/.github/workflows/opensearch-molecule.yml
+++ b/.github/workflows/opensearch-molecule.yml
@@ -5,8 +5,13 @@ on:
   push:
     branches:
       - main
-      - feat/opensearch
+    paths:
+      - 'roles/opensearch/**'
+      - '.github/workflows/opensearch-molecule.yml'
   pull_request:
+    paths:
+      - 'roles/opensearch/**'
+      - '.github/workflows/opensearch-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/opensearch-molecule.yml
+++ b/.github/workflows/opensearch-molecule.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - feat/k8ssandra
+      - feat/opensearch
   pull_request:
 
 defaults:

--- a/.github/workflows/server-molecule.yml
+++ b/.github/workflows/server-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/server/**'
+      - '.github/workflows/server-molecule.yml'
   pull_request:
-    branches:
-      - main
+    paths:
+      - 'roles/server/**'
+      - '.github/workflows/server-molecule.yml'
 
 defaults:
   run:

--- a/.github/workflows/strimzi-molecule.yml
+++ b/.github/workflows/strimzi-molecule.yml
@@ -5,8 +5,13 @@ on:
   push:
     branches:
       - main
-      - feat/k8ssandra
+    paths:
+      - 'roles/strimzi/**'
+      - '.github/workflows/strimzi-molecule.yml'
   pull_request:
+    paths:
+      - 'roles/strimzi/**'
+      - '.github/workflows/strimzi-molecule.yml'
 
 defaults:
   run:

--- a/docs/roles/README.md
+++ b/docs/roles/README.md
@@ -50,6 +50,11 @@ Installs and configures Elasticsearch for AxonOps Server configuration storage.
 
 **Use when**: Deploying a self-hosted AxonOps Server (Elasticsearch stores AxonOps configuration data).
 
+#### [opensearch](opensearch.md)
+Installs and configures OpenSearch as the backend store for AxonOps Server (replaces Elasticsearch).
+
+**Use when**: Deploying a self-hosted AxonOps Server with OpenSearch instead of Elasticsearch.
+
 #### [java](java.md)
 Installs Java (OpenJDK or Azul Zulu) on target systems.
 
@@ -74,6 +79,7 @@ Performs pre-installation checks to ensure systems meet requirements.
 | **strimzi** | Kafka on Kubernetes | Kubernetes cluster |
 | **cassandra** | Apache Cassandra installation | Agent, Java |
 | **elastic** | Elasticsearch installation | Server |
+| **opensearch** | OpenSearch installation | Server |
 | **java** | Java installation | Cassandra, Elastic |
 | **preflight** | System validation | Before any installation |
 

--- a/docs/roles/opensearch.md
+++ b/docs/roles/opensearch.md
@@ -1,0 +1,167 @@
+# OpenSearch Role
+
+## Overview
+
+The `opensearch` role installs and configures OpenSearch on target nodes. It is used as the backend configuration store for self-hosted AxonOps Server deployments, replacing Elasticsearch. It supports both single-node and multi-node cluster configurations with optional TLS security.
+
+## Requirements
+
+- Ansible 2.10 or higher
+- Target system running a supported Linux distribution (RHEL 8/9, Ubuntu, Debian)
+- The `ansible.posix` collection (`ansible-galaxy collection install ansible.posix`)
+
+## Role Variables
+
+### Basic Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_version` | `3.0.0` | OpenSearch version to install |
+| `opensearch_cluster_name` | `opensearch` | Cluster name |
+| `opensearch_cluster_type` | `multi-node` | `single-node` or `multi-node` |
+| `opensearch_install_root` | `/usr/share/opensearch` | Installation directory |
+| `opensearch_user` | `opensearch` | System user |
+| `opensearch_group` | `opensearch` | System group |
+
+### Network
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_api_port` | `9200` | HTTP API port |
+| `opensearch_network_host` | `{{ ansible_default_ipv4.address }}` | Network bind address |
+| `opensearch_bootstrap_memory_lock` | `true` | Lock memory to prevent swapping |
+
+### JVM
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_heap_size` | `1g` | JVM heap size (e.g. `1g`, `512m`) |
+| `opensearch_tmp_dir` | — | Custom temp directory (for noexec /tmp) |
+
+### Security
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_security_enabled` | `true` | Enable the security plugin |
+| `opensearch_admin_password` | — | **Required when security enabled.** Admin password |
+| `opensearch_dashboards_password` | — | Dashboards/Kibana server password |
+| `opensearch_auth_type` | `internal` | Auth type: `internal` or `oidc` |
+| `opensearch_cert_valid_days` | `730` | TLS certificate validity |
+| `opensearch_domain_name` | — | Domain name for certificate DNs |
+
+### System Tuning
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_vm_max_map_count` | `262144` | `vm.max_map_count` sysctl value |
+| `opensearch_fs_file_max` | `65536` | `fs.file-max` sysctl value |
+
+### Service
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_start_on_boot` | `true` | Enable service at boot |
+| `opensearch_start_on_install` | `true` | Start service after installation |
+| `opensearch_populate_etc_hosts` | `true` | Populate /etc/hosts with cluster nodes |
+| `opensearch_iac_enable` | `false` | IaC mode for idempotent re-runs |
+
+## Example Playbooks
+
+### Single-Node (Development)
+
+```yaml
+- name: Deploy single-node OpenSearch
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_version: "3.0.0"
+    opensearch_cluster_name: axonops-dev
+    opensearch_cluster_type: single-node
+    opensearch_heap_size: "1g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Multi-Node Cluster
+
+```yaml
+- name: Deploy OpenSearch cluster
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_version: "3.0.0"
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_heap_size: "4g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_dashboards_password: "{{ vault_opensearch_dashboards_password }}"
+    opensearch_domain_name: example.com
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Without Security Plugin
+
+```yaml
+- name: Deploy OpenSearch without security
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-test
+    opensearch_cluster_type: single-node
+    opensearch_security_enabled: false
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Part of Self-Hosted AxonOps Stack
+
+```yaml
+- name: Deploy AxonOps Server with OpenSearch
+  hosts: axon-server
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops
+    opensearch_cluster_type: single-node
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+
+  roles:
+    - axonops.axonops.opensearch
+    - axonops.axonops.server
+    - axonops.axonops.dash
+```
+
+## Tags
+
+| Tag | Description |
+|-----|-------------|
+| `hosts` | /etc/hosts population |
+| `tune` | System tuning (sysctl) |
+| `install` | OpenSearch download and installation |
+| `security` | Security plugin configuration |
+| `health` | Cluster health check |
+
+## Notes
+
+- **Security plugin**: When enabled, the role generates self-signed TLS certificates using the searchguard-tlstool on the control node and distributes them to cluster nodes.
+- **Inventory group**: Multi-node clusters expect hosts to be in the `opensearch` inventory group.
+- **Memory lock**: `opensearch_bootstrap_memory_lock` is enabled by default to prevent JVM heap swapping. Ensure the systemd service has `LimitMEMLOCK=infinity`.
+- **IaC mode**: Set `opensearch_iac_enable: true` for idempotent re-runs that check certificate state and regenerate if needed.
+
+## License
+
+See the main collection LICENSE file.
+
+## Author
+
+AxonOps Limited

--- a/docs/roles/opensearch.md
+++ b/docs/roles/opensearch.md
@@ -46,8 +46,31 @@ The `opensearch` role installs and configures OpenSearch on target nodes. It is 
 | `opensearch_admin_password` | — | **Required when security enabled.** Admin password |
 | `opensearch_dashboards_password` | — | Dashboards/Kibana server password |
 | `opensearch_auth_type` | `internal` | Auth type: `internal` or `oidc` |
-| `opensearch_cert_valid_days` | `730` | TLS certificate validity |
+| `opensearch_tls_mode` | `generate` | TLS mode: `generate` (self-signed) or `custom` (user-supplied) |
+
+### TLS Generate Mode (`opensearch_tls_mode: generate`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_cert_valid_days` | `730` | Certificate validity in days |
 | `opensearch_domain_name` | — | Domain name for certificate DNs |
+
+### TLS Custom Mode (`opensearch_tls_mode: custom`)
+
+All paths are on the **control node** and will be copied to each OpenSearch node.
+
+| Variable | Description |
+|----------|-------------|
+| `opensearch_tls_root_ca` | Path to root CA certificate (PEM) |
+| `opensearch_tls_root_ca_key` | Path to root CA private key |
+| `opensearch_tls_admin_cert` | Path to admin client certificate |
+| `opensearch_tls_admin_key` | Path to admin client private key |
+| `opensearch_tls_node_cert` | Path to node transport certificate (supports `{{ inventory_hostname }}`) |
+| `opensearch_tls_node_key` | Path to node transport private key |
+| `opensearch_tls_node_http_cert` | Path to node HTTP certificate |
+| `opensearch_tls_node_http_key` | Path to node HTTP private key |
+| `opensearch_tls_admin_dn` | Admin certificate DN (for `plugins.security.authcz.admin_dn`) |
+| `opensearch_tls_node_dn` | Node certificate DN pattern (for `plugins.security.nodes_dn`) |
 
 ### System Tuning
 
@@ -101,6 +124,34 @@ The `opensearch` role installs and configures OpenSearch on target nodes. It is 
     opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
     opensearch_dashboards_password: "{{ vault_opensearch_dashboards_password }}"
     opensearch_domain_name: example.com
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Custom TLS Certificates
+
+```yaml
+- name: Deploy OpenSearch with custom certificates
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_heap_size: "4g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_tls_mode: custom
+    opensearch_tls_root_ca: /path/to/certs/root-ca.pem
+    opensearch_tls_root_ca_key: /path/to/certs/root-ca.key
+    opensearch_tls_admin_cert: /path/to/certs/admin.pem
+    opensearch_tls_admin_key: /path/to/certs/admin.key
+    opensearch_tls_node_cert: "/path/to/certs/{{ inventory_hostname }}.pem"
+    opensearch_tls_node_key: "/path/to/certs/{{ inventory_hostname }}.key"
+    opensearch_tls_node_http_cert: "/path/to/certs/{{ inventory_hostname }}_http.pem"
+    opensearch_tls_node_http_key: "/path/to/certs/{{ inventory_hostname }}_http.key"
+    opensearch_tls_admin_dn: "CN=admin,OU=Ops,O=My Company,DC=example.com"
+    opensearch_tls_node_dn: "CN=*.example.com,OU=Ops,O=My Company,DC=example.com"
 
   roles:
     - axonops.axonops.opensearch

--- a/docs/roles/opensearch.md
+++ b/docs/roles/opensearch.md
@@ -98,7 +98,7 @@ All paths are on the **control node** and will be copied to each OpenSearch node
   become: true
 
   vars:
-    opensearch_version: "3.0.0"
+    opensearch_version: "3.6.0"
     opensearch_cluster_name: axonops-dev
     opensearch_cluster_type: single-node
     opensearch_heap_size: "1g"
@@ -117,7 +117,7 @@ All paths are on the **control node** and will be copied to each OpenSearch node
   become: true
 
   vars:
-    opensearch_version: "3.0.0"
+    opensearch_version: "3.6.0"
     opensearch_cluster_name: axonops-production
     opensearch_cluster_type: multi-node
     opensearch_heap_size: "4g"

--- a/examples/opensearch.yml
+++ b/examples/opensearch.yml
@@ -1,0 +1,51 @@
+---
+# ============================================================================
+# OpenSearch - Example Playbook
+# ============================================================================
+#
+# Deploys OpenSearch for use as the AxonOps Server backend store.
+#
+# Prerequisites:
+#   - Target hosts in the 'opensearch' inventory group
+#   - ansible.posix collection: ansible-galaxy collection install ansible.posix
+#
+# Usage:
+#   ansible-playbook examples/opensearch.yml
+#
+# ============================================================================
+
+# --- Single-node deployment (dev/test) ---
+- name: Deploy single-node OpenSearch
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_version: "3.0.0"
+    opensearch_cluster_name: axonops-dev
+    opensearch_cluster_type: single-node
+    opensearch_heap_size: "1g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+
+  roles:
+    - axonops.axonops.opensearch
+
+
+# ============================================================================
+# Multi-node cluster example
+# ============================================================================
+# - name: Deploy multi-node OpenSearch cluster
+#   hosts: opensearch
+#   become: true
+#
+#   vars:
+#     opensearch_version: "3.0.0"
+#     opensearch_cluster_name: axonops-production
+#     opensearch_cluster_type: multi-node
+#     opensearch_heap_size: "4g"
+#     opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+#     opensearch_dashboards_password: "{{ vault_opensearch_dashboards_password }}"
+#     opensearch_domain_name: example.com
+#
+#   roles:
+#     - axonops.axonops.opensearch

--- a/examples/opensearch.yml
+++ b/examples/opensearch.yml
@@ -20,7 +20,7 @@
   become: true
 
   vars:
-    opensearch_version: "3.0.0"
+    opensearch_version: "3.6.0"
     opensearch_cluster_name: axonops-dev
     opensearch_cluster_type: single-node
     opensearch_heap_size: "1g"
@@ -39,7 +39,7 @@
 #   become: true
 #
 #   vars:
-#     opensearch_version: "3.0.0"
+#     opensearch_version: "3.6.0"
 #     opensearch_cluster_name: axonops-production
 #     opensearch_cluster_type: multi-node
 #     opensearch_heap_size: "4g"

--- a/roles/opensearch/README.md
+++ b/roles/opensearch/README.md
@@ -1,0 +1,503 @@
+# OpenSearch Role
+
+## Overview
+
+The `opensearch` role installs and configures OpenSearch on target nodes. It serves as the backend configuration and metrics store for self-hosted AxonOps Server deployments. The role supports both single-node development setups and multi-node production clusters, with full TLS security via the OpenSearch Security plugin. Certificates can be generated automatically or supplied from your own PKI.
+
+**Note**: This role is only needed for self-hosted AxonOps deployments. AxonOps SaaS users do not need to install or manage OpenSearch.
+
+## Requirements
+
+- Ansible 2.10 or higher
+- `ansible.posix` collection (`ansible-galaxy collection install ansible.posix`)
+- Target nodes running a supported Linux distribution:
+  - RHEL / AlmaLinux / Rocky Linux 8 or 9
+  - Ubuntu (all supported releases)
+  - Debian (all supported releases)
+- The control node requires Java (JRE) if using `opensearch_tls_mode: generate`, as the certificate generation tool (`searchguard-tlstool`) is executed locally
+
+## Role Variables
+
+### Installation
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_version` | `3.6.0` | OpenSearch version to install |
+| `opensearch_download_url` | `https://artifacts.opensearch.org/releases/bundle/opensearch` | Base URL for the OpenSearch tar.gz download |
+| `opensearch_install_root` | `/usr/share/opensearch` | Directory where OpenSearch is extracted |
+| `opensearch_conf_dir` | `{{ opensearch_install_root }}/config` | Configuration directory |
+| `opensearch_user` | `opensearch` | System user that runs the OpenSearch process |
+| `opensearch_group` | `opensearch` | System group for the OpenSearch process |
+
+### Cluster Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_cluster_name` | `opensearch` | Name of the OpenSearch cluster. Change this for every deployment — the role warns if you leave the default |
+| `opensearch_cluster_type` | `multi-node` | Topology mode: `single-node` or `multi-node` |
+| `opensearch_seed_hosts` | All hosts in the current play | List of hostnames or IPs used for node discovery (multi-node only). Defaults to all hosts in the current play |
+| `opensearch_initial_master_nodes` | All hosts in the current play | List of master-eligible node names for initial cluster bootstrap (multi-node only). Removed automatically after the cluster forms |
+| `opensearch_node_roles` | _(not set)_ | Comma-separated list of node roles (e.g. `cluster_manager, data, ingest`). When not set, the node takes all roles. Set per host in inventory |
+
+### Network
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_api_port` | `9200` | HTTP API port |
+| `opensearch_network_host` | `{{ ansible_default_ipv4.address }}` | IP address or hostname OpenSearch binds to. Falls back to `0.0.0.0` when no default IPv4 address is detected |
+| `opensearch_bootstrap_memory_lock` | `true` | Lock JVM heap in RAM to prevent swapping. Requires `LimitMEMLOCK=infinity` in the systemd unit, which this role sets automatically |
+
+### JVM
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_heap_size` | `1g` | JVM heap size. Applied to both `-Xms` and `-Xmx`. Use `g` for gigabytes or `m` for megabytes (e.g. `4g`, `512m`). As a rule of thumb, set this to no more than half of available RAM |
+| `opensearch_tmp_dir` | _(not set)_ | Custom temporary directory for the JVM. Set this when `/tmp` is mounted with `noexec`, which prevents OpenSearch from starting |
+
+### Security Plugin
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_security_enabled` | `true` | Enable the OpenSearch Security plugin. When set to `false`, the cluster runs without TLS or authentication |
+| `opensearch_admin_password` | _(required)_ | Password for the built-in `admin` user. Required when `opensearch_security_enabled` is `true`. Store with Ansible Vault |
+| `opensearch_dashboards_password` | _(not set)_ | Password for the built-in `kibanaserver` user, used by OpenSearch Dashboards. Falls back to `opensearch_admin_password` when not set |
+| `opensearch_auth_type` | `internal` | Authentication type: `internal` (username/password against local user database) or `oidc` (OpenID Connect) |
+
+### TLS Mode
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_tls_mode` | `generate` | How TLS certificates are provisioned: `generate` (self-signed, automatic) or `custom` (user-supplied from control node) |
+
+#### TLS: `generate` mode
+
+In `generate` mode, the role downloads and runs the `searchguard-tlstool` on the control node to create a root CA, per-node transport certificates, per-node HTTP certificates, and an admin client certificate. These are then distributed to each node. No manual certificate management is required.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_cert_valid_days` | `730` | Number of days the generated certificates remain valid |
+| `opensearch_domain_name` | _(not set)_ | Domain suffix used in certificate Distinguished Names and DNS SANs (e.g. `example.com`). Required in generate mode |
+
+#### TLS: `custom` mode
+
+In `custom` mode, you supply all certificates yourself. The role copies them from the control node to each OpenSearch node. All variables in this section are required when `opensearch_tls_mode` is set to `custom`.
+
+Certificate path values support Jinja2 expressions, which lets you reference per-host files using `{{ inventory_hostname }}`.
+
+| Variable | Description |
+|----------|-------------|
+| `opensearch_tls_root_ca` | Path on the control node to the root CA certificate (PEM format) |
+| `opensearch_tls_root_ca_key` | Path on the control node to the root CA private key |
+| `opensearch_tls_admin_cert` | Path on the control node to the admin client certificate |
+| `opensearch_tls_admin_key` | Path on the control node to the admin client private key |
+| `opensearch_tls_node_cert` | Path on the control node to each node's transport certificate. Supports `{{ inventory_hostname }}` |
+| `opensearch_tls_node_key` | Path on the control node to each node's transport private key. Supports `{{ inventory_hostname }}` |
+| `opensearch_tls_node_http_cert` | Path on the control node to each node's HTTP (REST API) certificate. Supports `{{ inventory_hostname }}` |
+| `opensearch_tls_node_http_key` | Path on the control node to each node's HTTP private key. Supports `{{ inventory_hostname }}` |
+| `opensearch_tls_admin_dn` | Full Distinguished Name of the admin certificate, written to `plugins.security.authcz.admin_dn` in `opensearch.yml`. Example: `CN=admin,OU=Ops,O=Example Inc.,DC=example,DC=com` |
+| `opensearch_tls_node_dn` | DN pattern that matches all node certificates, written to `plugins.security.nodes_dn`. Example: `CN=*.example.com,OU=Ops,O=Example Inc.,DC=example,DC=com` |
+
+### Custom Security Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_custom_security_configs` | `[]` | List of Jinja2 template paths (relative to your playbook) to deploy into the `opensearch-security` configuration directory. Use this to supply custom `roles.yml`, `roles_mapping.yml`, and similar files |
+| `opensearch_copy_custom_security_configs` | `false` | When `true`, deploys the templates listed in `opensearch_custom_security_configs` and reinitialises the security index using `securityadmin.sh` |
+
+### OIDC Authentication
+
+These variables apply when `opensearch_auth_type` is set to `oidc`.
+
+| Variable | Description |
+|----------|-------------|
+| `opensearch_oidc.subject_key` | JWT claim to use as the username (e.g. `preferred_username`) |
+| `opensearch_oidc.roles_key` | JWT claim to use for role mapping (e.g. `roles`) |
+| `opensearch_oidc.connect_url` | OpenID Connect discovery endpoint URL |
+| `opensearch_oidc.dashboards_url` | Public URL of OpenSearch Dashboards, used for OIDC redirects |
+
+Example:
+
+```yaml
+opensearch_oidc:
+  subject_key: preferred_username
+  roles_key: roles
+  connect_url: https://idp.example.com/.well-known/openid-configuration
+  dashboards_url: https://dashboards.example.com
+```
+
+### System Tuning
+
+The role applies the following kernel and system settings to every target node. All values are configurable.
+
+| Variable | Default | Kernel parameter | Purpose |
+|----------|---------|-----------------|---------|
+| `opensearch_vm_max_map_count` | `262144` | `vm.max_map_count` | Required by OpenSearch for memory-mapped files. The default Linux value of `65530` is too low and prevents startup |
+| `opensearch_fs_file_max` | `65536` | `fs.file-max` | Maximum number of open file descriptors system-wide |
+| `opensearch_vm_swappiness` | `1` | `vm.swappiness` | Reduces the kernel's tendency to swap memory. A value of `1` is preferred over `0` to avoid OOM in edge cases |
+| `opensearch_tcp_retries2` | `5` | `net.ipv4.tcp_retries2` | Reduces TCP timeout for failed connections between cluster nodes |
+| `opensearch_disable_thp` | `true` | THP kernel subsystem | Disables Transparent Huge Pages for the current boot session and installs a `disable-thp` systemd service to persist across reboots. THP causes JVM performance problems and is not recommended for any JVM workload |
+
+The systemd service unit also sets these resource limits regardless of tuning variables:
+
+- `LimitNOFILE=65536` — maximum open file descriptors per process
+- `LimitMEMLOCK=infinity` — required for `bootstrap.memory_lock: true`
+- `LimitNPROC=4096` — maximum threads
+- `LimitAS=infinity` — no virtual memory cap
+- `LimitFSIZE=infinity` — no file size cap
+
+### `/etc/hosts` Management
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_populate_etc_hosts` | `true` | Add all hosts from the current play to `/etc/hosts` on each node. Useful when DNS is not available or not yet configured for cluster hostnames |
+| `opensearch_domain_name` | _(not set)_ | Domain suffix appended to hostnames when writing `/etc/hosts` entries. Entries take the form `<ip> <hostname>.<domain> <hostname>` |
+
+### Service Management
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_start_on_boot` | `true` | Enable the `opensearch` systemd service to start automatically at boot |
+| `opensearch_start_on_install` | `true` | Start OpenSearch immediately after the role finishes. When `false`, the service is configured but not started |
+
+### IaC Mode
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `opensearch_iac_enable` | `false` | Enable Infrastructure-as-Code mode. When `true`, the role checks whether certificates exist on each node and regenerates them if any are missing. Also forces security index reinitialisation. Use this for pipelines that run the role repeatedly against existing clusters |
+
+## Tags
+
+Use tags to run only specific parts of the role:
+
+| Tag | Tasks performed |
+|-----|----------------|
+| `hosts` | Populate `/etc/hosts` with cluster node entries |
+| `tune` | Apply sysctl settings and Transparent Huge Pages configuration |
+| `install` | Download, extract, and configure OpenSearch and its systemd unit |
+| `security` | Configure the Security plugin, generate or deploy TLS certificates, and initialise the security index |
+| `service` | Start the OpenSearch service and wait for it to become available |
+| `health` | Query the cluster health API and display the result |
+
+Example — run only system tuning and installation:
+
+```bash
+ansible-playbook site.yml --tags tune,install
+```
+
+Example — skip the health check:
+
+```bash
+ansible-playbook site.yml --skip-tags health
+```
+
+## Dependencies
+
+This role has no hard Ansible role dependencies. It does require the `ansible.posix` collection for the `sysctl` module used in system tuning:
+
+```bash
+ansible-galaxy collection install ansible.posix
+```
+
+When used as part of the full AxonOps stack, deploy this role before the `axonops.axonops.server` role.
+
+## Example Playbooks
+
+### Single-Node Development Cluster
+
+The simplest configuration for local development or evaluation. Uses automatic certificate generation.
+
+```yaml
+- name: Deploy single-node OpenSearch
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-dev
+    opensearch_cluster_type: single-node
+    opensearch_heap_size: "1g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Multi-Node Production Cluster
+
+A three-node cluster with automatically generated certificates. All nodes run the role in a single play, which causes the role to include all three in discovery and certificate generation automatically.
+
+```yaml
+- name: Deploy OpenSearch cluster
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_heap_size: "8g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_dashboards_password: "{{ vault_opensearch_dashboards_password }}"
+    opensearch_domain_name: internal.example.com
+    opensearch_cert_valid_days: 1095
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+Inventory for the above playbook:
+
+```ini
+[opensearch]
+os-node-1.internal.example.com
+os-node-2.internal.example.com
+os-node-3.internal.example.com
+```
+
+### Multi-Node Cluster with Dedicated Roles
+
+Use `opensearch_node_roles` in your inventory to separate cluster manager, data, and ingest responsibilities across nodes.
+
+```ini
+[opensearch]
+os-manager-1.example.com opensearch_node_roles="cluster_manager"
+os-manager-2.example.com opensearch_node_roles="cluster_manager"
+os-manager-3.example.com opensearch_node_roles="cluster_manager"
+os-data-1.example.com    opensearch_node_roles="data, ingest"
+os-data-2.example.com    opensearch_node_roles="data, ingest"
+```
+
+```yaml
+- name: Deploy OpenSearch with dedicated node roles
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_heap_size: "16g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Custom TLS Certificates
+
+Use certificates issued by your own CA instead of auto-generated self-signed certificates. All certificate files must exist on the control node before the play runs.
+
+```yaml
+- name: Deploy OpenSearch with custom TLS certificates
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_heap_size: "8g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_tls_mode: custom
+    opensearch_tls_root_ca: /etc/pki/tls/opensearch/root-ca.pem
+    opensearch_tls_root_ca_key: /etc/pki/tls/opensearch/root-ca.key
+    opensearch_tls_admin_cert: /etc/pki/tls/opensearch/admin.pem
+    opensearch_tls_admin_key: /etc/pki/tls/opensearch/admin.key
+    # The inventory_hostname expression selects the correct file per node
+    opensearch_tls_node_cert: "/etc/pki/tls/opensearch/{{ inventory_hostname }}.pem"
+    opensearch_tls_node_key: "/etc/pki/tls/opensearch/{{ inventory_hostname }}.key"
+    opensearch_tls_node_http_cert: "/etc/pki/tls/opensearch/{{ inventory_hostname }}_http.pem"
+    opensearch_tls_node_http_key: "/etc/pki/tls/opensearch/{{ inventory_hostname }}_http.key"
+    opensearch_tls_admin_dn: "CN=admin,OU=Ops,O=My Company,DC=example,DC=com"
+    opensearch_tls_node_dn: "CN=*.example.com,OU=Ops,O=My Company,DC=example,DC=com"
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Without Security (Development Only)
+
+Disables the Security plugin entirely. The cluster is accessible over plain HTTP with no authentication. **Do not use this in production.**
+
+```yaml
+- name: Deploy OpenSearch without security
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-test
+    opensearch_cluster_type: single-node
+    opensearch_security_enabled: false
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### As Part of the Self-Hosted AxonOps Stack
+
+Deploy OpenSearch alongside AxonOps Server and Dashboard in a single play. The role order matters: OpenSearch must be running before the server role starts.
+
+```yaml
+- name: Deploy self-hosted AxonOps stack
+  hosts: axonops_server
+  become: true
+
+  vars:
+    # OpenSearch
+    opensearch_cluster_name: axonops
+    opensearch_cluster_type: single-node
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+
+    # AxonOps Server
+    axon_server_license_key: "{{ vault_axonops_license_key }}"
+    axon_server_elastic_hosts:
+      - "https://127.0.0.1:9200"
+    axon_server_elastic_username: admin
+    axon_server_elastic_password: "{{ vault_opensearch_admin_password }}"
+    axon_server_elastic_tls_skip_verify: true
+
+  roles:
+    - axonops.axonops.opensearch
+    - axonops.axonops.server
+    - axonops.axonops.dash
+```
+
+### OIDC Authentication
+
+Authenticate users against an external OpenID Connect provider such as Keycloak, Okta, or Azure AD.
+
+```yaml
+- name: Deploy OpenSearch with OIDC authentication
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_heap_size: "8g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+    opensearch_auth_type: oidc
+    opensearch_oidc:
+      subject_key: preferred_username
+      roles_key: roles
+      connect_url: https://idp.example.com/auth/realms/axonops/.well-known/openid-configuration
+      dashboards_url: https://dashboards.example.com
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### IaC Pipeline (Idempotent Re-runs)
+
+Enable `opensearch_iac_enable` when running the role from a CI/CD pipeline or applying it to a running cluster. The role checks whether certificates are present on each node and only regenerates or re-applies configuration when necessary.
+
+```yaml
+- name: Reconcile OpenSearch cluster state
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_heap_size: "8g"
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+    opensearch_iac_enable: true
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+### Custom /tmp Directory
+
+If `/tmp` is mounted with `noexec` on your hosts, OpenSearch cannot extract its native libraries there and will fail to start. Set `opensearch_tmp_dir` to a directory on a `exec`-capable filesystem.
+
+```yaml
+- name: Deploy OpenSearch with custom temp directory
+  hosts: opensearch
+  become: true
+
+  vars:
+    opensearch_cluster_name: axonops-production
+    opensearch_cluster_type: multi-node
+    opensearch_admin_password: "{{ vault_opensearch_admin_password }}"
+    opensearch_domain_name: example.com
+    opensearch_tmp_dir: /var/lib/opensearch/tmp
+
+  roles:
+    - axonops.axonops.opensearch
+```
+
+## How TLS Works
+
+### Generate Mode (default)
+
+1. The role downloads `searchguard-tlstool` to `/tmp/opensearch-nodecerts/` on the **control node** (once, using `run_once`).
+2. A TLS configuration template is rendered that includes every node in the play with its hostname, FQDN, and IP address.
+3. The tool generates a root CA, per-node transport certificates (separate from HTTP certificates), and an admin client certificate.
+4. All generated certificates are copied to `{{ opensearch_conf_dir }}/` on each node.
+5. The tool also produces an `opensearch.yml` snippet for each node, which the role appends to the main configuration file.
+6. The `securityadmin.sh` script runs on one node to initialise the security index with the hashed user passwords.
+7. The local temporary directory is cleaned up after distribution.
+
+The generated certificates are created only once per cluster setup. To force regeneration on an existing cluster, set `opensearch_iac_enable: true`.
+
+### Custom Mode
+
+1. The role validates that all required certificate path variables are defined. The play fails immediately if any are missing.
+2. Each certificate is copied from the control node to `{{ opensearch_conf_dir }}/` on the corresponding target node.
+3. A TLS configuration block is appended to `opensearch.yml` referencing the deployed certificate files and the DN values you provided.
+4. The security index is initialised as in generate mode.
+
+## Post-Installation Verification
+
+After the role completes, verify the cluster is healthy:
+
+```bash
+# With security enabled
+curl -k -u admin:your_password \
+  https://<node-ip>:9200/_cluster/health?pretty
+
+# Without security
+curl http://<node-ip>:9200/_cluster/health?pretty
+```
+
+Check the service status and logs:
+
+```bash
+systemctl status opensearch
+journalctl -u opensearch -f
+```
+
+For a multi-node cluster, confirm all nodes have joined:
+
+```bash
+curl -k -u admin:your_password \
+  https://<node-ip>:9200/_cat/nodes?v
+```
+
+## Notes
+
+- **Cluster name warning**: The role issues a warning (but does not fail) when `opensearch_cluster_name` is left at the default value `opensearch`. Always set a meaningful cluster name for production deployments.
+
+- **Memory lock**: `opensearch_bootstrap_memory_lock` is enabled by default. The systemd service unit sets `LimitMEMLOCK=infinity` automatically, so no additional configuration is needed on the host.
+
+- **Multi-node bootstrap**: The role adds `cluster.initial_master_nodes` to `opensearch.yml` during initial bootstrap and then removes it once the cluster has formed. This follows the OpenSearch recommendation to avoid split-brain during restarts after the cluster is established.
+
+- **Password hashing**: The role hashes `opensearch_admin_password` and `opensearch_dashboards_password` using the `hash.sh` utility bundled with OpenSearch. Plain-text passwords are never written to configuration files.
+
+- **Custom internal users**: If a `files/internal_users.yml` file exists relative to your playbook, the role detects it and hashes passwords for any additional users defined there. Each user must have a corresponding `<username>_password` variable in scope.
+
+- **Security index initialisation**: The `securityadmin.sh` script runs with `-nhnv` (no hostname verification) and `-icl` (ignore cluster leader). It runs on one node only (`run_once`). If the cluster is not yet fully formed when this runs, OpenSearch retries internally. Allow up to two minutes for the cluster to become available.
+
+- **`/etc/hosts` population**: When `opensearch_populate_etc_hosts` is `true`, the role writes entries for every host in the current play to `/etc/hosts`. Entries are idempotent and managed within a marked block, so re-running the role safely updates them.
+
+- **Supported architecture**: The role downloads the `linux-x64` (AMD64) tarball. ARM64 nodes are not currently supported.
+
+## License
+
+See the main collection `LICENSE` file.
+
+## Author
+
+AxonOps Limited

--- a/roles/opensearch/defaults/main.yml
+++ b/roles/opensearch/defaults/main.yml
@@ -50,11 +50,31 @@ opensearch_security_enabled: true
 # Authentication type: 'internal' or 'oidc'
 opensearch_auth_type: internal
 
-# TLS certificate validity (days)
-opensearch_cert_valid_days: 730
+# TLS certificate mode: 'generate' (self-signed via searchguard-tlstool) or 'custom' (user-supplied)
+opensearch_tls_mode: generate
 
+# --- TLS generate mode settings (opensearch_tls_mode == 'generate') ---
+# Certificate validity (days)
+opensearch_cert_valid_days: 730
 # Domain name used in certificate DNs
 # opensearch_domain_name:
+
+# --- TLS custom mode settings (opensearch_tls_mode == 'custom') ---
+# Paths to certificate files on the control node. All are required when tls_mode is 'custom'.
+# opensearch_tls_root_ca: /path/to/root-ca.pem
+# opensearch_tls_root_ca_key: /path/to/root-ca.key
+# opensearch_tls_admin_cert: /path/to/admin.pem
+# opensearch_tls_admin_key: /path/to/admin.key
+# Per-node transport certs (Jinja2 supported, e.g. using inventory_hostname):
+# opensearch_tls_node_cert: /path/to/{{ inventory_hostname }}.pem
+# opensearch_tls_node_key: /path/to/{{ inventory_hostname }}.key
+# Per-node HTTP certs:
+# opensearch_tls_node_http_cert: /path/to/{{ inventory_hostname }}_http.pem
+# opensearch_tls_node_http_key: /path/to/{{ inventory_hostname }}_http.key
+# TLS distinguished names for admin certificate (used in opensearch.yml security config)
+# opensearch_tls_admin_dn: "CN=admin,OU=Ops,O=Example Inc.,DC=example.com"
+# TLS distinguished names for node certificates
+# opensearch_tls_node_dn: "CN=*.example.com,OU=Ops,O=Example Inc.,DC=example.com"
 
 # Custom security plugin configuration files (list of template paths)
 opensearch_custom_security_configs: []

--- a/roles/opensearch/defaults/main.yml
+++ b/roles/opensearch/defaults/main.yml
@@ -1,0 +1,87 @@
+---
+# ============================================================================
+# OpenSearch Role - Default Variables
+# ============================================================================
+
+# --- Version and Installation -----------------------------------------------
+
+opensearch_version: "3.0.0"
+opensearch_download_url: "https://artifacts.opensearch.org/releases/bundle/opensearch"
+
+# Installation format: tar
+opensearch_install_root: /usr/share/opensearch
+opensearch_conf_dir: "{{ opensearch_install_root }}/config"
+opensearch_user: opensearch
+opensearch_group: opensearch
+
+# --- Cluster Configuration --------------------------------------------------
+
+opensearch_cluster_name: opensearch
+opensearch_cluster_type: multi-node  # single-node or multi-node
+
+# Network
+opensearch_api_port: 9200
+opensearch_network_host: "{{ ansible_default_ipv4.address | default('0.0.0.0') }}"
+opensearch_bootstrap_memory_lock: true
+
+# Node discovery (multi-node only)
+# Override these in your playbook. The defaults use the 'opensearch' inventory group.
+# opensearch_seed_hosts: list of hostnames or IPs
+# opensearch_initial_master_nodes: list of master-eligible node names
+
+# Node roles - set per-host in inventory (e.g. opensearch_node_roles: "cluster_manager, data, ingest")
+# opensearch_node_roles:
+
+# --- JVM Configuration ------------------------------------------------------
+
+opensearch_heap_size: "1g"
+
+# Custom temp directory (useful when /tmp is mounted noexec)
+# opensearch_tmp_dir:
+
+# --- Security Plugin --------------------------------------------------------
+
+opensearch_security_enabled: true
+
+# Admin user password (required when security is enabled)
+# opensearch_admin_password:
+# opensearch_dashboards_password:
+
+# Authentication type: 'internal' or 'oidc'
+opensearch_auth_type: internal
+
+# TLS certificate validity (days)
+opensearch_cert_valid_days: 730
+
+# Domain name used in certificate DNs
+# opensearch_domain_name:
+
+# Custom security plugin configuration files (list of template paths)
+opensearch_custom_security_configs: []
+opensearch_copy_custom_security_configs: false
+
+# OIDC configuration (when opensearch_auth_type == 'oidc')
+# opensearch_oidc:
+#   subject_key: preferred_username
+#   roles_key: roles
+#   connect_url: https://idp.example.com/.well-known/openid-configuration
+#   dashboards_url: https://dashboards.example.com
+
+# --- /etc/hosts Management --------------------------------------------------
+
+opensearch_populate_etc_hosts: true
+
+# --- System Tuning -----------------------------------------------------------
+
+opensearch_vm_max_map_count: 262144
+opensearch_fs_file_max: 65536
+
+# --- IaC Mode ----------------------------------------------------------------
+
+# When true, forces certificate regeneration checks and idempotent re-runs
+opensearch_iac_enable: false
+
+# --- Service -----------------------------------------------------------------
+
+opensearch_start_on_boot: true
+opensearch_start_on_install: true

--- a/roles/opensearch/defaults/main.yml
+++ b/roles/opensearch/defaults/main.yml
@@ -28,6 +28,7 @@ opensearch_bootstrap_memory_lock: true
 # Override these in your playbook. By default, all hosts in the current play are used.
 # opensearch_seed_hosts: list of hostnames or IPs
 # opensearch_initial_master_nodes: list of master-eligible node names
+# opensearch_initial_cluster_manager_nodes: list of cluster manager node names
 
 # Node roles - set per-host in inventory (e.g. opensearch_node_roles: "cluster_manager, data, ingest")
 # opensearch_node_roles:

--- a/roles/opensearch/defaults/main.yml
+++ b/roles/opensearch/defaults/main.yml
@@ -25,7 +25,7 @@ opensearch_network_host: "{{ ansible_default_ipv4.address | default('0.0.0.0') }
 opensearch_bootstrap_memory_lock: true
 
 # Node discovery (multi-node only)
-# Override these in your playbook. The defaults use the 'opensearch' inventory group.
+# Override these in your playbook. By default, all hosts in the current play are used.
 # opensearch_seed_hosts: list of hostnames or IPs
 # opensearch_initial_master_nodes: list of master-eligible node names
 

--- a/roles/opensearch/defaults/main.yml
+++ b/roles/opensearch/defaults/main.yml
@@ -95,6 +95,11 @@ opensearch_populate_etc_hosts: true
 
 opensearch_vm_max_map_count: 262144
 opensearch_fs_file_max: 65536
+opensearch_vm_swappiness: 1
+opensearch_tcp_retries2: 5
+
+# Disable Transparent Huge Pages (recommended for JVM workloads)
+opensearch_disable_thp: true
 
 # --- IaC Mode ----------------------------------------------------------------
 

--- a/roles/opensearch/defaults/main.yml
+++ b/roles/opensearch/defaults/main.yml
@@ -5,7 +5,7 @@
 
 # --- Version and Installation -----------------------------------------------
 
-opensearch_version: "3.0.0"
+opensearch_version: "3.6.0"
 opensearch_download_url: "https://artifacts.opensearch.org/releases/bundle/opensearch"
 
 # Installation format: tar

--- a/roles/opensearch/handlers/main.yml
+++ b/roles/opensearch/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart OpenSearch
+  ansible.builtin.systemd:
+    name: opensearch
+    state: restarted
+    enabled: true

--- a/roles/opensearch/meta/main.yml
+++ b/roles/opensearch/meta/main.yml
@@ -1,0 +1,26 @@
+galaxy_info:
+  author: AxonOps Limited
+  description: Install and configure OpenSearch for AxonOps Server
+  company: AxonOps Limited
+  license: Apache 2.0
+  min_ansible_version: "2.10"
+
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+
+  galaxy_tags:
+  - axonops
+  - opensearch
+  - search
+  dependencies: []
+  documentation: https://github.com/axonops/axonops-ansible-collection
+  issues: https://github.com/axonops/axonops-ansible-collection/issues

--- a/roles/opensearch/molecule/default/converge.yml
+++ b/roles/opensearch/molecule/default/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    opensearch_version: "3.0.0"
+    opensearch_cluster_name: molecule-test
+    opensearch_cluster_type: single-node
+    opensearch_heap_size: "512m"
+    opensearch_security_enabled: false
+    opensearch_populate_etc_hosts: false
+    opensearch_start_on_boot: false
+    opensearch_start_on_install: true
+
+  roles:
+    - role: opensearch
+
+# code: language=ansible

--- a/roles/opensearch/molecule/default/converge.yml
+++ b/roles/opensearch/molecule/default/converge.yml
@@ -2,14 +2,14 @@
 - name: Converge
   hosts: all
   vars:
-    opensearch_version: "3.0.0"
+    opensearch_version: "3.6.0"
     opensearch_cluster_name: molecule-test
     opensearch_cluster_type: single-node
     opensearch_heap_size: "512m"
     opensearch_security_enabled: false
     opensearch_populate_etc_hosts: false
     opensearch_start_on_boot: false
-    opensearch_start_on_install: true
+    opensearch_start_on_install: false
 
   roles:
     - role: opensearch

--- a/roles/opensearch/molecule/default/molecule.yml
+++ b/roles/opensearch/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ driver:
 platforms:
   - name: ${MOLECULE_INSTANCE_NAME:-"default"}
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/opensearch/molecule/default/molecule.yml
+++ b/roles/opensearch/molecule/default/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: docker
+platforms:
+  - name: ${MOLECULE_INSTANCE_NAME:-"default"}
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml

--- a/roles/opensearch/tasks/etchosts.yml
+++ b/roles/opensearch/tasks/etchosts.yml
@@ -3,7 +3,7 @@
   ansible.builtin.blockinfile:
     dest: /etc/hosts
     block: |-
-      {% for item in groups['opensearch'] %}
+      {% for item in ansible_play_hosts %}
       {{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ip'] | default('')) }} {{ item }}.{{ opensearch_domain_name | default('local') }} {{ item }}
       {% endfor %}
     state: present

--- a/roles/opensearch/tasks/etchosts.yml
+++ b/roles/opensearch/tasks/etchosts.yml
@@ -1,0 +1,14 @@
+---
+- name: Populate inventory into /etc/hosts
+  ansible.builtin.blockinfile:
+    dest: /etc/hosts
+    block: |-
+      {% for item in groups['opensearch'] %}
+      {{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ip'] | default('')) }} {{ item }}.{{ opensearch_domain_name | default('local') }} {{ item }}
+      {% endfor %}
+    state: present
+    create: true
+    backup: true
+    marker: "# Ansible OpenSearch inventory hosts {mark}"
+
+# code: language=ansible

--- a/roles/opensearch/tasks/main.yml
+++ b/roles/opensearch/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+# ============================================================================
+# OpenSearch Role - Main Tasks
+# ============================================================================
+
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - opensearch_cluster_name is defined and opensearch_cluster_name != 'opensearch'
+    fail_msg: >-
+      WARNING: opensearch_cluster_name is set to 'opensearch'. For production
+      deployments, set opensearch_cluster_name to a meaningful cluster name.
+  ignore_errors: true
+  tags: always
+
+- name: Validate admin password is set when security is enabled
+  ansible.builtin.assert:
+    that:
+      - opensearch_admin_password is defined and opensearch_admin_password | length > 0
+    fail_msg: >-
+      opensearch_admin_password must be set when opensearch_security_enabled is true.
+  when: opensearch_security_enabled
+  tags: always
+
+- name: Populate /etc/hosts
+  ansible.builtin.import_tasks: etchosts.yml
+  when: opensearch_populate_etc_hosts
+  tags: hosts
+
+- name: Tune system settings
+  ansible.builtin.import_tasks: tune.yml
+  tags: tune
+
+- name: Install OpenSearch
+  ansible.builtin.import_tasks: opensearch.yml
+  tags: install
+
+- name: Configure security plugin
+  ansible.builtin.import_tasks: security.yml
+  when: opensearch_security_enabled
+  tags: security
+
+# After the cluster forms successfully for the first time,
+# remove cluster.initial_master_nodes to allow dynamic membership
+- name: Remove cluster.initial_master_nodes from configuration
+  ansible.builtin.lineinfile:
+    path: "{{ opensearch_conf_dir }}/opensearch.yml"
+    regexp: '^cluster\.initial_master_nodes'
+    state: absent
+  when: opensearch_cluster_type == 'multi-node'
+
+- name: Ensure OpenSearch is started
+  ansible.builtin.systemd:
+    name: opensearch
+    daemon_reload: true
+    state: started
+    enabled: "{{ opensearch_start_on_boot }}"
+
+- name: Wait for OpenSearch to be ready
+  ansible.builtin.wait_for:
+    host: "{{ opensearch_network_host }}"
+    port: "{{ opensearch_api_port }}"
+    delay: 5
+    connect_timeout: 1
+    timeout: 120
+
+- name: Check OpenSearch cluster health
+  ansible.builtin.uri:
+    url: "https://{{ opensearch_network_host }}:{{ opensearch_api_port }}/_cluster/health?pretty"
+    user: admin
+    password: "{{ opensearch_admin_password }}"
+    validate_certs: false
+  register: _opensearch_health
+  when: opensearch_security_enabled
+  tags: health
+
+- name: Check OpenSearch cluster health (no security)
+  ansible.builtin.uri:
+    url: "http://{{ opensearch_network_host }}:{{ opensearch_api_port }}/_cluster/health?pretty"
+    validate_certs: false
+  register: _opensearch_health
+  when: not opensearch_security_enabled
+  tags: health
+
+- name: Show OpenSearch cluster health
+  ansible.builtin.debug:
+    msg: "{{ _opensearch_health.json }}"
+  when: _opensearch_health is defined and _opensearch_health.json is defined
+  tags: health
+
+# code: language=ansible

--- a/roles/opensearch/tasks/main.yml
+++ b/roles/opensearch/tasks/main.yml
@@ -55,6 +55,8 @@
     daemon_reload: true
     state: started
     enabled: "{{ opensearch_start_on_boot }}"
+  when: opensearch_start_on_install
+  tags: service
 
 - name: Wait for OpenSearch to be ready
   ansible.builtin.wait_for:
@@ -63,6 +65,8 @@
     delay: 5
     connect_timeout: 1
     timeout: 120
+  when: opensearch_start_on_install
+  tags: service
 
 - name: Check OpenSearch cluster health
   ansible.builtin.uri:
@@ -71,7 +75,7 @@
     password: "{{ opensearch_admin_password }}"
     validate_certs: false
   register: _opensearch_health
-  when: opensearch_security_enabled
+  when: opensearch_start_on_install and opensearch_security_enabled
   tags: health
 
 - name: Check OpenSearch cluster health (no security)
@@ -79,7 +83,7 @@
     url: "http://{{ opensearch_network_host }}:{{ opensearch_api_port }}/_cluster/health?pretty"
     validate_certs: false
   register: _opensearch_health
-  when: not opensearch_security_enabled
+  when: opensearch_start_on_install and not opensearch_security_enabled
   tags: health
 
 - name: Show OpenSearch cluster health

--- a/roles/opensearch/tasks/opensearch.yml
+++ b/roles/opensearch/tasks/opensearch.yml
@@ -1,0 +1,75 @@
+---
+- name: Download OpenSearch {{ opensearch_version }}
+  ansible.builtin.get_url:
+    url: "{{ opensearch_download_url }}/{{ opensearch_version }}/opensearch-{{ opensearch_version }}-linux-x64.tar.gz"
+    dest: "/tmp/opensearch-{{ opensearch_version }}.tar.gz"
+    mode: "0644"
+  register: _opensearch_download
+
+- name: Create OpenSearch user
+  ansible.builtin.user:
+    name: "{{ opensearch_user }}"
+    state: present
+    shell: /bin/false
+    create_home: true
+    home: "{{ opensearch_install_root }}"
+  when: _opensearch_download.changed or opensearch_iac_enable
+
+- name: Create OpenSearch home directory
+  ansible.builtin.file:
+    path: "{{ opensearch_install_root }}"
+    state: directory
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0755"
+  when: _opensearch_download.changed or opensearch_iac_enable
+
+- name: Extract OpenSearch archive
+  ansible.builtin.unarchive:
+    src: "/tmp/opensearch-{{ opensearch_version }}.tar.gz"
+    dest: "{{ opensearch_install_root }}"
+    remote_src: true
+    extra_opts: ["--strip-components=1"]
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    creates: "{{ opensearch_conf_dir }}"
+  when: _opensearch_download.changed or opensearch_iac_enable
+
+- name: Deploy OpenSearch configuration
+  ansible.builtin.template:
+    src: "opensearch-{{ opensearch_cluster_type }}.yml.j2"
+    dest: "{{ opensearch_conf_dir }}/opensearch.yml"
+    backup: true
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0600"
+  notify: Restart OpenSearch
+
+- name: Deploy JVM options
+  ansible.builtin.template:
+    src: jvm.options.j2
+    dest: "{{ opensearch_conf_dir }}/jvm.options"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0600"
+  notify: Restart OpenSearch
+
+- name: Create custom OpenSearch tmp directory
+  ansible.builtin.file:
+    path: "{{ opensearch_tmp_dir }}"
+    state: directory
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0755"
+  when: opensearch_tmp_dir is defined
+
+- name: Deploy systemd service
+  ansible.builtin.template:
+    src: opensearch.service.j2
+    dest: /etc/systemd/system/opensearch.service
+    mode: "0644"
+    owner: root
+    group: root
+  notify: Reload systemd
+
+# code: language=ansible

--- a/roles/opensearch/tasks/security.yml
+++ b/roles/opensearch/tasks/security.yml
@@ -1,134 +1,241 @@
 ---
 # ============================================================================
 # OpenSearch Security Plugin Configuration
-# Uses searchguard-tlstool to generate self-signed TLS certificates
+# Supports two TLS modes:
+#   - generate: self-signed certs via searchguard-tlstool (default)
+#   - custom: user-supplied certificates
 # ============================================================================
 
-# --- Certificate Generation (on control node) --------------------------------
+# --- Validate custom TLS settings --------------------------------------------
 
-- name: Force remove local cert temp directory (IaC mode)
-  ansible.builtin.file:
-    path: /tmp/opensearch-nodecerts
-    state: absent
-  delegate_to: localhost
-  run_once: true
-  become: false
-  when: opensearch_iac_enable
+- name: Validate custom TLS certificate paths
+  ansible.builtin.assert:
+    that:
+      - opensearch_tls_root_ca is defined
+      - opensearch_tls_root_ca_key is defined
+      - opensearch_tls_admin_cert is defined
+      - opensearch_tls_admin_key is defined
+      - opensearch_tls_node_cert is defined
+      - opensearch_tls_node_key is defined
+      - opensearch_tls_node_http_cert is defined
+      - opensearch_tls_node_http_key is defined
+    fail_msg: >-
+      When opensearch_tls_mode is 'custom', you must provide all certificate paths:
+      opensearch_tls_root_ca, opensearch_tls_root_ca_key, opensearch_tls_admin_cert,
+      opensearch_tls_admin_key, opensearch_tls_node_cert, opensearch_tls_node_key,
+      opensearch_tls_node_http_cert, opensearch_tls_node_http_key.
+  when: opensearch_tls_mode == 'custom'
 
-- name: Create local cert temp directory
-  ansible.builtin.file:
-    path: /tmp/opensearch-nodecerts
-    state: directory
-    mode: "0755"
-  delegate_to: localhost
-  run_once: true
-  register: _cert_dir
-  become: false
+# =============================================================================
+# MODE: generate - Self-signed certificates via searchguard-tlstool
+# =============================================================================
 
-- name: Download TLS certificate generation tool
-  ansible.builtin.get_url:
-    url: https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-tlstool/1.5/search-guard-tlstool-1.5.tar.gz
-    dest: /tmp/opensearch-nodecerts/search-guard-tlstool.tar.gz
-    mode: "0644"
-  delegate_to: localhost
-  run_once: true
-  when: _cert_dir.changed
-  become: false
-
-- name: Extract TLS tool
-  ansible.builtin.unarchive:
-    src: /tmp/opensearch-nodecerts/search-guard-tlstool.tar.gz
-    dest: /tmp/opensearch-nodecerts/
-    remote_src: true
-  delegate_to: localhost
-  run_once: true
-  when: _cert_dir.changed
-  become: false
-
-- name: Make TLS tool executable
-  ansible.builtin.file:
-    path: /tmp/opensearch-nodecerts/tools/sgtlstool.sh
-    mode: "0755"
-  delegate_to: localhost
-  run_once: true
-  when: _cert_dir.changed
-  become: false
-
-- name: Generate TLS config template
-  ansible.builtin.template:
-    src: tlsconfig.yml.j2
-    dest: /tmp/opensearch-nodecerts/config/tlsconfig.yml
-    mode: "0644"
-  delegate_to: localhost
-  run_once: true
-  when: _cert_dir.changed
-  become: false
-
-- name: Generate node and admin certificates
-  ansible.builtin.command: >
-    /tmp/opensearch-nodecerts/tools/sgtlstool.sh
-    -c /tmp/opensearch-nodecerts/config/tlsconfig.yml
-    -ca -crt -t /tmp/opensearch-nodecerts/config/
-  delegate_to: localhost
-  run_once: true
-  when: _cert_dir.changed
-  become: false
-  changed_when: true
-
-# --- IaC certificate check ---------------------------------------------------
-
-- name: Check existing certificates (IaC mode)
-  when: opensearch_iac_enable
+- name: Generate self-signed TLS certificates
+  when: opensearch_tls_mode == 'generate'
   block:
-    - name: Check if certificates exist
-      ansible.builtin.stat:
-        path: "{{ item }}"
-        get_attributes: false
-        get_checksum: false
-        get_mime: false
-      register: _cert_stat
-      loop:
-        - "{{ opensearch_conf_dir }}/root-ca.pem"
-        - "{{ opensearch_conf_dir }}/root-ca.key"
-        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}.key"
-        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}.pem"
-        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}_http.key"
-        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}_http.pem"
-        - "{{ opensearch_conf_dir }}/admin.key"
-        - "{{ opensearch_conf_dir }}/admin.pem"
+    - name: Force remove local cert temp directory (IaC mode)
+      ansible.builtin.file:
+        path: /tmp/opensearch-nodecerts
+        state: absent
+      delegate_to: localhost
+      run_once: true
+      become: false
+      when: opensearch_iac_enable
 
-    - name: Determine if certificates need updating
+    - name: Create local cert temp directory
+      ansible.builtin.file:
+        path: /tmp/opensearch-nodecerts
+        state: directory
+        mode: "0755"
+      delegate_to: localhost
+      run_once: true
+      register: _cert_dir
+      become: false
+
+    - name: Download TLS certificate generation tool
+      ansible.builtin.get_url:
+        url: https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-tlstool/1.5/search-guard-tlstool-1.5.tar.gz
+        dest: /tmp/opensearch-nodecerts/search-guard-tlstool.tar.gz
+        mode: "0644"
+      delegate_to: localhost
+      run_once: true
+      when: _cert_dir.changed
+      become: false
+
+    - name: Extract TLS tool
+      ansible.builtin.unarchive:
+        src: /tmp/opensearch-nodecerts/search-guard-tlstool.tar.gz
+        dest: /tmp/opensearch-nodecerts/
+        remote_src: true
+      delegate_to: localhost
+      run_once: true
+      when: _cert_dir.changed
+      become: false
+
+    - name: Make TLS tool executable
+      ansible.builtin.file:
+        path: /tmp/opensearch-nodecerts/tools/sgtlstool.sh
+        mode: "0755"
+      delegate_to: localhost
+      run_once: true
+      when: _cert_dir.changed
+      become: false
+
+    - name: Generate TLS config template
+      ansible.builtin.template:
+        src: tlsconfig.yml.j2
+        dest: /tmp/opensearch-nodecerts/config/tlsconfig.yml
+        mode: "0644"
+      delegate_to: localhost
+      run_once: true
+      when: _cert_dir.changed
+      become: false
+
+    - name: Generate node and admin certificates
+      ansible.builtin.command: >
+        /tmp/opensearch-nodecerts/tools/sgtlstool.sh
+        -c /tmp/opensearch-nodecerts/config/tlsconfig.yml
+        -ca -crt -t /tmp/opensearch-nodecerts/config/
+      delegate_to: localhost
+      run_once: true
+      when: _cert_dir.changed
+      become: false
+      changed_when: true
+
+    # --- IaC certificate check -----------------------------------------------
+
+    - name: Check existing certificates (IaC mode)
+      when: opensearch_iac_enable
+      block:
+        - name: Check if certificates exist
+          ansible.builtin.stat:
+            path: "{{ item }}"
+            get_attributes: false
+            get_checksum: false
+            get_mime: false
+          register: _cert_stat
+          loop:
+            - "{{ opensearch_conf_dir }}/root-ca.pem"
+            - "{{ opensearch_conf_dir }}/root-ca.key"
+            - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}.key"
+            - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}.pem"
+            - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}_http.key"
+            - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}_http.pem"
+            - "{{ opensearch_conf_dir }}/admin.key"
+            - "{{ opensearch_conf_dir }}/admin.pem"
+
+        - name: Determine if certificates need updating
+          ansible.builtin.set_fact:
+            _force_update_cert: "{{ _cert_stat.results | selectattr('stat.exists', 'equalto', false) | list | length > 0 }}"
+
+    - name: Set cert update flag for non-IaC mode
       ansible.builtin.set_fact:
-        _force_update_cert: "{{ _cert_stat.results | selectattr('stat.exists', 'equalto', false) | list | length > 0 }}"
+        _force_update_cert: false
+      when: not opensearch_iac_enable
 
-- name: Set cert update count for non-IaC mode
-  ansible.builtin.set_fact:
-    _force_update_cert: false
-  when: not opensearch_iac_enable
+    # --- Copy generated certificates to nodes --------------------------------
 
-# --- Copy certificates to nodes ----------------------------------------------
+    - name: Copy generated certificates to OpenSearch nodes
+      ansible.builtin.copy:
+        src: "/tmp/opensearch-nodecerts/config/{{ item }}"
+        dest: "{{ opensearch_conf_dir }}/"
+        mode: "0600"
+        owner: "{{ opensearch_user }}"
+        group: "{{ opensearch_group }}"
+      loop:
+        - root-ca.pem
+        - root-ca.key
+        - "{{ inventory_hostname }}.key"
+        - "{{ inventory_hostname }}.pem"
+        - "{{ inventory_hostname }}_http.key"
+        - "{{ inventory_hostname }}_http.pem"
+        - admin.key
+        - admin.pem
+      when: (_cert_dir.changed and not opensearch_iac_enable) or (opensearch_iac_enable and _force_update_cert)
 
-- name: Copy certificates to OpenSearch nodes
-  ansible.builtin.copy:
-    src: "/tmp/opensearch-nodecerts/config/{{ item }}"
-    dest: "{{ opensearch_conf_dir }}/"
-    mode: "0600"
-    owner: "{{ opensearch_user }}"
-    group: "{{ opensearch_group }}"
-  loop:
-    - root-ca.pem
-    - root-ca.key
-    - "{{ inventory_hostname }}.key"
-    - "{{ inventory_hostname }}.pem"
-    - "{{ inventory_hostname }}_http.key"
-    - "{{ inventory_hostname }}_http.pem"
-    - admin.key
-    - admin.pem
-  when: (_cert_dir.changed and not opensearch_iac_enable) or (opensearch_iac_enable and _force_update_cert)
+    # --- Deploy generated TLS config snippet ---------------------------------
 
-# --- Security plugin configuration -------------------------------------------
+    - name: Deploy TLS certificate paths to opensearch.yml (generated)
+      ansible.builtin.blockinfile:
+        block: "{{ lookup('file', '/tmp/opensearch-nodecerts/config/' + inventory_hostname + '_elasticsearch_config_snippet.yml') }}"
+        dest: "{{ opensearch_conf_dir }}/opensearch.yml"
+        backup: true
+        insertafter: EOF
+        marker: "## {mark} OpenSearch Security TLS configuration ##"
+        owner: "{{ opensearch_user }}"
+        group: "{{ opensearch_group }}"
+      when: _cert_dir.changed or opensearch_iac_enable
 
-- name: Deploy security configuration to opensearch.yml
+    - name: Fix security plugin namespace in config (generated)
+      ansible.builtin.replace:
+        path: "{{ opensearch_conf_dir }}/opensearch.yml"
+        regexp: 'searchguard'
+        replace: 'plugins.security'
+      when: _cert_dir.changed or opensearch_iac_enable
+
+    # --- Set _certs_changed flag for downstream tasks ------------------------
+
+    - name: Set certs changed flag (generate mode)
+      ansible.builtin.set_fact:
+        _certs_changed: "{{ _cert_dir.changed }}"
+
+    # --- Cleanup temp directory -----------------------------------------------
+
+    - name: Cleanup local certificate temp directory
+      ansible.builtin.file:
+        path: /tmp/opensearch-nodecerts
+        state: absent
+      delegate_to: localhost
+      run_once: true
+      when: _cert_dir.changed
+      become: false
+
+# =============================================================================
+# MODE: custom - User-supplied certificates
+# =============================================================================
+
+- name: Deploy custom TLS certificates
+  when: opensearch_tls_mode == 'custom'
+  block:
+    - name: Copy custom root CA certificate
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ opensearch_conf_dir }}/{{ item.name }}"
+        mode: "0600"
+        owner: "{{ opensearch_user }}"
+        group: "{{ opensearch_group }}"
+      loop:
+        - { src: "{{ opensearch_tls_root_ca }}", name: "root-ca.pem" }
+        - { src: "{{ opensearch_tls_root_ca_key }}", name: "root-ca.key" }
+        - { src: "{{ opensearch_tls_admin_cert }}", name: "admin.pem" }
+        - { src: "{{ opensearch_tls_admin_key }}", name: "admin.key" }
+        - { src: "{{ opensearch_tls_node_cert }}", name: "{{ inventory_hostname }}.pem" }
+        - { src: "{{ opensearch_tls_node_key }}", name: "{{ inventory_hostname }}.key" }
+        - { src: "{{ opensearch_tls_node_http_cert }}", name: "{{ inventory_hostname }}_http.pem" }
+        - { src: "{{ opensearch_tls_node_http_key }}", name: "{{ inventory_hostname }}_http.key" }
+      loop_control:
+        label: "{{ item.name }}"
+      register: _custom_certs_copy
+
+    - name: Deploy custom TLS configuration to opensearch.yml
+      ansible.builtin.blockinfile:
+        block: "{{ lookup('template', 'security_tls_custom.yml.j2') }}"
+        dest: "{{ opensearch_conf_dir }}/opensearch.yml"
+        backup: true
+        insertafter: EOF
+        marker: "## {mark} OpenSearch Security TLS configuration ##"
+        owner: "{{ opensearch_user }}"
+        group: "{{ opensearch_group }}"
+
+    - name: Set certs changed flag (custom mode)
+      ansible.builtin.set_fact:
+        _certs_changed: "{{ _custom_certs_copy.changed }}"
+
+# =============================================================================
+# Common security configuration (both TLS modes)
+# =============================================================================
+
+- name: Deploy security auth configuration to opensearch.yml
   ansible.builtin.blockinfile:
     block: "{{ lookup('template', 'security_conf.yml.j2') }}"
     dest: "{{ opensearch_conf_dir }}/opensearch.yml"
@@ -137,25 +244,7 @@
     marker: "## {mark} OpenSearch Security configuration ##"
     owner: "{{ opensearch_user }}"
     group: "{{ opensearch_group }}"
-  when: _cert_dir.changed or opensearch_iac_enable
-
-- name: Deploy TLS certificate paths to opensearch.yml
-  ansible.builtin.blockinfile:
-    block: "{{ lookup('file', '/tmp/opensearch-nodecerts/config/{{ inventory_hostname }}_elasticsearch_config_snippet.yml') }}"
-    dest: "{{ opensearch_conf_dir }}/opensearch.yml"
-    backup: true
-    insertafter: EOF
-    marker: "## {mark} OpenSearch Security TLS configuration ##"
-    owner: "{{ opensearch_user }}"
-    group: "{{ opensearch_group }}"
-  when: _cert_dir.changed or opensearch_iac_enable
-
-- name: Fix security plugin namespace in config
-  ansible.builtin.replace:
-    path: "{{ opensearch_conf_dir }}/opensearch.yml"
-    regexp: 'searchguard'
-    replace: 'plugins.security'
-  when: _cert_dir.changed or opensearch_iac_enable
+  when: _certs_changed or opensearch_iac_enable
 
 - name: Create security plugin configuration directory
   ansible.builtin.file:
@@ -164,7 +253,6 @@
     owner: "{{ opensearch_user }}"
     group: "{{ opensearch_group }}"
     mode: "0700"
-  when: _cert_dir.changed or opensearch_iac_enable
 
 - name: Deploy security plugin config.yml
   ansible.builtin.template:
@@ -219,7 +307,7 @@
     group: "{{ opensearch_group }}"
     mode: "0644"
   run_once: true
-  when: _cert_dir.changed or opensearch_iac_enable
+  when: _certs_changed or opensearch_iac_enable
 
 - name: Deploy custom security configuration files
   ansible.builtin.template:
@@ -239,7 +327,7 @@
   environment:
     JAVA_HOME: "{{ opensearch_install_root }}/jdk"
   run_once: true
-  when: _cert_dir.changed or opensearch_iac_enable
+  when: _certs_changed or opensearch_iac_enable
   changed_when: true
 
 - name: Hash dashboards password
@@ -250,7 +338,7 @@
     JAVA_HOME: "{{ opensearch_install_root }}/jdk"
   run_once: true
   when:
-    - (_cert_dir.changed or opensearch_iac_enable)
+    - (_certs_changed or opensearch_iac_enable)
     - opensearch_dashboards_password is defined
   changed_when: true
 
@@ -284,7 +372,7 @@
       environment:
         JAVA_HOME: "{{ opensearch_install_root }}/jdk"
       run_once: true
-      when: _cert_dir.changed or opensearch_copy_custom_security_configs
+      when: _certs_changed or opensearch_copy_custom_security_configs
       loop: "{{ _custom_users_filtered | list }}"
       changed_when: true
 
@@ -302,7 +390,7 @@
   environment:
     JAVA_HOME: "{{ opensearch_install_root }}/jdk"
   run_once: true
-  when: _cert_dir.changed and opensearch_copy_custom_security_configs
+  when: _certs_changed and opensearch_copy_custom_security_configs
   changed_when: true
 
 - name: Initialise security index (default configs)
@@ -317,18 +405,7 @@
   environment:
     JAVA_HOME: "{{ opensearch_install_root }}/jdk"
   run_once: true
-  when: _cert_dir.changed and not opensearch_copy_custom_security_configs
+  when: _certs_changed and not opensearch_copy_custom_security_configs
   changed_when: true
-
-# --- Cleanup ------------------------------------------------------------------
-
-- name: Cleanup local certificate temp directory
-  ansible.builtin.file:
-    path: /tmp/opensearch-nodecerts
-    state: absent
-  delegate_to: localhost
-  run_once: true
-  when: _cert_dir.changed
-  become: false
 
 # code: language=ansible

--- a/roles/opensearch/tasks/security.yml
+++ b/roles/opensearch/tasks/security.yml
@@ -235,16 +235,16 @@
 # Common security configuration (both TLS modes)
 # =============================================================================
 
-- name: Deploy security auth configuration to opensearch.yml
+- name: Deploy security plugin configuration to opensearch.yml
   ansible.builtin.blockinfile:
-    block: "{{ lookup('template', 'security_conf.yml.j2') }}"
+    block: "{{ lookup('template', 'security_plugin_conf.yml.j2') }}"
     dest: "{{ opensearch_conf_dir }}/opensearch.yml"
     backup: true
     insertafter: EOF
-    marker: "## {mark} OpenSearch Security configuration ##"
+    marker: "## {mark} OpenSearch Plugin Security configuration ##"
     owner: "{{ opensearch_user }}"
     group: "{{ opensearch_group }}"
-  when: _certs_changed or opensearch_iac_enable
+  when: opensearch_auth_type == 'oidc' or opensearch_copy_custom_security_configs
 
 - name: Create security plugin configuration directory
   ansible.builtin.file:
@@ -254,15 +254,13 @@
     group: "{{ opensearch_group }}"
     mode: "0700"
 
-- name: Deploy security plugin config.yml
+- name: Deploy security auth configuration
   ansible.builtin.template:
-    src: security_plugin_conf.yml.j2
-    dest: "{{ opensearch_install_root }}/config/opensearch-security/config.yml"
-    backup: true
+    src: "{{ lookup('template', 'security_conf.yml.j2') }}"
+    dest: "{{ opensearch_conf_dir }}/opensearch-security/config.yml"
     owner: "{{ opensearch_user }}"
     group: "{{ opensearch_group }}"
-    mode: "0600"
-  when: opensearch_auth_type == 'oidc' or opensearch_copy_custom_security_configs
+  when: _certs_changed or opensearch_iac_enable
 
 # --- File ownership and permissions ------------------------------------------
 

--- a/roles/opensearch/tasks/security.yml
+++ b/roles/opensearch/tasks/security.yml
@@ -304,7 +304,6 @@
     owner: "{{ opensearch_user }}"
     group: "{{ opensearch_group }}"
     mode: "0644"
-  run_once: true
   when: _certs_changed or opensearch_iac_enable
 
 - name: Deploy custom security configuration files
@@ -324,7 +323,6 @@
     {{ opensearch_install_root }}/config/opensearch-security/internal_users.yml
   environment:
     JAVA_HOME: "{{ opensearch_install_root }}/jdk"
-  run_once: true
   when: _certs_changed or opensearch_iac_enable
   changed_when: true
 
@@ -334,7 +332,6 @@
     {{ opensearch_install_root }}/config/opensearch-security/internal_users.yml
   environment:
     JAVA_HOME: "{{ opensearch_install_root }}/jdk"
-  run_once: true
   when:
     - (_certs_changed or opensearch_iac_enable)
     - opensearch_dashboards_password is defined

--- a/roles/opensearch/tasks/security.yml
+++ b/roles/opensearch/tasks/security.yml
@@ -1,0 +1,334 @@
+---
+# ============================================================================
+# OpenSearch Security Plugin Configuration
+# Uses searchguard-tlstool to generate self-signed TLS certificates
+# ============================================================================
+
+# --- Certificate Generation (on control node) --------------------------------
+
+- name: Force remove local cert temp directory (IaC mode)
+  ansible.builtin.file:
+    path: /tmp/opensearch-nodecerts
+    state: absent
+  delegate_to: localhost
+  run_once: true
+  become: false
+  when: opensearch_iac_enable
+
+- name: Create local cert temp directory
+  ansible.builtin.file:
+    path: /tmp/opensearch-nodecerts
+    state: directory
+    mode: "0755"
+  delegate_to: localhost
+  run_once: true
+  register: _cert_dir
+  become: false
+
+- name: Download TLS certificate generation tool
+  ansible.builtin.get_url:
+    url: https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-tlstool/1.5/search-guard-tlstool-1.5.tar.gz
+    dest: /tmp/opensearch-nodecerts/search-guard-tlstool.tar.gz
+    mode: "0644"
+  delegate_to: localhost
+  run_once: true
+  when: _cert_dir.changed
+  become: false
+
+- name: Extract TLS tool
+  ansible.builtin.unarchive:
+    src: /tmp/opensearch-nodecerts/search-guard-tlstool.tar.gz
+    dest: /tmp/opensearch-nodecerts/
+    remote_src: true
+  delegate_to: localhost
+  run_once: true
+  when: _cert_dir.changed
+  become: false
+
+- name: Make TLS tool executable
+  ansible.builtin.file:
+    path: /tmp/opensearch-nodecerts/tools/sgtlstool.sh
+    mode: "0755"
+  delegate_to: localhost
+  run_once: true
+  when: _cert_dir.changed
+  become: false
+
+- name: Generate TLS config template
+  ansible.builtin.template:
+    src: tlsconfig.yml.j2
+    dest: /tmp/opensearch-nodecerts/config/tlsconfig.yml
+    mode: "0644"
+  delegate_to: localhost
+  run_once: true
+  when: _cert_dir.changed
+  become: false
+
+- name: Generate node and admin certificates
+  ansible.builtin.command: >
+    /tmp/opensearch-nodecerts/tools/sgtlstool.sh
+    -c /tmp/opensearch-nodecerts/config/tlsconfig.yml
+    -ca -crt -t /tmp/opensearch-nodecerts/config/
+  delegate_to: localhost
+  run_once: true
+  when: _cert_dir.changed
+  become: false
+  changed_when: true
+
+# --- IaC certificate check ---------------------------------------------------
+
+- name: Check existing certificates (IaC mode)
+  when: opensearch_iac_enable
+  block:
+    - name: Check if certificates exist
+      ansible.builtin.stat:
+        path: "{{ item }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      register: _cert_stat
+      loop:
+        - "{{ opensearch_conf_dir }}/root-ca.pem"
+        - "{{ opensearch_conf_dir }}/root-ca.key"
+        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}.key"
+        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}.pem"
+        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}_http.key"
+        - "{{ opensearch_conf_dir }}/{{ inventory_hostname }}_http.pem"
+        - "{{ opensearch_conf_dir }}/admin.key"
+        - "{{ opensearch_conf_dir }}/admin.pem"
+
+    - name: Determine if certificates need updating
+      ansible.builtin.set_fact:
+        _force_update_cert: "{{ _cert_stat.results | selectattr('stat.exists', 'equalto', false) | list | length > 0 }}"
+
+- name: Set cert update count for non-IaC mode
+  ansible.builtin.set_fact:
+    _force_update_cert: false
+  when: not opensearch_iac_enable
+
+# --- Copy certificates to nodes ----------------------------------------------
+
+- name: Copy certificates to OpenSearch nodes
+  ansible.builtin.copy:
+    src: "/tmp/opensearch-nodecerts/config/{{ item }}"
+    dest: "{{ opensearch_conf_dir }}/"
+    mode: "0600"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+  loop:
+    - root-ca.pem
+    - root-ca.key
+    - "{{ inventory_hostname }}.key"
+    - "{{ inventory_hostname }}.pem"
+    - "{{ inventory_hostname }}_http.key"
+    - "{{ inventory_hostname }}_http.pem"
+    - admin.key
+    - admin.pem
+  when: (_cert_dir.changed and not opensearch_iac_enable) or (opensearch_iac_enable and _force_update_cert)
+
+# --- Security plugin configuration -------------------------------------------
+
+- name: Deploy security configuration to opensearch.yml
+  ansible.builtin.blockinfile:
+    block: "{{ lookup('template', 'security_conf.yml.j2') }}"
+    dest: "{{ opensearch_conf_dir }}/opensearch.yml"
+    backup: true
+    insertafter: EOF
+    marker: "## {mark} OpenSearch Security configuration ##"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+  when: _cert_dir.changed or opensearch_iac_enable
+
+- name: Deploy TLS certificate paths to opensearch.yml
+  ansible.builtin.blockinfile:
+    block: "{{ lookup('file', '/tmp/opensearch-nodecerts/config/{{ inventory_hostname }}_elasticsearch_config_snippet.yml') }}"
+    dest: "{{ opensearch_conf_dir }}/opensearch.yml"
+    backup: true
+    insertafter: EOF
+    marker: "## {mark} OpenSearch Security TLS configuration ##"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+  when: _cert_dir.changed or opensearch_iac_enable
+
+- name: Fix security plugin namespace in config
+  ansible.builtin.replace:
+    path: "{{ opensearch_conf_dir }}/opensearch.yml"
+    regexp: 'searchguard'
+    replace: 'plugins.security'
+  when: _cert_dir.changed or opensearch_iac_enable
+
+- name: Create security plugin configuration directory
+  ansible.builtin.file:
+    path: "{{ opensearch_install_root }}/config/opensearch-security"
+    state: directory
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0700"
+  when: _cert_dir.changed or opensearch_iac_enable
+
+- name: Deploy security plugin config.yml
+  ansible.builtin.template:
+    src: security_plugin_conf.yml.j2
+    dest: "{{ opensearch_install_root }}/config/opensearch-security/config.yml"
+    backup: true
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0600"
+  when: opensearch_auth_type == 'oidc' or opensearch_copy_custom_security_configs
+
+# --- File ownership and permissions ------------------------------------------
+
+- name: Set OpenSearch directory ownership
+  ansible.builtin.file:
+    path: "{{ opensearch_install_root }}"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    recurse: true
+
+- name: Set config directory permissions
+  ansible.builtin.file:
+    path: "{{ opensearch_conf_dir }}"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0700"
+
+# --- Start and initialise security index -------------------------------------
+
+- name: Restart OpenSearch with security configuration
+  ansible.builtin.systemd:
+    name: opensearch
+    state: restarted
+    enabled: true
+    daemon_reload: true
+
+- name: Wait for OpenSearch to be ready
+  ansible.builtin.wait_for:
+    host: "{{ opensearch_network_host }}"
+    port: "{{ opensearch_api_port }}"
+    delay: 5
+    connect_timeout: 1
+    timeout: 120
+
+# --- Internal users and password hashing -------------------------------------
+
+- name: Deploy internal users template
+  ansible.builtin.template:
+    src: internal_users.yml.j2
+    dest: "{{ opensearch_install_root }}/config/opensearch-security/internal_users.yml"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    mode: "0644"
+  run_once: true
+  when: _cert_dir.changed or opensearch_iac_enable
+
+- name: Deploy custom security configuration files
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ opensearch_install_root }}/config/opensearch-security/"
+    owner: "{{ opensearch_user }}"
+    group: "{{ opensearch_group }}"
+    backup: true
+    mode: "0640"
+  loop: "{{ opensearch_custom_security_configs }}"
+  when: opensearch_copy_custom_security_configs
+
+- name: Hash admin password
+  ansible.builtin.shell: >
+    sed -i '/hash: / s,{{ opensearch_admin_password }},'$(bash {{ opensearch_install_root }}/plugins/opensearch-security/tools/hash.sh -p {{ opensearch_admin_password }} | tail -1)','
+    {{ opensearch_install_root }}/config/opensearch-security/internal_users.yml
+  environment:
+    JAVA_HOME: "{{ opensearch_install_root }}/jdk"
+  run_once: true
+  when: _cert_dir.changed or opensearch_iac_enable
+  changed_when: true
+
+- name: Hash dashboards password
+  ansible.builtin.shell: >
+    sed -i '/hash: / s,{{ opensearch_dashboards_password }},'$(bash {{ opensearch_install_root }}/plugins/opensearch-security/tools/hash.sh -p {{ opensearch_dashboards_password }} | tail -1)','
+    {{ opensearch_install_root }}/config/opensearch-security/internal_users.yml
+  environment:
+    JAVA_HOME: "{{ opensearch_install_root }}/jdk"
+  run_once: true
+  when:
+    - (_cert_dir.changed or opensearch_iac_enable)
+    - opensearch_dashboards_password is defined
+  changed_when: true
+
+# --- Custom internal users ---------------------------------------------------
+
+- name: Check for custom internal users file
+  ansible.builtin.stat:
+    path: files/internal_users.yml
+  register: _custom_users_file
+  delegate_to: localhost
+  run_once: true
+  become: false
+
+- name: Process custom internal users
+  when: _custom_users_file.stat.exists
+  block:
+    - name: Load custom internal users
+      ansible.builtin.include_vars:
+        file: files/internal_users.yml
+        name: _custom_users
+      run_once: true
+
+    - name: Filter service keys from user list
+      ansible.builtin.set_fact:
+        _custom_users_filtered: '{{ _custom_users | dict2items | rejectattr("key", "equalto", "_meta") | list | items2dict }}'
+
+    - name: Hash passwords for custom users
+      ansible.builtin.shell: >
+        sed -i '/hash: / s,{{ lookup("vars", item + "_password") }},'$(bash {{ opensearch_install_root }}/plugins/opensearch-security/tools/hash.sh -p {{ lookup("vars", item + "_password") }} | tail -1)','
+        {{ opensearch_install_root }}/config/opensearch-security/internal_users.yml
+      environment:
+        JAVA_HOME: "{{ opensearch_install_root }}/jdk"
+      run_once: true
+      when: _cert_dir.changed or opensearch_copy_custom_security_configs
+      loop: "{{ _custom_users_filtered | list }}"
+      changed_when: true
+
+# --- Initialise security index -----------------------------------------------
+
+- name: Initialise security index (custom configs)
+  ansible.builtin.shell: >
+    bash {{ opensearch_install_root }}/plugins/opensearch-security/tools/securityadmin.sh
+    -cacert {{ opensearch_conf_dir }}/root-ca.pem
+    -cert {{ opensearch_conf_dir }}/admin.pem
+    -key {{ opensearch_conf_dir }}/admin.key
+    -cd {{ opensearch_install_root }}/config/opensearch-security
+    -nhnv -icl
+    -h {{ opensearch_network_host }}
+  environment:
+    JAVA_HOME: "{{ opensearch_install_root }}/jdk"
+  run_once: true
+  when: _cert_dir.changed and opensearch_copy_custom_security_configs
+  changed_when: true
+
+- name: Initialise security index (default configs)
+  ansible.builtin.shell: >
+    bash {{ opensearch_install_root }}/plugins/opensearch-security/tools/securityadmin.sh
+    -cacert {{ opensearch_conf_dir }}/root-ca.pem
+    -cert {{ opensearch_conf_dir }}/admin.pem
+    -key {{ opensearch_conf_dir }}/admin.key
+    -f {{ opensearch_install_root }}/config/opensearch-security/internal_users.yml
+    -nhnv -icl
+    -h {{ opensearch_network_host }}
+  environment:
+    JAVA_HOME: "{{ opensearch_install_root }}/jdk"
+  run_once: true
+  when: _cert_dir.changed and not opensearch_copy_custom_security_configs
+  changed_when: true
+
+# --- Cleanup ------------------------------------------------------------------
+
+- name: Cleanup local certificate temp directory
+  ansible.builtin.file:
+    path: /tmp/opensearch-nodecerts
+    state: absent
+  delegate_to: localhost
+  run_once: true
+  when: _cert_dir.changed
+  become: false
+
+# code: language=ansible

--- a/roles/opensearch/tasks/security.yml
+++ b/roles/opensearch/tasks/security.yml
@@ -256,7 +256,7 @@
 
 - name: Deploy security auth configuration
   ansible.builtin.template:
-    src: "{{ lookup('template', 'security_conf.yml.j2') }}"
+    src: "security_conf.yml.j2"
     dest: "{{ opensearch_conf_dir }}/opensearch-security/config.yml"
     owner: "{{ opensearch_user }}"
     group: "{{ opensearch_group }}"

--- a/roles/opensearch/tasks/tune.yml
+++ b/roles/opensearch/tasks/tune.yml
@@ -11,4 +11,53 @@
     value: "{{ opensearch_fs_file_max }}"
     state: present
 
+- name: Set vm.swappiness
+  ansible.posix.sysctl:
+    name: vm.swappiness
+    value: "{{ opensearch_vm_swappiness }}"
+    state: present
+
+- name: Set net.ipv4.tcp_retries2
+  ansible.posix.sysctl:
+    name: net.ipv4.tcp_retries2
+    value: "{{ opensearch_tcp_retries2 }}"
+    state: present
+
+- name: Disable Transparent Huge Pages (current session)
+  ansible.builtin.shell: |
+    echo never > /sys/kernel/mm/transparent_hugepage/enabled
+    echo never > /sys/kernel/mm/transparent_hugepage/defrag
+  changed_when: false
+  failed_when: false
+  when: opensearch_disable_thp
+
+- name: Disable Transparent Huge Pages on boot
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/disable-thp.service
+    mode: "0644"
+    owner: root
+    group: root
+    content: |
+      [Unit]
+      Description=Disable Transparent Huge Pages
+      DefaultDependencies=no
+      After=sysinit.target local-fs.target
+      Before=opensearch.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/sh -c 'echo never > /sys/kernel/mm/transparent_hugepage/enabled && echo never > /sys/kernel/mm/transparent_hugepage/defrag'
+
+      [Install]
+      WantedBy=basic.target
+  notify: Reload systemd
+  when: opensearch_disable_thp
+
+- name: Enable disable-thp service
+  ansible.builtin.systemd:
+    name: disable-thp
+    enabled: true
+    daemon_reload: true
+  when: opensearch_disable_thp
+
 # code: language=ansible

--- a/roles/opensearch/tasks/tune.yml
+++ b/roles/opensearch/tasks/tune.yml
@@ -1,0 +1,14 @@
+---
+- name: Set vm.max_map_count
+  ansible.posix.sysctl:
+    name: vm.max_map_count
+    value: "{{ opensearch_vm_max_map_count }}"
+    state: present
+
+- name: Set fs.file-max
+  ansible.posix.sysctl:
+    name: fs.file-max
+    value: "{{ opensearch_fs_file_max }}"
+    state: present
+
+# code: language=ansible

--- a/roles/opensearch/templates/internal_users.yml.j2
+++ b/roles/opensearch/templates/internal_users.yml.j2
@@ -1,0 +1,21 @@
+---
+# This is the internal user database
+# The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+
+_meta:
+  type: "internalusers"
+  config_version: 2
+
+# Define your internal users here
+
+admin:
+  hash: "{{ opensearch_admin_password }}"
+  reserved: true
+  backend_roles:
+  - "admin"
+  description: "admin user"
+
+kibanaserver:
+  hash: "{{ opensearch_dashboards_password | default(opensearch_admin_password) }}"
+  reserved: true
+  description: "kibanaserver user"

--- a/roles/opensearch/templates/jvm.options.j2
+++ b/roles/opensearch/templates/jvm.options.j2
@@ -1,0 +1,94 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://opensearch.org/docs/opensearch/install/important-settings/
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms{{ opensearch_heap_size }}
+-Xmx{{ opensearch_heap_size }}
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-10:-XX:+UseConcMarkSweepGC
+8-10:-XX:CMSInitiatingOccupancyFraction=75
+8-10:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1GC is the default GC for all JDKs 11 and newer
+11-:-XX:+UseG1GC
+# See https://github.com/elastic/elasticsearch/pull/46169 for the history
+# behind these settings, but the tl;dr is that default values can lead
+# to situations where heap usage grows enough to trigger a circuit breaker
+# before GC kicks in.
+11-:-XX:G1ReservePercent=25
+11-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=${OPENSEARCH_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+
+# JDK 20+ Incubating Vector Module for SIMD optimizations;
+# disabling may reduce performance on vector optimized lucene
+20-:--add-modules=jdk.incubator.vector
+
+# See please https://bugs.openjdk.org/browse/JDK-8341127 (openjdk/jdk#21283)
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
+
+21-:-javaagent:agent/opensearch-agent.jar
+21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+
+
+{% if opensearch_tmp_dir is defined %}
+## Custom temp directory (avoid /tmp with noexec issue)
+-Djava.io.tmpdir={{ opensearch_tmp_dir }}
+{% endif %}

--- a/roles/opensearch/templates/opensearch-multi-node.yml.j2
+++ b/roles/opensearch/templates/opensearch-multi-node.yml.j2
@@ -11,6 +11,7 @@ bootstrap.memory_lock: {{ opensearch_bootstrap_memory_lock | lower }}
 discovery.seed_hosts: [{% for host in opensearch_seed_hosts | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 
 cluster.initial_master_nodes: [{% for host in opensearch_initial_master_nodes | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+
 cluster.initial_cluster_manager_nodes: [{% for host in opensearch_initial_cluster_manager_nodes | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 
 {% if opensearch_node_roles is defined %}

--- a/roles/opensearch/templates/opensearch-multi-node.yml.j2
+++ b/roles/opensearch/templates/opensearch-multi-node.yml.j2
@@ -11,6 +11,7 @@ bootstrap.memory_lock: {{ opensearch_bootstrap_memory_lock | lower }}
 discovery.seed_hosts: [{% for host in opensearch_seed_hosts | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 
 cluster.initial_master_nodes: [{% for host in opensearch_initial_master_nodes | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+cluster.initial_cluster_manager_nodes: [{% for host in opensearch_initial_cluster_manager_nodes | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 
 {% if opensearch_node_roles is defined %}
 node.roles: [{{ opensearch_node_roles }}]

--- a/roles/opensearch/templates/opensearch-multi-node.yml.j2
+++ b/roles/opensearch/templates/opensearch-multi-node.yml.j2
@@ -8,9 +8,9 @@ http.port: {{ opensearch_api_port }}
 
 bootstrap.memory_lock: {{ opensearch_bootstrap_memory_lock | lower }}
 
-discovery.seed_hosts: [{% for host in opensearch_seed_hosts | default(groups['opensearch']) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+discovery.seed_hosts: [{% for host in opensearch_seed_hosts | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 
-cluster.initial_master_nodes: [{% for host in opensearch_initial_master_nodes | default(groups['opensearch']) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+cluster.initial_master_nodes: [{% for host in opensearch_initial_master_nodes | default(ansible_play_hosts) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 
 {% if opensearch_node_roles is defined %}
 node.roles: [{{ opensearch_node_roles }}]

--- a/roles/opensearch/templates/opensearch-multi-node.yml.j2
+++ b/roles/opensearch/templates/opensearch-multi-node.yml.j2
@@ -1,0 +1,17 @@
+cluster.name: "{{ opensearch_cluster_name }}"
+
+node.name: "{{ inventory_hostname }}"
+
+network.host: "{{ opensearch_network_host }}"
+
+http.port: {{ opensearch_api_port }}
+
+bootstrap.memory_lock: {{ opensearch_bootstrap_memory_lock | lower }}
+
+discovery.seed_hosts: [{% for host in opensearch_seed_hosts | default(groups['opensearch']) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+
+cluster.initial_master_nodes: [{% for host in opensearch_initial_master_nodes | default(groups['opensearch']) %}"{{ host }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+
+{% if opensearch_node_roles is defined %}
+node.roles: [{{ opensearch_node_roles }}]
+{% endif %}

--- a/roles/opensearch/templates/opensearch-single-node.yml.j2
+++ b/roles/opensearch/templates/opensearch-single-node.yml.j2
@@ -1,0 +1,11 @@
+cluster.name: "{{ opensearch_cluster_name }}"
+
+node.name: "{{ inventory_hostname }}"
+
+network.host: "{{ opensearch_network_host }}"
+
+http.port: {{ opensearch_api_port }}
+
+discovery.type: single-node
+
+bootstrap.memory_lock: {{ opensearch_bootstrap_memory_lock | lower }}

--- a/roles/opensearch/templates/opensearch.service.j2
+++ b/roles/opensearch/templates/opensearch.service.j2
@@ -1,0 +1,51 @@
+[Unit]
+Description=opensearch
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+RuntimeDirectory=opensearch
+PrivateTmp=true
+
+WorkingDirectory={{ opensearch_install_root }}
+
+User={{ opensearch_user }}
+Group={{ opensearch_user }}
+
+ExecStart={{ opensearch_install_root }}/bin/opensearch -p {{ opensearch_install_root }}/opensearch.pid -q
+
+StandardOutput=journal
+StandardError=inherit
+
+# Specifies the maximum file descriptor number that can be opened by this process
+LimitNOFILE=65536
+
+# Specifies the memory lock settings
+LimitMEMLOCK=infinity
+
+# Specifies the maximum number of processes
+LimitNPROC=4096
+
+# Specifies the maximum size of virtual memory
+LimitAS=infinity
+
+# Specifies the maximum file size
+LimitFSIZE=infinity
+
+# Disable timeout logic and wait until process is stopped
+TimeoutStopSec=0
+
+# SIGTERM signal is used to stop the Java process
+KillSignal=SIGTERM
+
+# Send the signal only to the JVM rather than its control group
+KillMode=process
+
+# Java process is never killed
+SendSIGKILL=no
+
+# When a JVM receives a SIGTERM signal it exits with code 143
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/opensearch/templates/security_conf.yml.j2
+++ b/roles/opensearch/templates/security_conf.yml.j2
@@ -1,0 +1,287 @@
+---
+
+# This is the main OpenSearch Security configuration file where authentication
+# and authorization is defined.
+#
+# You need to configure at least one authentication domain in the authc of this file.
+# An authentication domain is responsible for extracting the user credentials from
+# the request and for validating them against an authentication backend like Active Directory for example.
+#
+# If more than one authentication domain is configured the first one which succeeds wins.
+# If all authentication domains fail then the request is unauthenticated.
+# In this case an exception is thrown and/or the HTTP status is set to 401.
+#
+# After authentication authorization (authz) will be applied. There can be zero or more authorizers which collect
+# the roles from a given backend for the authenticated user.
+#
+# Both, authc and auth can be enabled/disabled separately for REST and TRANSPORT layer. Default is true for both.
+#        http_enabled: true
+#        transport_enabled: true
+#
+# For HTTP it is possible to allow anonymous authentication. If that is the case then the HTTP authenticators try to
+# find user credentials in the HTTP request. If credentials are found then the user gets regularly authenticated.
+# If none can be found the user will be authenticated as an "anonymous" user. This user has always the username "anonymous"
+# and one role named "anonymous_backendrole".
+# If you enable anonymous authentication all HTTP authenticators will not challenge.
+#
+#
+# Note: If you define more than one HTTP authenticators make sure to put non-challenging authenticators like "proxy" or "clientcert"
+# first and the challenging one last.
+# Because it's not possible to challenge a client with two different authentication methods (for example
+# Kerberos and Basic) only one can have the challenge flag set to true. You can cope with this situation
+# by using pre-authentication, e.g. sending a HTTP Basic authentication header in the request.
+#
+# Default value of the challenge flag is true.
+#
+#
+# HTTP
+#   basic (challenging)
+#   proxy (not challenging, needs xff)
+#   kerberos (challenging)
+#   clientcert (not challenging, needs https)
+#   jwt (not challenging)
+#   host (not challenging) #DEPRECATED, will be removed in a future version.
+#                          host based authentication is configurable in roles_mapping
+
+# Authc
+#   internal
+#   noop
+#   ldap
+
+# Authz
+#   ldap
+#   noop
+
+
+
+_meta:
+  type: "config"
+  config_version: 2
+
+config:
+  dynamic:
+    # Set filtered_alias_mode to 'disallow' to forbid more than 2 filtered aliases per index
+    # Set filtered_alias_mode to 'warn' to allow more than 2 filtered aliases per index but warns about it (default)
+    # Set filtered_alias_mode to 'nowarn' to allow more than 2 filtered aliases per index silently
+    #filtered_alias_mode: warn
+    #do_not_fail_on_forbidden: false
+    #kibana:
+    # Kibana multitenancy
+    #multitenancy_enabled: true
+    #server_username: kibanaserver
+    #index: '.kibana'
+# OpenID settings
+{% if opensearch_auth_type == 'oidc' %}
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: ".*"
+        remoteIpHeader: "x-forwarded-for"
+    authc:
+      # In order for Dashboards to access OpenSearch, you must first use
+      # authentication_backend.type: internal
+      basic_internal_auth_domain:
+        description: "Authenticate via HTTP Basic against internal users database"
+        http_enabled: true
+        transport_enabled: false
+        order: 0
+        http_authenticator:
+          type: basic
+          challenge: false
+        authentication_backend:
+          type: internal
+      openid_auth_domain:
+        description: "Authenticate via OpenID"
+        http_enabled: true
+        transport_enabled: true
+        order: 1
+        http_authenticator:
+          type: openid
+          challenge: false
+          config:
+            enable_ssl: false
+            verify_hostnames: false
+            subject_key: {{ opensearch_oidc.subject_key}}
+            roles_key: {{ opensearch_oidc.roles_key}}
+            openid_connect_url: {{ opensearch_oidc.connect_url}}
+            kibana_url: {{ opensearch_oidc.dashboards_url}}
+        authentication_backend:
+          type: noop
+    authz: {}
+{% else %}
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: '192\.168\.0\.10|192\.168\.0\.11' # regex pattern
+        #internalProxies: '.*' # trust all internal proxies, regex pattern
+        #remoteIpHeader:  'x-forwarded-for'
+        ###### see https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html for regex help
+        ###### more information about XFF https://en.wikipedia.org/wiki/X-Forwarded-For
+        ###### and here https://tools.ietf.org/html/rfc7239
+        ###### and https://tomcat.apache.org/tomcat-8.0-doc/config/valve.html#Remote_IP_Valve
+    authc:
+      kerberos_auth_domain:
+        http_enabled: false
+        transport_enabled: false
+        order: 6
+        http_authenticator:
+          type: kerberos
+          challenge: true
+          config:
+            # If true a lot of kerberos/security related debugging output will be logged to standard out
+            krb_debug: false
+            # If true then the realm will be stripped from the user name
+            strip_realm_from_principal: true
+        authentication_backend:
+          type: noop
+      basic_internal_auth_domain:
+        description: "Authenticate via HTTP Basic against internal users database"
+        http_enabled: true
+        transport_enabled: true
+        order: 4
+        http_authenticator:
+          type: basic
+          challenge: true
+        authentication_backend:
+          type: intern
+      proxy_auth_domain:
+        description: "Authenticate via proxy"
+        http_enabled: false
+        transport_enabled: false
+        order: 3
+        http_authenticator:
+          type: proxy
+          challenge: false
+          config:
+            user_header: "x-proxy-user"
+            roles_header: "x-proxy-roles"
+        authentication_backend:
+          type: noop
+      jwt_auth_domain:
+        description: "Authenticate via Json Web Token"
+        http_enabled: false
+        transport_enabled: false
+        order: 0
+        http_authenticator:
+          type: jwt
+          challenge: false
+          config:
+            signing_key: "base64 encoded HMAC key or public RSA/ECDSA pem key"
+            jwt_header: "Authorization"
+            jwt_url_parameter: null
+            roles_key: null
+            subject_key: null
+        authentication_backend:
+          type: noop
+      clientcert_auth_domain:
+        description: "Authenticate via SSL client certificates"
+        http_enabled: false
+        transport_enabled: false
+        order: 2
+        http_authenticator:
+          type: clientcert
+          config:
+            username_attribute: cn #optional, if omitted DN becomes username
+          challenge: false
+        authentication_backend:
+          type: noop
+      ldap:
+        description: "Authenticate via LDAP or Active Directory"
+        http_enabled: false
+        transport_enabled: false
+        order: 5
+        http_authenticator:
+          type: basic
+          challenge: false
+        authentication_backend:
+          # LDAP authentication backend (authenticate users against a LDAP or Active Directory)
+          type: ldap
+          config:
+            # enable ldaps
+            enable_ssl: false
+            # enable start tls, enable_ssl should be false
+            enable_start_tls: false
+            # send client certificate
+            enable_ssl_client_auth: false
+            # verify ldap hostname
+            verify_hostnames: true
+            hosts:
+            - localhost:8389
+            bind_dn: null
+            password: null
+            userbase: 'ou=people,dc=example,dc=com'
+            # Filter to search for users (currently in the whole subtree beneath userbase)
+            # {0} is substituted with the username
+            usersearch: '(sAMAccountName={0})'
+            # Use this attribute from the user as username (if not set then DN is used)
+            username_attribute: null
+    authz:
+      roles_from_myldap:
+        description: "Authorize via LDAP or Active Directory"
+        http_enabled: false
+        transport_enabled: false
+        authorization_backend:
+          # LDAP authorization backend (gather roles from a LDAP or Active Directory, you have to configure the above LDAP authentication backend settings too)
+          type: ldap
+          config:
+            # enable ldaps
+            enable_ssl: false
+            # enable start tls, enable_ssl should be false
+            enable_start_tls: false
+            # send client certificate
+            enable_ssl_client_auth: false
+            # verify ldap hostname
+            verify_hostnames: true
+            hosts:
+            - localhost:8389
+            bind_dn: null
+            password: null
+            rolebase: 'ou=groups,dc=example,dc=com'
+            # Filter to search for roles (currently in the whole subtree beneath rolebase)
+            # {0} is substituted with the DN of the user
+            # {1} is substituted with the username
+            # {2} is substituted with an attribute value from user's directory entry, of the authenticated user. Use userroleattribute to specify the name of the attribute
+            rolesearch: '(member={0})'
+            # Specify the name of the attribute which value should be substituted with {2} above
+            userroleattribute: null
+            # Roles as an attribute of the user entry
+            userrolename: disabled
+            #userrolename: memberOf
+            # The attribute in a role entry containing the name of that role, Default is "name".
+            # Can also be "dn" to use the full DN as rolename.
+            rolename: cn
+            # Resolve nested roles transitive (roles which are members of other roles and so on ...)
+            resolve_nested_roles: true
+            userbase: 'ou=people,dc=example,dc=com'
+            # Filter to search for users (currently in the whole subtree beneath userbase)
+            # {0} is substituted with the username
+            usersearch: '(uid={0})'
+            # Skip users matching a user name, a wildcard or a regex pattern
+            #skip_users:
+            #  - 'cn=Michael Jackson,ou*people,o=TEST'
+            #  - '/\S*/'
+      roles_from_another_ldap:
+        description: "Authorize via another Active Directory"
+        http_enabled: false
+        transport_enabled: false
+        authorization_backend:
+          type: ldap
+          #config goes here ...
+  #    auth_failure_listeners:
+  #      ip_rate_limiting:
+  #        type: ip
+  #        allowed_tries: 10
+  #        time_window_seconds: 3600
+  #        block_expiry_seconds: 600
+  #        max_blocked_clients: 100000
+  #        max_tracked_clients: 100000
+  #      internal_authentication_backend_limiting:
+  #        type: username
+  #        authentication_backend: intern
+  #        allowed_tries: 10
+  #        time_window_seconds: 3600
+  #        block_expiry_seconds: 600
+  #        max_blocked_clients: 100000
+{% endif %}

--- a/roles/opensearch/templates/security_plugin_conf.yml.j2
+++ b/roles/opensearch/templates/security_plugin_conf.yml.j2
@@ -1,0 +1,6 @@
+
+plugins.security.allow_default_init_securityindex: true
+plugins.security.audit.type: internal_opensearch
+plugins.security.enable_snapshot_restore_privilege: true
+plugins.security.check_snapshot_restore_write_privileges: true
+plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]

--- a/roles/opensearch/templates/security_tls_custom.yml.j2
+++ b/roles/opensearch/templates/security_tls_custom.yml.j2
@@ -1,0 +1,12 @@
+plugins.security.ssl.transport.pemcert_filepath: {{ inventory_hostname }}.pem
+plugins.security.ssl.transport.pemkey_filepath: {{ inventory_hostname }}.key
+plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
+plugins.security.ssl.transport.enforce_hostname_verification: false
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.http.pemcert_filepath: {{ inventory_hostname }}_http.pem
+plugins.security.ssl.http.pemkey_filepath: {{ inventory_hostname }}_http.key
+plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
+plugins.security.authcz.admin_dn:
+  - "{{ opensearch_tls_admin_dn | default('CN=admin,OU=Ops,O=Example Inc.,DC=example.com') }}"
+plugins.security.nodes_dn:
+  - "{{ opensearch_tls_node_dn | default('CN=*,OU=Ops,O=Example Inc.,DC=example.com') }}"

--- a/roles/opensearch/templates/tlsconfig.yml.j2
+++ b/roles/opensearch/templates/tlsconfig.yml.j2
@@ -19,7 +19,7 @@ defaults:
 ### Nodes
 ###
 nodes:
-{% for item in groups['opensearch'] %}
+{% for item in ansible_play_hosts %}
   - name: {{ item }}
     dn: CN={{ item }}.{{ opensearch_domain_name }},OU=Ops,O={{ opensearch_domain_name }}\, Inc.,DC={{ opensearch_domain_name }}
     dns: {{ item }}.{{ opensearch_domain_name }}

--- a/roles/opensearch/templates/tlsconfig.yml.j2
+++ b/roles/opensearch/templates/tlsconfig.yml.j2
@@ -1,0 +1,35 @@
+ca:
+   root:
+      dn: CN=root.ca.{{ opensearch_domain_name }},OU=CA,O={{ opensearch_domain_name }}\, Inc.,DC={{ opensearch_domain_name }}
+      keysize: 2048
+      validityDays: {{ opensearch_cert_valid_days }}
+      pkPassword: none
+      file: root-ca.pem
+
+### Default values and global settings
+defaults:
+      validityDays: {{ opensearch_cert_valid_days }}
+      pkPassword: none
+      httpsEnabled: true
+      reuseTransportCertificatesForHttp: false
+      verifyHostnames: false
+      resolveHostnames: false
+
+###
+### Nodes
+###
+nodes:
+{% for item in groups['opensearch'] %}
+  - name: {{ item }}
+    dn: CN={{ item }}.{{ opensearch_domain_name }},OU=Ops,O={{ opensearch_domain_name }}\, Inc.,DC={{ opensearch_domain_name }}
+    dns: {{ item }}.{{ opensearch_domain_name }}
+    ip: {{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ip'] | default('')) }}
+{% endfor %}
+
+###
+### Clients
+###
+clients:
+  - name: admin
+    dn: CN=admin.{{ opensearch_domain_name }},OU=Ops,O={{ opensearch_domain_name }}\, Inc.,DC={{ opensearch_domain_name }}
+    admin: true

--- a/roles/opensearch/vars/main.yml
+++ b/roles/opensearch/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for opensearch


### PR DESCRIPTION
## Summary

- Adds new **`opensearch`** role to install and configure OpenSearch (v3.6.0) as the backend store for self-hosted AxonOps Server deployments
- Adds **path filters** to all 9 molecule CI workflows so only the affected role's tests run on each push/PR

## OpenSearch Role

Replaces the cloned third-party role with one that follows collection standards:

- All variables use `opensearch_` prefix (was `os_`/misc)
- Default version **3.6.0**
- `.j2` extensions on all templates
- `delegate_to` instead of `local_action`
- Proper `ansible.builtin.systemd` handlers
- Proper file modes and ownership throughout
- Two **TLS modes**:
  - `generate` (default) — auto-generates self-signed certs via searchguard-tlstool
  - `custom` — user supplies their own CA, admin, and node certificates
- Supports single-node and multi-node clusters
- Security plugin with internal auth and OIDC support
- System tuning (vm.max_map_count, fs.file-max)

### Files added/modified

| Component | Path |
|-----------|------|
| Role | `roles/opensearch/` (defaults, tasks, templates, handlers, meta, vars) |
| Molecule test | `roles/opensearch/molecule/default/` |
| Example playbook | `examples/opensearch.yml` |
| Documentation | `docs/roles/opensearch.md` |
| CI workflow | `.github/workflows/opensearch-molecule.yml` |
| Docs index | `docs/roles/README.md` (updated) |

## CI Path Filters

All 9 molecule workflows now use `paths` filters to only trigger when their role changes:

- `agent-molecule` → `roles/agent/**`
- `cassandra-molecule` → `roles/cassandra/**`
- `dash-molecule` → `roles/dash/**`
- `elastic-molecule` → `roles/elastic/**`
- `java-molecule` → `roles/java/**`
- `k8ssandra-molecule` → `roles/k8ssandra/**`
- `opensearch-molecule` → `roles/opensearch/**`
- `server-molecule` → `roles/server/**`
- `strimzi-molecule` → `roles/strimzi/**`

## Test Plan

- [x] Molecule converge passes for opensearch (install + config, service start skipped in Docker)
- [x] CI workflow triggers only for opensearch changes
- [x] Unrelated role changes do NOT trigger other molecule workflows