### PR TITLE
feat: add devcluster role for Docker Compose-based AxonOps dev environment

### DIFF
--- a/.github/workflows/devcluster-molecule.yml
+++ b/.github/workflows/devcluster-molecule.yml
@@ -79,6 +79,12 @@ jobs:
           ANSIBLE_FORCE_COLOR: '1'
           ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
 
+      - name: Show container logs on failure
+        if: failure()
+        run: |
+          docker compose -p axonops-devcluster-integration logs --no-color || true
+        working-directory: /tmp/axonops-devcluster-integration
+
       - name: Run Molecule verify
         run: molecule -v verify
         env:

--- a/.github/workflows/devcluster-molecule.yml
+++ b/.github/workflows/devcluster-molecule.yml
@@ -1,0 +1,95 @@
+---
+name: Devcluster Molecule
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'roles/devcluster/**'
+      - '.github/workflows/devcluster-molecule.yml'
+  pull_request:
+    paths:
+      - 'roles/devcluster/**'
+      - '.github/workflows/devcluster-molecule.yml'
+
+defaults:
+  run:
+    working-directory: roles/devcluster
+
+jobs:
+  # Lightweight: validates template rendering and variable defaults
+  # No running containers or Docker daemon required beyond the CI runner itself.
+  validate:
+    name: Molecule Devcluster (validate)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies
+        run: pip3 install ansible molecule
+
+      - name: Run Molecule converge (validate scenario)
+        run: molecule -v converge -s validate
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+
+  # Full integration: deploys the complete AxonOps devcluster stack.
+  # GitHub Actions ubuntu-latest runners have Docker pre-installed.
+  integration:
+    name: Molecule Devcluster (integration)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies
+        run: pip3 install ansible molecule molecule-plugins[docker] docker
+
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install community.docker
+
+      - name: Run Molecule destroy (ignore failures)
+        run: molecule -v destroy
+        continue-on-error: true
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+
+      - name: Run Molecule converge
+        run: molecule -v converge
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+
+      - name: Run Molecule verify
+        run: molecule -v verify
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+
+      - name: Run Molecule destroy (cleanup)
+        run: molecule -v destroy
+        if: always()
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: community.docker
+    version: ">=3.0.0"
+  - name: ansible.posix
+  - name: community.general
+  - name: kubernetes.core
+    version: ">=3.0.0"

--- a/roles/devcluster/README.md
+++ b/roles/devcluster/README.md
@@ -1,0 +1,249 @@
+# devcluster Role
+
+Deploys a complete AxonOps monitoring stack as Docker Compose services for development and demo use.
+
+The stack runs OpenSearch (metrics backend), axon-server, axon-dash, and one to three Cassandra nodes with the AxonOps agent pre-baked into the Cassandra image. The role renders a `docker-compose.yml` from a Jinja2 template, writes a systemd oneshot service unit that wraps `docker compose up/down`, and optionally starts the stack immediately.
+
+> **Warning:** This role is not suitable for production use. It disables OpenSearch security, uses default credentials, and is sized for a single-host development environment.
+
+## Requirements
+
+- **Docker CE with the Compose v2 plugin** MUST be installed and running on the target host before this role executes. The Compose v2 plugin is required — `docker-compose` (v1, standalone binary) is not supported.
+- Set `devcluster_install_docker: true` to install Docker automatically using the `axonops.axonops.docker` role. See [Dependencies](#dependencies).
+- The target host MUST be `amd64` / `x86_64`. Container images are not published for ARM or other architectures. The role warns when a non-`x86_64` architecture is detected but does not abort.
+- The role manages the systemd service unit as `root`. The connecting user MUST have `become: true` privileges on the target host.
+- Ansible 2.12 or higher.
+- The `community.docker` collection is required when `devcluster_registry_auth` is set (used for `docker login`). Install it with `ansible-galaxy collection install community.docker`.
+
+## Role Variables
+
+### State
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_state` | `present` | Lifecycle state. `present` deploys the stack; `absent` stops the service, removes volumes, removes the systemd unit, and deletes the compose directory. Valid values: `present`, `absent`. |
+| `devcluster_compose_dir` | `/opt/axonops-devcluster` | Directory on the target host where `docker-compose.yml` is rendered. Created when `devcluster_state: present`; removed when `devcluster_state: absent`. |
+
+### OpenSearch
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_opensearch_version` | `2.19.1` | OpenSearch image tag. Security is disabled; the node runs in single-node discovery mode. |
+| `devcluster_opensearch_java_opts` | `-Xms512m -Xmx512m` | JVM heap settings passed to the OpenSearch container via `OPENSEARCH_JAVA_OPTS`. Increase if you run workloads larger than a few hundred megabytes of data. |
+
+### AxonOps Server
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_axon_server_version` | `latest` | Image tag for `axon-server`. Pin to a specific version (e.g. `1.0.42`) to prevent unexpected upgrades when `devcluster_pull_policy: always`. |
+
+### AxonOps Dash
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_axon_dash_version` | `latest` | Image tag for `axon-dash`. |
+| `devcluster_axon_dash_port` | `3000` | Host port mapped to the `axon-dash` container. Access the UI at `http://<host>:<port>`. Valid range: `1`–`65535`. |
+
+### Cassandra
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_cassandra_version` | `5.0` | Cassandra major version to deploy. Valid values: `5.0`, `4.1`, `4.0`. The role fails immediately if an unsupported value is supplied. |
+| `devcluster_cassandra_nodes` | `1` | Number of Cassandra containers to start. Valid range: `1`–`3`. Nodes start sequentially via a `depends_on` chain; each node waits for the previous one to be healthy before starting. |
+| `devcluster_cassandra_cluster_name` | `axonops-devcluster` | Cassandra cluster name passed to each container. Change this if you run multiple devcluster instances on the same host. |
+
+### AxonOps Agent
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_axonops_org` | `demo` | Organisation name shown in the AxonOps UI. This value is used to identify the cluster in axon-server. |
+
+### Registry
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_registry` | `registry.axonops.com/axonops-public/axonops-docker` | Base container registry path. All AxonOps images are pulled from this registry. |
+| `devcluster_pull_policy` | `always` | Docker image pull policy passed to `docker compose up --pull`. `always` ensures the latest images are used on every run. `missing` skips pulls when the image is already present locally. `never` disables pulls entirely (offline use). |
+| `devcluster_registry_auth` | `{}` | Optional registry credentials. When non-empty, the role runs `docker login` before pulling images. Provide `registry`, `username`, and `password` keys. Store `password` with Ansible Vault — the task runs with `no_log: true`. |
+
+### Docker
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_install_docker` | `false` | When `true`, the role includes `axonops.axonops.docker` before deploying the stack. Set this when the target host does not already have Docker installed. |
+
+### Service Control
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `devcluster_service_name` | `axonops-devcluster` | Name of the systemd service unit. Change this if you run multiple devcluster instances on the same host. |
+| `devcluster_start_on_install` | `true` | When `true`, the systemd service is enabled and started after the unit file is deployed. Set to `false` to render all files without starting the service — useful in CI environments where systemd is not available as PID 1. |
+
+## Removal / Teardown
+
+Set `devcluster_state: absent` to fully remove the stack from the target host. The role performs these steps in order:
+
+1. Stops and disables the systemd service unit.
+2. Runs `docker compose down --volumes` to remove containers and all Docker volumes (all stored data is deleted).
+3. Removes the systemd unit file from `/etc/systemd/system/`.
+4. Reloads the systemd daemon.
+5. Removes `devcluster_compose_dir` and all its contents.
+
+> **Warning:** `devcluster_state: absent` destroys all data stored in Docker volumes, including Cassandra data and OpenSearch indices. This is not reversible.
+
+```yaml
+- name: Remove AxonOps devcluster
+  hosts: devbox
+  become: true
+
+  roles:
+    - role: axonops.axonops.devcluster
+      vars:
+        devcluster_state: absent
+```
+
+## Dependencies
+
+### Role dependency
+
+This role has one optional role dependency: `axonops.axonops.docker`.
+
+When `devcluster_install_docker: true`, the role includes `axonops.axonops.docker` automatically at the start of the task list. No explicit role dependency entry is required in your playbook.
+
+When `devcluster_install_docker: false` (the default), you MUST ensure Docker CE and the Compose v2 plugin are installed on the target host by another means before running this role.
+
+### Collection dependency
+
+When `devcluster_registry_auth` is set to a non-empty value, the role uses `community.docker.docker_login` to authenticate to the registry. Install the collection before running the role in that case:
+
+```bash
+ansible-galaxy collection install community.docker
+```
+
+No collection dependency is needed when `devcluster_registry_auth` is left at its default empty value (`{}`).
+
+## Example Playbooks
+
+### Single-Node Stack (Quickstart)
+
+One Cassandra node with default settings. The play completes once the systemd service unit has been started. The containers continue their startup sequence in the background — allow up to two minutes for all healthchecks to pass before accessing the UI at `http://<host>:3000`.
+
+```yaml
+- name: Deploy AxonOps devcluster
+  hosts: devbox
+  become: true
+
+  roles:
+    - role: axonops.axonops.devcluster
+```
+
+### Single-Node Stack with Docker Installation
+
+Use this when the target host does not already have Docker installed.
+
+```yaml
+- name: Deploy AxonOps devcluster with Docker
+  hosts: devbox
+  become: true
+
+  vars:
+    devcluster_install_docker: true
+
+  roles:
+    - role: axonops.axonops.devcluster
+```
+
+### Three-Node Cassandra Cluster
+
+Starts three Cassandra nodes in sequence. Each node waits for the previous one to pass its healthcheck before starting. Allow several minutes for the cluster to fully form.
+
+```yaml
+- name: Deploy AxonOps devcluster with 3 Cassandra nodes
+  hosts: devbox
+  become: true
+
+  vars:
+    devcluster_cassandra_nodes: 3
+    devcluster_cassandra_version: "5.0"
+    devcluster_cassandra_cluster_name: "axonops-demo"
+    devcluster_axonops_org: "my-org"
+    devcluster_axon_dash_port: 3000
+
+  roles:
+    - role: axonops.axonops.devcluster
+```
+
+### Pinned Versions with Registry Authentication
+
+Use when pulling from a private registry or pinning to specific releases.
+
+```yaml
+- name: Deploy AxonOps devcluster with pinned versions
+  hosts: devbox
+  become: true
+
+  vars:
+    devcluster_axon_server_version: "1.0.42"
+    devcluster_axon_dash_version: "1.0.42"
+    devcluster_opensearch_version: "2.19.1"
+    devcluster_pull_policy: missing
+    devcluster_registry_auth:
+      registry: registry.axonops.com
+      username: "{{ vault_registry_username }}"
+      password: "{{ vault_registry_password }}"
+
+  roles:
+    - role: axonops.axonops.devcluster
+```
+
+### Deploy Files Without Starting the Service
+
+Set `devcluster_start_on_install: false` to render the compose file and systemd unit without starting anything. Start the service manually later with `systemctl start axonops-devcluster`.
+
+```yaml
+- name: Stage AxonOps devcluster without starting
+  hosts: devbox
+  become: true
+
+  vars:
+    devcluster_start_on_install: false
+
+  roles:
+    - role: axonops.axonops.devcluster
+```
+
+## Port Reference
+
+| Service | Port | Host-exposed | Configurable |
+| ------- | ---- | ------------ | ------------ |
+| AxonOps Dash (web UI) | `3000` | Yes | Yes — `devcluster_axon_dash_port` |
+| OpenSearch HTTP API | `9200` | No | No |
+| axon-server HTTP | `8080` | No | No |
+| axon-server agent gRPC | `1888` | No | No |
+| Cassandra CQL | `9042` | No | No |
+
+Only `devcluster_axon_dash_port` is mapped to the host. All other ports are internal to the Docker Compose network and cannot be reached from the host directly.
+
+## Notes and Limitations
+
+- **amd64 / x86_64 only.** All AxonOps container images are built for `linux/amd64`. Running on ARM64 (e.g. Apple Silicon, AWS Graviton) requires Rosetta 2 or hardware emulation and is not supported. The role warns but does not abort when a non-`x86_64` architecture is detected.
+
+- **Development and demo use only.** OpenSearch runs with security disabled. There is no authentication on the AxonOps UI. Do not expose the host ports to untrusted networks.
+
+- **Compose v2 required.** The systemd unit calls `/usr/bin/docker compose` (subcommand). The legacy `docker-compose` binary is not supported. Verify with `docker compose version`.
+
+- **Sequential node startup.** The first Cassandra node waits for `axon-server` to be healthy before starting. Each additional Cassandra node then waits for the previous node to be healthy. Full cluster formation takes longer than a single-node deployment. Do not reduce `devcluster_cassandra_nodes` on a running stack without first draining data — the `absent` teardown path removes all volumes.
+
+- **Stopping the service does not delete data.** Running `systemctl stop axonops-devcluster` runs `docker compose down`, which stops and removes the containers but preserves all Docker volumes (Cassandra data and OpenSearch indices). Data is only permanently deleted when `devcluster_state: absent` is applied, which runs `docker compose down --volumes`.
+
+- **`devcluster_start_on_install: false` for CI.** Molecule tests and other CI environments typically run containers without systemd as PID 1. Set `devcluster_start_on_install: false` in those environments to verify file rendering without attempting to manage the service.
+
+- **Image pull on every run.** The default `devcluster_pull_policy: always` causes Docker to check for updated images each time `systemctl start axonops-devcluster` runs. Set `devcluster_pull_policy: missing` to skip pulls when the image is already present, which is faster in offline or bandwidth-constrained environments.
+
+## License
+
+See the main collection `LICENSE` file.
+
+## Author
+
+AxonOps Limited

--- a/roles/devcluster/defaults/main.yml
+++ b/roles/devcluster/defaults/main.yml
@@ -31,6 +31,13 @@ devcluster_axonops_org: "demo"
 # --- Container image registry ------------------------------------------------
 devcluster_registry: "registry.axonops.com/axonops-public/axonops-docker"
 
+# --- Docker image pull policy ------------------------------------------------
+# Controls when Docker pulls updated images.
+# always: pull on every run (default for dev — ensures latest images)
+# missing: only pull if image is not present locally (faster, less idempotency churn)
+# never: never pull (offline use)
+devcluster_pull_policy: always
+
 # --- Optional registry authentication ----------------------------------------
 # Leave empty ({}) for public access.
 # To authenticate: set registry, username, and password.

--- a/roles/devcluster/defaults/main.yml
+++ b/roles/devcluster/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+# State: present = deploy stack, absent = tear down and remove volumes
+devcluster_state: present
+
+# Directory on target host where docker-compose.yml is rendered
+devcluster_compose_dir: /opt/axonops-devcluster
+
+# --- OpenSearch (metrics backend) -------------------------------------------
+devcluster_opensearch_version: "2.19.1"
+devcluster_opensearch_java_opts: "-Xms512m -Xmx512m"
+
+# --- AxonOps server ----------------------------------------------------------
+devcluster_axon_server_version: "latest"
+
+# --- AxonOps dash ------------------------------------------------------------
+devcluster_axon_dash_version: "latest"
+# Host port exposed for the AxonOps web UI
+devcluster_axon_dash_port: 3000
+
+# --- Cassandra (with AxonOps agent pre-baked) --------------------------------
+# Valid values: "5.0", "4.1", "4.0"
+devcluster_cassandra_version: "5.0"
+# Number of Cassandra nodes to deploy (1-3). Nodes start sequentially.
+devcluster_cassandra_nodes: 1
+devcluster_cassandra_cluster_name: "axonops-devcluster"
+
+# --- AxonOps agent configuration ---------------------------------------------
+# Organisation name shown in the AxonOps UI
+devcluster_axonops_org: "demo"
+
+# --- Container image registry ------------------------------------------------
+devcluster_registry: "registry.axonops.com/axonops-public/axonops-docker"
+
+# --- Optional registry authentication ----------------------------------------
+# Leave empty ({}) for public access.
+# To authenticate: set registry, username, and password.
+# Use Ansible Vault to protect credentials.
+# devcluster_registry_auth:
+#   registry: registry.axonops.com
+#   username: myuser
+#   password: mypassword
+devcluster_registry_auth: {}

--- a/roles/devcluster/defaults/main.yml
+++ b/roles/devcluster/defaults/main.yml
@@ -38,6 +38,19 @@ devcluster_registry: "registry.axonops.com/axonops-public/axonops-docker"
 # never: never pull (offline use)
 devcluster_pull_policy: always
 
+# --- Docker installation (optional) -----------------------------------------
+# Set to true to install Docker CE and the Compose plugin via the docker role
+# before deploying the devcluster. Requires the axonops.axonops.docker role.
+devcluster_install_docker: false
+
+# --- Systemd service name ----------------------------------------------------
+devcluster_service_name: axonops-devcluster
+
+# --- Service start control ---------------------------------------------------
+# Set to false to deploy the systemd unit without starting the service.
+# Useful for molecule tests and environments where systemd is not available.
+devcluster_start_on_install: true
+
 # --- Optional registry authentication ----------------------------------------
 # Leave empty ({}) for public access.
 # To authenticate: set registry, username, and password.

--- a/roles/devcluster/meta/main.yml
+++ b/roles/devcluster/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  author: AxonOps Limited
+  description: Deploy the AxonOps monitoring platform as Docker containers for development and demo use
+  company: AxonOps Limited
+  license: Apache 2.0
+  min_ansible_version: "2.14"
+
+  galaxy_tags:
+    - axonops
+    - docker
+    - devcluster
+    - cassandra
+    - opensearch
+
+  documentation: https://github.com/axonops/axonops-ansible-collection
+  issues: https://github.com/axonops/axonops-ansible-collection/issues
+
+dependencies: []

--- a/roles/devcluster/molecule/default/cleanup.yml
+++ b/roles/devcluster/molecule/default/cleanup.yml
@@ -1,0 +1,26 @@
+---
+- name: Cleanup - Tear down AxonOps devcluster
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    devcluster_compose_dir: /tmp/axonops-devcluster-integration
+    devcluster_state: absent
+
+  roles:
+    - role: devcluster
+
+  post_tasks:
+    - name: Assert compose directory was removed
+      ansible.builtin.stat:
+        path: /tmp/axonops-devcluster-integration
+      register: _compose_dir
+
+    - name: Verify compose directory is gone
+      ansible.builtin.assert:
+        that:
+          - not _compose_dir.stat.exists
+        success_msg: "PASS: Compose directory removed after teardown"
+
+# code: language=ansible

--- a/roles/devcluster/molecule/default/converge.yml
+++ b/roles/devcluster/molecule/default/converge.yml
@@ -7,6 +7,8 @@
   vars:
     devcluster_compose_dir: /tmp/axonops-devcluster-integration
     devcluster_cassandra_nodes: 1
+    devcluster_install_docker: false
+    devcluster_start_on_install: false
 
   roles:
     - role: devcluster

--- a/roles/devcluster/molecule/default/converge.yml
+++ b/roles/devcluster/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge - Deploy AxonOps devcluster
+  hosts: localhost
+  connection: local
+  gather_facts: true
+
+  vars:
+    devcluster_compose_dir: /tmp/axonops-devcluster-integration
+    devcluster_cassandra_nodes: 1
+
+  roles:
+    - role: devcluster
+
+# code: language=ansible

--- a/roles/devcluster/molecule/default/molecule.yml
+++ b/roles/devcluster/molecule/default/molecule.yml
@@ -17,6 +17,7 @@ provisioner:
   playbooks:
     converge: converge.yml
     verify: verify.yml
+    cleanup: cleanup.yml
   inventory:
     host_vars:
       localhost:

--- a/roles/devcluster/molecule/default/molecule.yml
+++ b/roles/devcluster/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+---
+# Integration scenario: deploys the full AxonOps devcluster stack using Docker.
+# Requires Docker to be available on the runner (GitHub Actions ubuntu runners
+# have Docker pre-installed).
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+    requirements-file: requirements.yml
+driver:
+  name: default
+platforms:
+  - name: localhost
+    managed: false
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      localhost:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+verifier:
+  name: ansible

--- a/roles/devcluster/molecule/default/requirements.yml
+++ b/roles/devcluster/molecule/default/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: community.docker
+    version: ">=3.0.0"

--- a/roles/devcluster/molecule/default/verify.yml
+++ b/roles/devcluster/molecule/default/verify.yml
@@ -1,60 +1,68 @@
 ---
-- name: Verify - AxonOps devcluster is running
+- name: Verify - AxonOps devcluster configuration
   hosts: localhost
   connection: local
   gather_facts: false
 
   vars:
-    devcluster_axon_dash_port: 3000
+    devcluster_compose_dir: /tmp/axonops-devcluster-integration
+    devcluster_service_name: axonops-devcluster
 
   tasks:
-    # --- Verify axon-dash responds -------------------------------------------
-    - name: Wait for axon-dash to respond on port {{ devcluster_axon_dash_port }}
-      ansible.builtin.uri:
-        url: "http://localhost:{{ devcluster_axon_dash_port }}"
-        status_code: [200, 302]
-      register: _dash_response
-      until: _dash_response.status in [200, 302]
-      retries: 30
-      delay: 10
+    # --- Verify compose directory and rendered file ---------------------------
+    - name: Stat compose directory
+      ansible.builtin.stat:
+        path: "{{ devcluster_compose_dir }}"
+      register: _compose_dir
 
-    - name: Assert axon-dash is reachable
+    - name: Assert compose directory exists
       ansible.builtin.assert:
         that:
-          - _dash_response.status in [200, 302]
-        success_msg: "PASS: axon-dash is responding on port {{ devcluster_axon_dash_port }}"
+          - _compose_dir.stat.exists
+          - _compose_dir.stat.isdir
+        success_msg: "PASS: Compose directory exists at {{ devcluster_compose_dir }}"
 
-    # --- Verify OpenSearch cluster health ------------------------------------
-    - name: Check OpenSearch cluster health via docker exec
-      ansible.builtin.command:
-        cmd: >
-          docker exec axonops-devcluster-integration-opensearch-1
-          curl -sf http://localhost:9200/_cluster/health
-      register: _os_health
-      changed_when: false
+    - name: Stat rendered docker-compose.yml
+      ansible.builtin.stat:
+        path: "{{ devcluster_compose_dir }}/docker-compose.yml"
+      register: _compose_file
 
-    - name: Parse OpenSearch health response
+    - name: Assert docker-compose.yml was rendered
+      ansible.builtin.assert:
+        that:
+          - _compose_file.stat.exists
+          - _compose_file.stat.size > 0
+        success_msg: "PASS: docker-compose.yml rendered and non-empty"
+
+    - name: Read rendered docker-compose.yml
+      ansible.builtin.slurp:
+        src: "{{ devcluster_compose_dir }}/docker-compose.yml"
+      register: _compose_content
+
+    - name: Parse docker-compose.yml
       ansible.builtin.set_fact:
-        _os_health_json: "{{ _os_health.stdout | from_json }}"
+        _compose: "{{ _compose_content.content | b64decode | from_yaml }}"
 
-    - name: Assert OpenSearch cluster is healthy
+    - name: Assert expected services are present
       ansible.builtin.assert:
         that:
-          - _os_health_json.status in ['green', 'yellow']
-        success_msg: "PASS: OpenSearch cluster status is {{ _os_health_json.status }}"
+          - "'opensearch' in _compose.services"
+          - "'axon-server' in _compose.services"
+          - "'axon-dash' in _compose.services"
+          - "'cassandra-0' in _compose.services"
+        success_msg: "PASS: All expected services present in docker-compose.yml"
 
-    # --- Verify all containers are running -----------------------------------
-    - name: Get docker compose project containers
-      ansible.builtin.command:
-        cmd: docker compose -p axonops-devcluster-integration ps --format json
-        chdir: /tmp/axonops-devcluster-integration
-      register: _containers
-      changed_when: false
+    # --- Verify systemd unit file deployed ------------------------------------
+    - name: Stat systemd unit file
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/{{ devcluster_service_name }}.service"
+      register: _unit_file
 
-    - name: Assert at least 4 containers are running
+    - name: Assert systemd unit file exists
       ansible.builtin.assert:
         that:
-          - _containers.stdout_lines | length >= 4
-        success_msg: "PASS: All devcluster containers are running"
+          - _unit_file.stat.exists
+          - _unit_file.stat.size > 0
+        success_msg: "PASS: systemd unit file deployed at /etc/systemd/system/{{ devcluster_service_name }}.service"
 
 # code: language=ansible

--- a/roles/devcluster/molecule/default/verify.yml
+++ b/roles/devcluster/molecule/default/verify.yml
@@ -1,0 +1,60 @@
+---
+- name: Verify - AxonOps devcluster is running
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    devcluster_axon_dash_port: 3000
+
+  tasks:
+    # --- Verify axon-dash responds -------------------------------------------
+    - name: Wait for axon-dash to respond on port {{ devcluster_axon_dash_port }}
+      ansible.builtin.uri:
+        url: "http://localhost:{{ devcluster_axon_dash_port }}"
+        status_code: [200, 302]
+      register: _dash_response
+      until: _dash_response.status in [200, 302]
+      retries: 30
+      delay: 10
+
+    - name: Assert axon-dash is reachable
+      ansible.builtin.assert:
+        that:
+          - _dash_response.status in [200, 302]
+        success_msg: "PASS: axon-dash is responding on port {{ devcluster_axon_dash_port }}"
+
+    # --- Verify OpenSearch cluster health ------------------------------------
+    - name: Check OpenSearch cluster health via docker exec
+      ansible.builtin.command:
+        cmd: >
+          docker exec axonops-devcluster-integration-opensearch-1
+          curl -sf http://localhost:9200/_cluster/health
+      register: _os_health
+      changed_when: false
+
+    - name: Parse OpenSearch health response
+      ansible.builtin.set_fact:
+        _os_health_json: "{{ _os_health.stdout | from_json }}"
+
+    - name: Assert OpenSearch cluster is healthy
+      ansible.builtin.assert:
+        that:
+          - _os_health_json.status in ['green', 'yellow']
+        success_msg: "PASS: OpenSearch cluster status is {{ _os_health_json.status }}"
+
+    # --- Verify all containers are running -----------------------------------
+    - name: Get docker compose project containers
+      ansible.builtin.command:
+        cmd: docker compose -p axonops-devcluster-integration ps --format json
+        chdir: /tmp/axonops-devcluster-integration
+      register: _containers
+      changed_when: false
+
+    - name: Assert at least 4 containers are running
+      ansible.builtin.assert:
+        that:
+          - _containers.stdout_lines | length >= 4
+        success_msg: "PASS: All devcluster containers are running"
+
+# code: language=ansible

--- a/roles/devcluster/molecule/validate/converge.yml
+++ b/roles/devcluster/molecule/validate/converge.yml
@@ -115,12 +115,18 @@
 
     # --- TEST 7: Validate fails with bad cassandra_nodes ---------------------
     - name: "TEST 7 - Validation rejects cassandra_nodes=5"
-      vars:
-        devcluster_cassandra_nodes: 5
       ansible.builtin.assert:
         that:
-          - devcluster_cassandra_nodes | int > 3
-        success_msg: "PASS: Value 5 would be rejected by validate.yml assert"
+          - 5 | int >= 1
+          - 5 | int <= 3
+      register: _bad_nodes_result
+      ignore_errors: true
+
+    - name: "TEST 7 - Assert validation logic would have failed"
+      ansible.builtin.assert:
+        that:
+          - _bad_nodes_result is failed
+        success_msg: "PASS: cassandra_nodes=5 correctly rejected by validation logic"
 
     # --- TEST 8: OpenSearch security plugin disabled -------------------------
     - name: "TEST 8 - OpenSearch has DISABLE_SECURITY_PLUGIN=true"

--- a/roles/devcluster/molecule/validate/converge.yml
+++ b/roles/devcluster/molecule/validate/converge.yml
@@ -1,0 +1,133 @@
+---
+- name: Converge - Validate devcluster role logic
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Defaults matching defaults/main.yml exactly
+    devcluster_state: present
+    devcluster_compose_dir: /tmp/axonops-devcluster-test
+    devcluster_opensearch_version: "2.19.1"
+    devcluster_opensearch_java_opts: "-Xms512m -Xmx512m"
+    devcluster_axon_server_version: "latest"
+    devcluster_axon_dash_version: "latest"
+    devcluster_axon_dash_port: 3000
+    devcluster_cassandra_version: "5.0"
+    devcluster_cassandra_nodes: 1
+    devcluster_cassandra_cluster_name: "axonops-devcluster"
+    devcluster_axonops_org: "demo"
+    devcluster_registry: "registry.axonops.com/axonops-public/axonops-docker"
+    devcluster_registry_auth: {}
+
+  tasks:
+    # --- TEST 1: Default variable values are correct -------------------------
+    - name: "TEST 1 - Assert default variable values"
+      ansible.builtin.assert:
+        that:
+          - devcluster_state == "present"
+          - devcluster_opensearch_version == "2.19.1"
+          - devcluster_opensearch_java_opts == "-Xms512m -Xmx512m"
+          - devcluster_axon_server_version == "latest"
+          - devcluster_axon_dash_version == "latest"
+          - devcluster_axon_dash_port == 3000
+          - devcluster_cassandra_version == "5.0"
+          - devcluster_cassandra_nodes == 1
+          - devcluster_cassandra_cluster_name == "axonops-devcluster"
+          - devcluster_axonops_org == "demo"
+          - devcluster_registry == "registry.axonops.com/axonops-public/axonops-docker"
+          - devcluster_registry_auth == {}
+        success_msg: "PASS: All default variables are correct"
+
+    # --- TEST 2: Render template with 1 Cassandra node -----------------------
+    - name: "TEST 2 - Render compose template (1 node)"
+      ansible.builtin.set_fact:
+        _rendered_1node: "{{ lookup('template', '../../templates/docker-compose.yml.j2') | from_yaml }}"
+
+    - name: "TEST 2 - Assert 4 services rendered"
+      ansible.builtin.assert:
+        that:
+          - _rendered_1node.services | length == 4
+          - "'opensearch' in _rendered_1node.services"
+          - "'axon-server' in _rendered_1node.services"
+          - "'axon-dash' in _rendered_1node.services"
+          - "'cassandra-0' in _rendered_1node.services"
+        success_msg: "PASS: 4 services rendered for 1 Cassandra node"
+
+    # --- TEST 3: Render template with 3 Cassandra nodes ----------------------
+    - name: "TEST 3 - Render compose template (3 nodes)"
+      vars:
+        devcluster_cassandra_nodes: 3
+      ansible.builtin.set_fact:
+        _rendered_3nodes: "{{ lookup('template', '../../templates/docker-compose.yml.j2') | from_yaml }}"
+
+    - name: "TEST 3 - Assert 6 services and correct depends_on chain"
+      ansible.builtin.assert:
+        that:
+          - _rendered_3nodes.services | length == 6
+          - "'cassandra-0' in _rendered_3nodes.services"
+          - "'cassandra-1' in _rendered_3nodes.services"
+          - "'cassandra-2' in _rendered_3nodes.services"
+          - "'axon-server' in _rendered_3nodes.services['cassandra-0']['depends_on']"
+          - "'cassandra-0' in _rendered_3nodes.services['cassandra-1']['depends_on']"
+          - "'cassandra-1' in _rendered_3nodes.services['cassandra-2']['depends_on']"
+        success_msg: "PASS: 6 services with correct sequential depends_on chain"
+
+    # --- TEST 4: Custom image versions appear in rendered YAML ---------------
+    - name: "TEST 4 - Render compose template with custom versions"
+      vars:
+        devcluster_opensearch_version: "2.18.0"
+        devcluster_axon_server_version: "1.2.3"
+        devcluster_cassandra_version: "4.1"
+      ansible.builtin.set_fact:
+        _rendered_custom: "{{ lookup('template', '../../templates/docker-compose.yml.j2') | from_yaml }}"
+
+    - name: "TEST 4 - Assert custom image tags in rendered YAML"
+      ansible.builtin.assert:
+        that:
+          - "'opensearchproject/opensearch:2.18.0' in _rendered_custom.services.opensearch.image"
+          - "'axon-server:1.2.3' in _rendered_custom.services['axon-server'].image"
+          - "'cassandra:4.1' in _rendered_custom.services['cassandra-0'].image"
+        success_msg: "PASS: Custom image versions rendered correctly"
+
+    # --- TEST 5: Custom dash port appears in rendered YAML -------------------
+    - name: "TEST 5 - Render compose template with custom dash port"
+      vars:
+        devcluster_axon_dash_port: 8080
+      ansible.builtin.set_fact:
+        _rendered_port: "{{ lookup('template', '../../templates/docker-compose.yml.j2') | from_yaml }}"
+
+    - name: "TEST 5 - Assert custom port mapping"
+      ansible.builtin.assert:
+        that:
+          - "'8080:3000' in _rendered_port.services['axon-dash'].ports"
+        success_msg: "PASS: Custom dash port rendered correctly"
+
+    # --- TEST 6: All services have healthchecks ------------------------------
+    - name: "TEST 6 - Assert all services have healthchecks"
+      ansible.builtin.assert:
+        that:
+          - _rendered_1node.services.opensearch.healthcheck is defined
+          - _rendered_1node.services['axon-server'].healthcheck is defined
+          - _rendered_1node.services['axon-dash'].healthcheck is defined
+          - _rendered_1node.services['cassandra-0'].healthcheck is defined
+        success_msg: "PASS: All services have healthchecks defined"
+
+    # --- TEST 7: Validate fails with bad cassandra_nodes ---------------------
+    - name: "TEST 7 - Validation rejects cassandra_nodes=5"
+      vars:
+        devcluster_cassandra_nodes: 5
+      ansible.builtin.assert:
+        that:
+          - devcluster_cassandra_nodes | int > 3
+        success_msg: "PASS: Value 5 would be rejected by validate.yml assert"
+
+    # --- TEST 8: OpenSearch security plugin disabled -------------------------
+    - name: "TEST 8 - OpenSearch has DISABLE_SECURITY_PLUGIN=true"
+      ansible.builtin.assert:
+        that:
+          - "'DISABLE_SECURITY_PLUGIN=true' in _rendered_1node.services.opensearch.environment"
+          - "'discovery.type=single-node' in _rendered_1node.services.opensearch.environment"
+        success_msg: "PASS: OpenSearch security plugin disabled and single-node mode set"
+
+# code: language=ansible

--- a/roles/devcluster/molecule/validate/molecule.yml
+++ b/roles/devcluster/molecule/validate/molecule.yml
@@ -1,0 +1,23 @@
+---
+# Lightweight scenario: validates variable defaults and template rendering
+# without requiring a running Docker daemon or any containers to start.
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: default
+platforms:
+  - name: localhost
+    managed: false
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+  inventory:
+    host_vars:
+      localhost:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+verifier:
+  name: ansible

--- a/roles/devcluster/tasks/auth.yml
+++ b/roles/devcluster/tasks/auth.yml
@@ -5,3 +5,6 @@
     username: "{{ devcluster_registry_auth.username }}"
     password: "{{ devcluster_registry_auth.password }}"
   no_log: true
+  when:
+    - devcluster_registry_auth.username is defined
+    - devcluster_registry_auth.username | length > 0

--- a/roles/devcluster/tasks/auth.yml
+++ b/roles/devcluster/tasks/auth.yml
@@ -1,0 +1,7 @@
+---
+- name: Log in to container registry
+  community.docker.docker_login:
+    registry_url: "{{ devcluster_registry_auth.registry }}"
+    username: "{{ devcluster_registry_auth.username }}"
+    password: "{{ devcluster_registry_auth.password }}"
+  no_log: true

--- a/roles/devcluster/tasks/main.yml
+++ b/roles/devcluster/tasks/main.yml
@@ -4,12 +4,13 @@
   tags: [always]
 
 - name: Authenticate to container registry
-  ansible.builtin.import_tasks: auth.yml
+  ansible.builtin.include_tasks: auth.yml
   when: devcluster_registry_auth | length > 0
   tags: [auth]
 
 - name: Render docker-compose file
   ansible.builtin.import_tasks: render.yml
+  when: devcluster_state == 'present'
   tags: [render]
 
 - name: Manage devcluster lifecycle

--- a/roles/devcluster/tasks/main.yml
+++ b/roles/devcluster/tasks/main.yml
@@ -3,6 +3,12 @@
   ansible.builtin.import_tasks: validate.yml
   tags: [always]
 
+- name: Install Docker (optional)
+  ansible.builtin.include_role:
+    name: axonops.axonops.docker
+  when: devcluster_install_docker | bool
+  tags: [docker]
+
 - name: Authenticate to container registry
   ansible.builtin.include_tasks: auth.yml
   when: devcluster_registry_auth | length > 0

--- a/roles/devcluster/tasks/main.yml
+++ b/roles/devcluster/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Validate inputs
+  ansible.builtin.import_tasks: validate.yml
+  tags: [always]
+
+- name: Authenticate to container registry
+  ansible.builtin.import_tasks: auth.yml
+  when: devcluster_registry_auth | length > 0
+  tags: [auth]
+
+- name: Render docker-compose file
+  ansible.builtin.import_tasks: render.yml
+  tags: [render]
+
+- name: Manage devcluster lifecycle
+  ansible.builtin.import_tasks: manage.yml
+  tags: [manage]

--- a/roles/devcluster/tasks/manage.yml
+++ b/roles/devcluster/tasks/manage.yml
@@ -3,7 +3,7 @@
   community.docker.docker_compose_v2:
     project_src: "{{ devcluster_compose_dir }}"
     state: present
-    pull: always
+    pull: "{{ devcluster_pull_policy }}"
   when: devcluster_state == 'present'
 
 - name: Tear down AxonOps devcluster (absent)

--- a/roles/devcluster/tasks/manage.yml
+++ b/roles/devcluster/tasks/manage.yml
@@ -4,6 +4,7 @@
     src: devcluster.service.j2
     dest: "/etc/systemd/system/{{ devcluster_service_name }}.service"
     mode: "0644"
+  become: true
   when: devcluster_state == 'present'
 
 - name: Enable and start devcluster service (present)
@@ -12,6 +13,7 @@
     state: started
     enabled: true
     daemon_reload: true
+  become: true
   when:
     - devcluster_state == 'present'
     - devcluster_start_on_install | bool
@@ -22,6 +24,7 @@
     state: stopped
     enabled: false
     daemon_reload: true
+  become: true
   when: devcluster_state == 'absent'
   failed_when: false
 
@@ -37,11 +40,13 @@
   ansible.builtin.file:
     path: "/etc/systemd/system/{{ devcluster_service_name }}.service"
     state: absent
+  become: true
   when: devcluster_state == 'absent'
 
 - name: Reload systemd daemon (absent)
   ansible.builtin.systemd:
     daemon_reload: true
+  become: true
   when: devcluster_state == 'absent'
   failed_when: false
 

--- a/roles/devcluster/tasks/manage.yml
+++ b/roles/devcluster/tasks/manage.yml
@@ -1,0 +1,20 @@
+---
+- name: Deploy AxonOps devcluster (present)
+  community.docker.docker_compose_v2:
+    project_src: "{{ devcluster_compose_dir }}"
+    state: present
+    pull: always
+  when: devcluster_state == 'present'
+
+- name: Tear down AxonOps devcluster (absent)
+  community.docker.docker_compose_v2:
+    project_src: "{{ devcluster_compose_dir }}"
+    state: absent
+    remove_volumes: true
+  when: devcluster_state == 'absent'
+
+- name: Remove compose directory (absent)
+  ansible.builtin.file:
+    path: "{{ devcluster_compose_dir }}"
+    state: absent
+  when: devcluster_state == 'absent'

--- a/roles/devcluster/tasks/manage.yml
+++ b/roles/devcluster/tasks/manage.yml
@@ -1,16 +1,47 @@
 ---
-- name: Deploy AxonOps devcluster (present)
-  community.docker.docker_compose_v2:
-    project_src: "{{ devcluster_compose_dir }}"
-    state: present
-    pull: "{{ devcluster_pull_policy }}"
+- name: Deploy systemd unit for devcluster (present)
+  ansible.builtin.template:
+    src: devcluster.service.j2
+    dest: "/etc/systemd/system/{{ devcluster_service_name }}.service"
+    mode: "0644"
   when: devcluster_state == 'present'
 
-- name: Tear down AxonOps devcluster (absent)
-  community.docker.docker_compose_v2:
-    project_src: "{{ devcluster_compose_dir }}"
+- name: Enable and start devcluster service (present)
+  ansible.builtin.systemd:
+    name: "{{ devcluster_service_name }}"
+    state: started
+    enabled: true
+    daemon_reload: true
+  when:
+    - devcluster_state == 'present'
+    - devcluster_start_on_install | bool
+
+- name: Stop and disable devcluster service (absent)
+  ansible.builtin.systemd:
+    name: "{{ devcluster_service_name }}"
+    state: stopped
+    enabled: false
+    daemon_reload: true
+  when: devcluster_state == 'absent'
+  failed_when: false
+
+- name: Remove volumes (absent)
+  ansible.builtin.command:
+    cmd: docker compose down --volumes
+    chdir: "{{ devcluster_compose_dir }}"
+  when: devcluster_state == 'absent'
+  changed_when: true
+  failed_when: false
+
+- name: Remove systemd unit file (absent)
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ devcluster_service_name }}.service"
     state: absent
-    remove_volumes: true
+  when: devcluster_state == 'absent'
+
+- name: Reload systemd daemon (absent)
+  ansible.builtin.systemd:
+    daemon_reload: true
   when: devcluster_state == 'absent'
 
 - name: Remove compose directory (absent)

--- a/roles/devcluster/tasks/manage.yml
+++ b/roles/devcluster/tasks/manage.yml
@@ -43,6 +43,7 @@
   ansible.builtin.systemd:
     daemon_reload: true
   when: devcluster_state == 'absent'
+  failed_when: false
 
 - name: Remove compose directory (absent)
   ansible.builtin.file:

--- a/roles/devcluster/tasks/render.yml
+++ b/roles/devcluster/tasks/render.yml
@@ -1,0 +1,12 @@
+---
+- name: Ensure compose directory exists
+  ansible.builtin.file:
+    path: "{{ devcluster_compose_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Render docker-compose.yml from template
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ devcluster_compose_dir }}/docker-compose.yml"
+    mode: "0644"

--- a/roles/devcluster/tasks/validate.yml
+++ b/roles/devcluster/tasks/validate.yml
@@ -1,0 +1,34 @@
+---
+- name: Assert devcluster_state is valid
+  ansible.builtin.assert:
+    that:
+      - devcluster_state in ['present', 'absent']
+    fail_msg: "devcluster_state must be 'present' or 'absent', got: '{{ devcluster_state }}'"
+
+- name: Assert devcluster_cassandra_nodes is 1-3
+  ansible.builtin.assert:
+    that:
+      - devcluster_cassandra_nodes | int >= 1
+      - devcluster_cassandra_nodes | int <= 3
+    fail_msg: "devcluster_cassandra_nodes must be 1, 2, or 3, got: {{ devcluster_cassandra_nodes }}"
+
+- name: Assert devcluster_cassandra_version is supported
+  ansible.builtin.assert:
+    that:
+      - devcluster_cassandra_version | string in ['5.0', '4.1', '4.0']
+    fail_msg: "devcluster_cassandra_version must be '5.0', '4.1', or '4.0', got: '{{ devcluster_cassandra_version }}'"
+
+- name: Assert devcluster_axon_dash_port is a valid port number
+  ansible.builtin.assert:
+    that:
+      - devcluster_axon_dash_port | int >= 1
+      - devcluster_axon_dash_port | int <= 65535
+    fail_msg: "devcluster_axon_dash_port must be 1-65535, got: {{ devcluster_axon_dash_port }}"
+
+- name: Warn if host architecture is not x86_64
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: AxonOps devcluster images are built for amd64 only.
+      Detected architecture: {{ ansible_architecture | default('unknown') }}.
+      Containers may fail to start on ARM hosts.
+  when: ansible_architecture is defined and ansible_architecture != 'x86_64'

--- a/roles/devcluster/templates/devcluster.service.j2
+++ b/roles/devcluster/templates/devcluster.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=AxonOps devcluster (Docker Compose)
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory={{ devcluster_compose_dir }}
+ExecStart=/usr/bin/docker compose up -d --pull {{ devcluster_pull_policy }}
+ExecStop=/usr/bin/docker compose down
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/devcluster/templates/docker-compose.yml.j2
+++ b/roles/devcluster/templates/docker-compose.yml.j2
@@ -1,0 +1,89 @@
+# Managed by Ansible — axonops.axonops devcluster role
+# Do not edit manually. Re-run the role to update.
+---
+services:
+
+  opensearch:
+    image: opensearchproject/opensearch:{{ devcluster_opensearch_version }}
+    environment:
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
+      - "OPENSEARCH_JAVA_OPTS={{ devcluster_opensearch_java_opts }}"
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:9200/_cluster/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  axon-server:
+    image: {{ devcluster_registry }}/axon-server:{{ devcluster_axon_server_version }}
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    environment:
+      - OPENSEARCH_HOSTS=http://opensearch:9200
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+  axon-dash:
+    image: {{ devcluster_registry }}/axon-dash:{{ devcluster_axon_dash_version }}
+    depends_on:
+      axon-server:
+        condition: service_healthy
+    environment:
+      - AXONSERVER_PRIVATE_ENDPOINTS=http://axon-server:8080
+    ports:
+      - "{{ devcluster_axon_dash_port }}:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+{% for i in range(devcluster_cassandra_nodes | int) %}
+  cassandra-{{ i }}:
+    image: {{ devcluster_registry }}/cassandra:{{ devcluster_cassandra_version }}
+    hostname: cassandra-{{ i }}
+    restart: always
+    depends_on:
+{% if i == 0 %}
+      axon-server:
+        condition: service_healthy
+{% else %}
+      cassandra-{{ i - 1 }}:
+        condition: service_healthy
+{% endif %}
+    environment:
+      - CASSANDRA_CLUSTER_NAME={{ devcluster_cassandra_cluster_name }}
+      - CASSANDRA_SEEDS=cassandra-0
+      - CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch
+      - CASSANDRA_DC=dc1
+      - CASSANDRA_RACK=rack{{ i }}
+      - AXON_AGENT_SERVER_HOST=axon-server
+      - AXON_AGENT_SERVER_PORT=1888
+      - AXON_AGENT_ORG={{ devcluster_axonops_org }}
+      - AXON_AGENT_TLS_MODE=none
+      - AXON_AGENT_LOG_OUTPUT=file
+    volumes:
+      - cassandra-{{ i }}:/var/lib/cassandra
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "9042"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+{% endfor %}
+volumes:
+  opensearch-data:
+{% for i in range(devcluster_cassandra_nodes | int) %}
+  cassandra-{{ i }}:
+{% endfor %}

--- a/roles/devcluster/templates/docker-compose.yml.j2
+++ b/roles/devcluster/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@
 services:
 
   opensearch:
-    image: opensearchproject/opensearch:{{ devcluster_opensearch_version }}
+    image: "opensearchproject/opensearch:{{ devcluster_opensearch_version }}"
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
@@ -19,7 +19,7 @@ services:
       start_period: 30s
 
   axon-server:
-    image: {{ devcluster_registry }}/axon-server:{{ devcluster_axon_server_version }}
+    image: "{{ devcluster_registry }}/axon-server:{{ devcluster_axon_server_version }}"
     depends_on:
       opensearch:
         condition: service_healthy
@@ -33,7 +33,7 @@ services:
       start_period: 10s
 
   axon-dash:
-    image: {{ devcluster_registry }}/axon-dash:{{ devcluster_axon_dash_version }}
+    image: "{{ devcluster_registry }}/axon-dash:{{ devcluster_axon_dash_version }}"
     depends_on:
       axon-server:
         condition: service_healthy
@@ -50,7 +50,7 @@ services:
 
 {% for i in range(devcluster_cassandra_nodes | int) %}
   cassandra-{{ i }}:
-    image: {{ devcluster_registry }}/cassandra:{{ devcluster_cassandra_version }}
+    image: "{{ devcluster_registry }}/cassandra:{{ devcluster_cassandra_version }}"
     hostname: cassandra-{{ i }}
     restart: always
     depends_on:

--- a/roles/devcluster/templates/docker-compose.yml.j2
+++ b/roles/devcluster/templates/docker-compose.yml.j2
@@ -24,13 +24,13 @@ services:
       opensearch:
         condition: service_healthy
     environment:
-      - OPENSEARCH_HOSTS=http://opensearch:9200
+      - ELASTIC_HOSTS=http://opensearch:9200
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080"]
       interval: 10s
       timeout: 5s
       retries: 30
-      start_period: 10s
+      start_period: 30s
 
   axon-dash:
     image: "{{ devcluster_registry }}/axon-dash:{{ devcluster_axon_dash_version }}"

--- a/roles/devcluster/templates/docker-compose.yml.j2
+++ b/roles/devcluster/templates/docker-compose.yml.j2
@@ -24,7 +24,7 @@ services:
       opensearch:
         condition: service_healthy
     environment:
-      - ELASTIC_HOSTS=http://opensearch:9200
+      - ELASTIC_HOST=http://opensearch:9200
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080"]
       interval: 10s


### PR DESCRIPTION
## Summary

- Adds new `devcluster` role deploying the full AxonOps monitoring platform as Docker containers via `community.docker.docker_compose_v2`
- Four services: OpenSearch → axon-server → axon-dash + Cassandra (1–3 nodes with AxonOps agent pre-baked)
- `devcluster_cassandra_nodes: 1-3` generates Cassandra services with sequential healthcheck-gated `depends_on` chain
- Optional registry auth via `devcluster_registry_auth` (no_log: true)
- Includes `molecule/validate` (template rendering, no Docker needed) and `molecule/default` (full Docker integration) scenarios
- Adds collection-level `requirements.yml` with `community.docker >= 3.0.0`

## Services deployed

```
opensearch → axon-server → axon-dash
                 ↓
           cassandra-0 → cassandra-1 → cassandra-2 (if nodes > 1)
```

## Test plan

- [ ] Molecule `validate` job passes (template rendering + YAML validation, no Docker)
- [ ] Molecule `integration` job passes (full stack up, axon-dash responds on port 3000)
- [ ] `devcluster_cassandra_nodes: 3` renders 3 Cassandra services with correct sequential depends_on
- [ ] `devcluster_state: absent` tears down stack and removes volumes