### PR TITLE
fix: enforce axon_server_org_name as required in server role

### DIFF
--- a/docs/roles/server.md
+++ b/docs/roles/server.md
@@ -24,6 +24,7 @@ The `server` role installs and configures the AxonOps Server, which is the core 
 | `axon_server_version` | `latest` | Version of AxonOps Server to install |
 | `axon_server_hum` | `false` | Enable Human Readable IDs |
 | `axon_server_license_key` | - | License key for on-premises AxonOps deployment (required for self-hosted) |
+| `axon_server_org_name` | - | Organisation name used by AxonOps Server (**required**) |
 
 ### Network Configuration
 
@@ -134,6 +135,7 @@ using `single-node` mode with automatically generated TLS certificates:
     opensearch_domain_name: example.com
 
     # AxonOps Server configuration
+    axon_server_org_name: "mycompany"
     axon_server_license_key: "your-license-key-here"
     axon_server_cql_hosts:
       - localhost:9042
@@ -159,6 +161,7 @@ using `single-node` mode with automatically generated TLS certificates:
   hosts: axon-server
   become: true
   vars:
+    axon_server_org_name: "mycompany"
     axon_server_license_key: "your-license-key-here"
     axon_server_cql_hosts:
       - localhost:9042
@@ -197,6 +200,7 @@ using `single-node` mode with automatically generated TLS certificates:
     es_heap_size: 2g
 
     # AxonOps Server Configuration
+    axon_server_org_name: "mycompany"
     axon_server_license_key: "your-license-key-here"
     axon_server_cql_hosts:
       - localhost:9042
@@ -236,6 +240,7 @@ using `single-node` mode with automatically generated TLS certificates:
   hosts: axon-server
   become: true
   vars:
+    axon_server_org_name: "mycompany"
     axon_server_license_key: "your-license-key-here"
     axon_server_cql_hosts:
       - cassandra-1.example.com:9042
@@ -262,6 +267,7 @@ using `single-node` mode with automatically generated TLS certificates:
   hosts: axon-server
   become: true
   vars:
+    axon_server_org_name: "mycompany"
     axon_server_license_key: "your-license-key-here"
     axon_server_cql_hosts:
       - localhost:9042
@@ -298,6 +304,7 @@ using `single-node` mode with automatically generated TLS certificates:
   hosts: axon-server
   become: true
   vars:
+    axon_server_org_name: "mycompany"
     axon_server_license_key: "your-license-key-here"
     axon_server_cql_hosts:
       - localhost:9042
@@ -326,6 +333,7 @@ using `single-node` mode with automatically generated TLS certificates:
   hosts: axon-server
   become: true
   vars:
+    axon_server_org_name: "mycompany"
     axon_server_license_key: "your-license-key-here"
     axon_server_cql_hosts:
       - localhost:9042

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -58,8 +58,8 @@ axon_server_retention:
     local: 10d
     remote: 30d
 
-# Optional for multplie clusters
-# axon_server_org_name: "axonops"
+# REQUIRED — must be set by the caller; no default value
+# axon_server_org_name: "mycompany"
 
 # CQL configuration
 axon_server_cql_hosts: []

--- a/roles/server/molecule/default/converge.yml
+++ b/roles/server/molecule/default/converge.yml
@@ -1,6 +1,8 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    axon_server_org_name: "test-org"
 
   roles:
     - role: server

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -9,7 +9,9 @@
     that:
       - axon_server_state is defined
       - axon_server_state in ['present', 'absent']
-    fail_msg: "You must configured the axon_server_state variable with one of the following values: present, absent."
+      - axon_server_org_name is defined
+      - axon_server_org_name | length > 0
+    fail_msg: "axon_server_state must be 'present' or 'absent', and axon_server_org_name must be set."
 
 - name: Confirm if TLS is required
   ansible.builtin.assert:

--- a/roles/server/templates/axon-server.yml.j2
+++ b/roles/server/templates/axon-server.yml.j2
@@ -69,9 +69,7 @@ alerting:
 retention:
   {{ axon_server_retention | to_nice_yaml(indent=2) | indent(2) }}
 
-{% if axon_server_org_name is defined %}
 org_name: {{ axon_server_org_name }}
-{% endif %}
 {% if axon_server_license_key is defined and axon_server_license_key != "" %}
 license_key: "{{ axon_server_license_key }}"
 {% endif %}


### PR DESCRIPTION
Fixes #73

## Summary

- Add preflight `assert` for `axon_server_org_name` (must be defined and non-empty) in `roles/server/tasks/main.yml`
- Remove `{% if axon_server_org_name is defined %}` guard in `roles/server/templates/axon-server.yml.j2` — field is now always rendered
- Update `roles/server/defaults/main.yml` comment to clearly mark the variable as required
- Update `roles/server/molecule/default/converge.yml` to set `axon_server_org_name: "test-org"`
- Add `axon_server_org_name` to the variable table in `docs/roles/server.md` as **required**; add it to all example playbooks that were missing it

## Test plan

- [ ] `molecule converge` passes for the `server` role
- [ ] Running the role without `axon_server_org_name` fails at "Preflight check" with a clear error message
- [ ] Running with `axon_server_org_name: "mycompany"` renders `org_name: mycompany` in the generated config