### PR TITLE
ci: add molecule CI workflows for configurations and cqlai roles

### DIFF
--- a/.github/workflows/configurations-molecule.yml
+++ b/.github/workflows/configurations-molecule.yml
@@ -59,8 +59,7 @@ jobs:
           AXONOPS_URL: ${{ secrets.AXONOPS_URL }}
           AXONOPS_ORG: ${{ secrets.AXONOPS_ORG }}
           AXONOPS_CLUSTER: ${{ secrets.AXONOPS_CLUSTER }}
-          AXONOPS_USERNAME: ${{ secrets.AXONOPS_USERNAME }}
-          AXONOPS_PASSWORD: ${{ secrets.AXONOPS_PASSWORD }}
+          AXONOPS_TOKEN: ${{ secrets.AXONOPS_TOKEN }}
 
       - name: Run Molecule converge
         run: molecule -v converge
@@ -73,5 +72,4 @@ jobs:
           AXONOPS_URL: ${{ secrets.AXONOPS_URL }}
           AXONOPS_ORG: ${{ secrets.AXONOPS_ORG }}
           AXONOPS_CLUSTER: ${{ secrets.AXONOPS_CLUSTER }}
-          AXONOPS_USERNAME: ${{ secrets.AXONOPS_USERNAME }}
-          AXONOPS_PASSWORD: ${{ secrets.AXONOPS_PASSWORD }}
+          AXONOPS_TOKEN: ${{ secrets.AXONOPS_TOKEN }}

--- a/.github/workflows/configurations-molecule.yml
+++ b/.github/workflows/configurations-molecule.yml
@@ -1,0 +1,77 @@
+---
+name: AxonOps Configurations Molecule
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'roles/configurations/**'
+      - '.github/workflows/configurations-molecule.yml'
+  pull_request:
+    paths:
+      - 'roles/configurations/**'
+      - '.github/workflows/configurations-molecule.yml'
+
+defaults:
+  run:
+    working-directory: roles/configurations
+
+jobs:
+  molecule:
+    name: Molecule AxonOps Configurations
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - rockylinux9
+          - rockylinux10
+          - ubuntu2204
+          - ubuntu2404
+          - debian12
+          - debian13
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule molecule-plugins[docker] docker
+
+      - name: Install collection locally.
+        run: ansible-galaxy collection install $GITHUB_WORKSPACE --force
+        working-directory: ${{ github.workspace }}
+
+      - name: Run Molecule destroy (ignore failures)
+        run: molecule -v destroy
+        continue-on-error: true
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: configurations-${{ matrix.distro }}
+          AXONOPS_URL: ${{ secrets.AXONOPS_URL }}
+          AXONOPS_ORG: ${{ secrets.AXONOPS_ORG }}
+          AXONOPS_CLUSTER: ${{ secrets.AXONOPS_CLUSTER }}
+          AXONOPS_USERNAME: ${{ secrets.AXONOPS_USERNAME }}
+          AXONOPS_PASSWORD: ${{ secrets.AXONOPS_PASSWORD }}
+
+      - name: Run Molecule converge
+        run: molecule -v converge
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: configurations-${{ matrix.distro }}
+          AXONOPS_URL: ${{ secrets.AXONOPS_URL }}
+          AXONOPS_ORG: ${{ secrets.AXONOPS_ORG }}
+          AXONOPS_CLUSTER: ${{ secrets.AXONOPS_CLUSTER }}
+          AXONOPS_USERNAME: ${{ secrets.AXONOPS_USERNAME }}
+          AXONOPS_PASSWORD: ${{ secrets.AXONOPS_PASSWORD }}

--- a/.github/workflows/cqlai-molecule.yml
+++ b/.github/workflows/cqlai-molecule.yml
@@ -1,0 +1,63 @@
+---
+name: CQL AI Molecule
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'roles/cqlai/**'
+      - '.github/workflows/cqlai-molecule.yml'
+  pull_request:
+    paths:
+      - 'roles/cqlai/**'
+      - '.github/workflows/cqlai-molecule.yml'
+
+defaults:
+  run:
+    working-directory: roles/cqlai
+
+jobs:
+  molecule:
+    name: Molecule CQL AI
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - rockylinux9
+          - rockylinux10
+          - ubuntu2204
+          - ubuntu2404
+          - debian12
+          - debian13
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule molecule-plugins[docker] docker
+
+      - name: Run Molecule destroy (ignore failures)
+        run: molecule -v destroy
+        continue-on-error: true
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: cqlai-${{ matrix.distro }}
+
+      - name: Run Molecule converge
+        run: molecule -v converge
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: cqlai-${{ matrix.distro }}

--- a/roles/configurations/molecule/default/molecule.yml
+++ b/roles/configurations/molecule/default/molecule.yml
@@ -13,8 +13,7 @@ platforms:
       AXONOPS_URL: ${AXONOPS_URL:-https://dash.axonops.cloud/}
       AXONOPS_ORG: ${AXONOPS_ORG:-'axonops'}
       AXONOPS_CLUSTER: ${AXONOPS_CLUSTER:-'axonsaas'}
-      AXONOPS_USERNAME: ${AXONOPS_USERNAME}
-      AXONOPS_PASSWORD: ${AXONOPS_PASSWORD}
+      AXONOPS_TOKEN: ${AXONOPS_TOKEN}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - ${HOME}/.ansible/collections/ansible_collections/axonops/axonops:/root/.ansible/collections/ansible_collections/axonops/axonops:ro


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cqlai-molecule.yml` — standard 6-OS matrix matching other role workflows
- Adds `.github/workflows/configurations-molecule.yml` — 6-OS matrix with collection install step and AxonOps API secrets passed through

## Details

Both roles had molecule tests locally but no GitHub Actions workflow, so they were never tested in CI.

The `configurations` workflow has two differences from the standard pattern:
1. Installs the collection via `ansible-galaxy collection install` before running molecule, because the converge playbook references the FQCN `axonops.axonops.configurations`
2. Passes `AXONOPS_URL`, `AXONOPS_ORG`, `AXONOPS_CLUSTER`, `AXONOPS_USERNAME`, and `AXONOPS_PASSWORD` from repository secrets — the role makes live API calls

**Prerequisites:** Repository secrets `AXONOPS_USERNAME` and `AXONOPS_PASSWORD` (and optionally `AXONOPS_URL`, `AXONOPS_ORG`, `AXONOPS_CLUSTER`) must be configured for the `configurations` workflow to pass.

## Test plan

- [ ] Verify `cqlai-molecule.yml` triggers and passes on all 6 distros
- [ ] Verify `configurations-molecule.yml` triggers and passes once API secrets are set in repository settings
- [ ] Confirm path filters work — changes outside `roles/cqlai/` or `roles/configurations/` do not trigger these workflows

Closes #70