### PR TITLE
ci: add Ubuntu 26.04 to molecule CI matrix

### DIFF
--- a/.github/workflows/agent-molecule.yml
+++ b/.github/workflows/agent-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
 

--- a/.github/workflows/cassandra-molecule.yml
+++ b/.github/workflows/cassandra-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
         scenario:

--- a/.github/workflows/cqlai-molecule.yml
+++ b/.github/workflows/cqlai-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
 

--- a/.github/workflows/dash-molecule.yml
+++ b/.github/workflows/dash-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
 

--- a/.github/workflows/elastic-molecule.yml
+++ b/.github/workflows/elastic-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
 

--- a/.github/workflows/java-molecule.yml
+++ b/.github/workflows/java-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
 

--- a/.github/workflows/opensearch-molecule.yml
+++ b/.github/workflows/opensearch-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
 

--- a/.github/workflows/pki-agent-molecule.yml
+++ b/.github/workflows/pki-agent-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
 
     steps:

--- a/.github/workflows/server-molecule.yml
+++ b/.github/workflows/server-molecule.yml
@@ -28,6 +28,7 @@ jobs:
           - rockylinux10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian12
           - debian13
 


### PR DESCRIPTION
## Summary

- Add `ubuntu2604` to the distro matrix in all 9 molecule GitHub Actions workflows
- Covers: agent, cassandra, cqlai, dash, elastic, java, opensearch, pki-agent, server
- No role code changed — CI-only

## Test plan

- [x] CI runs molecule on `ubuntu2604` across all affected roles
- [ ] Existing platforms unaffected

## Checklist

- [x] No Ansible role files changed
- [x] No documentation changes required
- [x] `ubuntu2604` inserted consistently after `ubuntu2404` in all matrices