### PR TITLE
fix: resolve Ansible Galaxy importer errors and add publish job

### DIFF
--- a/plugins/filter/custom.py
+++ b/plugins/filter/custom.py
@@ -1,5 +1,13 @@
 __author__ = "dale mcdiarmid"
 
+DOCUMENTATION = r"""
+  name: axonops_filters
+  short_description: Utility filters for AxonOps collection
+  description:
+    - A set of Jinja2 filters used internally by the AxonOps Ansible collection.
+  author: dale mcdiarmid
+"""
+
 import re
 import os.path
 from six import string_types

--- a/plugins/modules/adaptive_repair.py
+++ b/plugins/modules/adaptive_repair.py
@@ -92,7 +92,7 @@ options:
             - The default is TRUE.
         required: false
         type: bool
-    segmentretries: 3
+    segmentretries:
         description:
             - The maximum number segmentretries before fail a segment
             - The default is 3

--- a/plugins/modules/alert_rule.py
+++ b/plugins/modules/alert_rule.py
@@ -60,16 +60,13 @@ options:
             - It can be read from the environment variable AXONOPS_CLUSTER_TYPE.
         required: false
         type: str
-TODO
 
 '''
 
 EXAMPLES = r'''
-TODO
 '''
 
 RETURN = r'''
-TODO
 '''
 
 import re

--- a/plugins/modules/log_alert_rule.py
+++ b/plugins/modules/log_alert_rule.py
@@ -98,7 +98,7 @@ options:
             - For how long in the past you want the scrape log.
         required: true
         type: str
-    operator
+    operator:
         description:
             - The operator to use un the alert query.
             - The default value is '>='.

--- a/plugins/modules/opsgenie_integration.py
+++ b/plugins/modules/opsgenie_integration.py
@@ -60,16 +60,13 @@ options:
             - It can be read from the environment variable AXONOPS_CLUSTER_TYPE.
         required: false
         type: str
-TODO
 
 '''
 
 EXAMPLES = r'''
-TODO
 '''
 
 RETURN = r'''
-TODO
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/pagerduty_integration.py
+++ b/plugins/modules/pagerduty_integration.py
@@ -60,16 +60,13 @@ options:
             - It can be read from the environment variable AXONOPS_CLUSTER_TYPE.
         required: false
         type: str
-TODO
 
 '''
 
 EXAMPLES = r'''
-TODO
 '''
 
 RETURN = r'''
-TODO
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/servicenow_integration.py
+++ b/plugins/modules/servicenow_integration.py
@@ -60,16 +60,13 @@ options:
             - It can be read from the environment variable AXONOPS_CLUSTER_TYPE.
         required: false
         type: str
-TODO
 
 '''
 
 EXAMPLES = r'''
-TODO
 '''
 
 RETURN = r'''
-TODO
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/slack_integration.py
+++ b/plugins/modules/slack_integration.py
@@ -60,15 +60,12 @@ options:
             - It can be read from the environment variable AXONOPS_CLUSTER_TYPE.
         required: false
         type: str
-TODO
 '''
 
 EXAMPLES = r'''
-TODO
 '''
 
 RETURN = r'''
-TODO
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/teams_integration.py
+++ b/plugins/modules/teams_integration.py
@@ -60,16 +60,13 @@ options:
             - It can be read from the environment variable AXONOPS_CLUSTER_TYPE.
         required: false
         type: str
-TODO
 
 '''
 
 EXAMPLES = r'''
-TODO
 '''
 
 RETURN = r'''
-TODO
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/roles/cassandra/README.md
+++ b/roles/cassandra/README.md
@@ -1,0 +1,30 @@
+# AxonOps Cassandra Ansible Role
+
+Installs and configures Apache Cassandra from the Apache tar distribution.
+
+## Requirements
+
+- Java must be installed before running this role (use `axonops.axonops.java`).
+
+## Configuration
+
+Key variables (see `defaults/main.yml` for the full list):
+
+```yaml
+cassandra_cluster_name: default
+cassandra_dc: default
+cassandra_rack: rack1
+cassandra_max_heap_size: 1G
+```
+
+## Example Playbook
+
+```yaml
+- hosts: cassandra
+  roles:
+    - role: axonops.axonops.java
+    - role: axonops.axonops.cassandra
+      vars:
+        cassandra_cluster_name: my-cluster
+        cassandra_dc: dc1
+```

--- a/roles/configurations/README.md
+++ b/roles/configurations/README.md
@@ -1,0 +1,36 @@
+# AxonOps Configurations Ansible Role
+
+Manages AxonOps configuration resources — alert rules, log alerts, dashboards, integrations, adaptive repair, and more — via the AxonOps API.
+
+## Requirements
+
+A running AxonOps server and a valid API token (`AXONOPS_TOKEN`) or username/password.
+
+## Authentication
+
+```yaml
+# Token-based (recommended)
+AXONOPS_TOKEN: <your-token>
+
+# Or username/password
+AXONOPS_USERNAME: admin
+AXONOPS_PASSWORD: secret
+```
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  vars:
+    axonops_alert_rules:
+      - name: High CPU
+        dashboard: System
+        chart: CPU usage per host
+        operator: '>='
+        critical_value: 99
+        warning_value: 90
+        duration: 1h
+        description: High CPU usage detected
+  roles:
+    - role: axonops.axonops.configurations
+```

--- a/roles/java/README.md
+++ b/roles/java/README.md
@@ -1,0 +1,21 @@
+# AxonOps Java Ansible Role
+
+Installs Java (OpenJDK or Zulu) on the target hosts.
+
+## Configuration
+
+```yaml
+# Use Zulu Java instead of OpenJDK (Debian-based systems only)
+java_use_zulu: false
+
+# Install EPEL repository on RHEL-based systems before installing Java
+java_install_epel: false
+```
+
+## Example Playbook
+
+```yaml
+- hosts: cassandra
+  roles:
+    - role: axonops.axonops.java
+```

--- a/roles/k8ssandra/README.md
+++ b/roles/k8ssandra/README.md
@@ -1,0 +1,18 @@
+# AxonOps K8ssandra Ansible Role
+
+Installs the K8ssandra operator via Helm and deploys a `K8ssandraCluster` custom resource with the AxonOps agent sidecar.
+
+## Requirements
+
+- A running Kubernetes cluster with `kubectl` and `helm` available on the control node.
+- `kubernetes.core` Ansible collection.
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: axonops.axonops.k8ssandra
+```
+
+See `defaults/main.yml` for the full list of configurable variables.

--- a/roles/preflight/README.md
+++ b/roles/preflight/README.md
@@ -1,0 +1,21 @@
+# AxonOps Preflight Ansible Role
+
+Runs pre-flight checks on target hosts before deploying Cassandra or other AxonOps components.
+
+## Checks
+
+| Variable | Default | Description |
+|---|---|---|
+| `preflight_check_memory` | `true` | Verify minimum memory requirements |
+| `preflight_check_ntp` | `true` | Verify NTP is configured |
+| `preflight_check_os` | `true` | Verify OS is supported |
+| `preflight_check_cassandra_data_directory` | `true` | Verify data directory exists and has space |
+| `preflight_check_swap` | `true` | Verify swap is disabled |
+
+## Example Playbook
+
+```yaml
+- hosts: cassandra
+  roles:
+    - role: axonops.axonops.preflight
+```

--- a/roles/server/README.md
+++ b/roles/server/README.md
@@ -1,0 +1,21 @@
+# AxonOps Server Ansible Role
+
+Installs and configures the AxonOps server (`axon-server`).
+
+## Configuration
+
+```yaml
+axon_server_state: present   # present or absent
+axon_server_version: latest  # version to install
+axon_server_hum: false       # enable human-readable metrics
+```
+
+## Example Playbook
+
+```yaml
+- hosts: axonops_server
+  roles:
+    - role: axonops.axonops.server
+      vars:
+        axon_server_version: latest
+```

--- a/roles/strimzi/README.md
+++ b/roles/strimzi/README.md
@@ -1,0 +1,19 @@
+# AxonOps Strimzi Ansible Role
+
+Installs the Strimzi Kafka operator via Helm and deploys `KafkaNodePool` and `Kafka` custom resources in KRaft mode.
+
+## Requirements
+
+- A running Kubernetes cluster with `kubectl` and `helm` available on the control node.
+- `kubernetes.core` Ansible collection.
+- Strimzi 0.51 or later (KRaft mode only — ZooKeeper not supported).
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: axonops.axonops.strimzi
+```
+
+See `defaults/main.yml` for the full list of configurable variables.


### PR DESCRIPTION
## Summary

- Add `publish` job to `release.yml` that publishes to Ansible Galaxy using `ANSIBLE_GALAXY_TOKEN` secret
- Fix Galaxy importer errors that were blocking the `v0.5.1` release from being imported

## Galaxy Importer Errors Fixed

### Missing role READMEs
Added `README.md` to 7 roles that were missing it: `cassandra`, `configurations`, `java`, `preflight`, `server`, `k8ssandra`, `strimzi`

### Invalid YAML in module DOCUMENTATION blocks
- `adaptive_repair.py`: stray inline value `segmentretries: 3` (should be `segmentretries:`)
- `log_alert_rule.py`: missing colon on `operator` key
- 6 modules (`pagerduty_integration`, `alert_rule`, `teams_integration`, `servicenow_integration`, `opsgenie_integration`, `slack_integration`): bare `TODO` lines inside DOCUMENTATION/EXAMPLES/RETURN triple-quoted blocks caused YAML parse failures

### Missing filter plugin DOCUMENTATION
Added `DOCUMENTATION` attribute to `plugins/filter/custom.py`

## Test plan

- [ ] Re-tag `v0.5.1` (or next version) and verify the Galaxy import job completes without errors
- [ ] Confirm `ansible-galaxy collection publish` step succeeds in the release workflow