### PR TITLE
feat: add comprehensive Kafka monitoring alert pack to configurations role

### DIFF
--- a/.github/workflows/configurations-molecule.yml
+++ b/.github/workflows/configurations-molecule.yml
@@ -28,7 +28,9 @@ jobs:
 
     steps:
       - name: Disabled for now, it needs work
-        run: exit 0
+        run: |
+          echo "Workflow currently disabled"
+          exit 0
 
       - name: Check out the codebase.
         uses: actions/checkout@v4

--- a/.github/workflows/configurations-molecule.yml
+++ b/.github/workflows/configurations-molecule.yml
@@ -21,17 +21,13 @@ jobs:
   molecule:
     name: Molecule AxonOps Configurations
     runs-on: ubuntu-latest
+    if: false  # Disabled — molecule scenario needs work before it can run in CI
     strategy:
       matrix:
         distro:
           - rockylinux9
 
     steps:
-      - name: Disabled for now, it needs work
-        run: |
-          echo "Workflow currently disabled"
-          exit 0
-
       - name: Check out the codebase.
         uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/full-example/roles
 venv/
 .venv
 .claude/settings.local.json
+.ansible

--- a/docs/roles/configurations.md
+++ b/docs/roles/configurations.md
@@ -507,8 +507,10 @@ axonops_alert_rules:
     description: Kafka partitions offline
 ```
 
-A full set of example Kafka alert rules is available at
-[examples/configurations/kafka/alert_rules.yml](../../examples/configurations/kafka/alert_rules.yml).
+A comprehensive set of Kafka alert rules covering metric and log-based alerts is available in
+[examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/](../../examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/).
+See the [Kafka Alert Pack section in the configurations role README](../../roles/configurations/README.md#kafka-alert-pack)
+for the full list of rules and quick-start instructions.
 
 ### Metric Alerts
 
@@ -583,12 +585,14 @@ axonops_alert_rules:
     description: Detected High disk utilization
 ```
 
-**Note:** More examples of metric checks can be found in the org level
+**Note:** More examples of metric checks can be found in the org-level
 [metric_alert_rules.yml](../../examples/configurations/cassandra/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml) or
-the cluster level
+the cluster-level
 [metric_alert_rules.yml](../../examples/configurations/cassandra/config/REPLACE_WITH_ORG_NAME/REPLACE_WITH_CLUSTER_NAME/metric_alert_rules.yml)
-example files. For Kafka-specific alert rules, see
-[kafka/alert_rules.yml](../../examples/configurations/kafka/alert_rules.yml).
+example files. For Kafka-specific metric and log alert rules, see
+[kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml](../../examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml)
+and
+[kafka/config/REPLACE_WITH_ORG_NAME/log_alert_rules.yml](../../examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/log_alert_rules.yml).
 
 ### Service Checks
 

--- a/examples/configurations/kafka/alert_rules.yml
+++ b/examples/configurations/kafka/alert_rules.yml
@@ -1,3 +1,17 @@
+######## Kafka Default Alert Pack ########
+# This file is the default Kafka alert pack for AxonOps.
+# It is retained for backwards compatibility. The canonical alert definitions
+# have been moved to the config/ directory structure:
+#
+#   config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml  — 50+ metric alerts
+#   config/REPLACE_WITH_ORG_NAME/log_alert_rules.yml     — 30+ log pattern alerts
+#
+# For new deployments, use the config/ structure with the configurations role:
+#
+#   ansible-playbook kafka-alerts.yml
+#
+# The rules below are a minimal legacy reference set.
+
 axonops_alert_rules:
 
 ######## KAFKA OVERVIEW ALERTS ########
@@ -94,8 +108,6 @@ axonops_alert_rules:
   warning_value: 10
   duration: 15m
   description: Failed Auth requests against Kafka Controller
-
-
 
 
 ######## SYSTEM ALERTS ########

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/REPLACE_WITH_CLUSTER_NAME/log_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/REPLACE_WITH_CLUSTER_NAME/log_alert_rules.yml
@@ -1,0 +1,7 @@
+######## Kafka Cluster-Specific Log Alert Overrides ########
+# Add cluster-specific log alert rules here.
+# These are APPENDED to the org-level rules in config/<org>/log_alert_rules.yml
+# Use this file to tune thresholds, add cluster-specific patterns, or target
+# non-standard log paths for this cluster only.
+
+axonops_log_alert_rule: []

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/REPLACE_WITH_CLUSTER_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/REPLACE_WITH_CLUSTER_NAME/metric_alert_rules.yml
@@ -1,0 +1,7 @@
+######## Kafka Cluster-Specific Metric Alert Overrides ########
+# Add cluster-specific metric alert rules here.
+# These are APPENDED to the org-level rules in config/<org>/metric_alert_rules.yml
+# Use this file to tune thresholds, add cluster-specific alerts, or re-define
+# org-level rules with different values for this cluster only.
+
+axonops_alert_rules: []

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/log_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/log_alert_rules.yml
@@ -1,0 +1,311 @@
+######## Kafka Log Alert Rules ########
+# Comprehensive log-based alert rules for Apache Kafka clusters monitored by AxonOps.
+# Covers: Kafka Broker, KRaft Controller, and Kafka Connect log streams.
+# These rules are applied to ALL clusters in the organisation.
+# Override or extend per-cluster in config/<org>/<cluster>/log_alert_rules.yml
+#
+# Log phrases must be wrapped as: \"text to search\"
+# For regex patterns use single-quoted strings without escaping.
+# Match FATAL and ERROR as standalone tokens at the log level field position
+# (e.g. '] FATAL ' or '] ERROR ') to avoid false positives.
+
+axonops_log_alert_rule:
+
+######## KAFKA BROKER — STARTUP & AVAILABILITY ########
+
+- name: Broker Startup Failure
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"Fatal error during KafkaServer startup\"
+  source: "/var/log/kafka/server.log"
+  description: Broker failed to start. Check port conflicts, config errors, or permissions. Verify server.properties and listener ports.
+  present: true
+
+- name: Broker JVM OOM
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"OutOfMemoryError\"
+  source: "/var/log/kafka/server.log"
+  description: JVM heap exhausted. Increase -Xmx, review message sizes, check for memory leaks in custom interceptors or serialisers.
+  present: true
+
+- name: Broker FATAL Error
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: '] FATAL '
+  source: "/var/log/kafka/server.log"
+  description: Fatal condition causing broker abort. Investigate immediately; check full stack trace.
+  present: true
+
+- name: Kafka Storage Exception
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"KafkaStorageException\"
+  source: "/var/log/kafka/server.log"
+  description: Disk-level failure. Check disk health, SMART status, and filesystem mount state.
+  present: true
+
+- name: Data Directory Failure
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"Failed to create or validate data directory\"
+  source: "/var/log/kafka/server.log"
+  description: Kafka cannot access a log directory. Verify directory exists, permissions are correct, and the filesystem is mounted and writable.
+  present: true
+
+- name: Log Flush IO Error
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"Error while flushing log\"
+  source: "/var/log/kafka/server.log"
+  description: Typically java.io.IOException — No space left on device. Expand storage, reduce retention, or delete unused topics.
+  present: true
+
+- name: Disk Lock Error
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"Disk error while locking directory\"
+  source: "/var/log/kafka/server.log"
+  description: Another process is holding the data directory lock or the filesystem is read-only. Ensure no duplicate Kafka processes are running.
+  present: true
+
+
+######## KAFKA BROKER — REPLICATION & PARTITION HEALTH ########
+
+- name: Broker Under Replicated Partitions
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  content: \"under replicated\"
+  source: "/var/log/kafka/server.log"
+  description: Partitions have fewer in-sync replicas than the replication factor. Risk of data loss if another broker fails.
+  present: true
+
+- name: ISR Shrunk
+  warning_value: 3
+  critical_value: 20
+  duration: 5m
+  content: \"ISR shrunk\"
+  source: "/var/log/kafka/server.log"
+  description: A replica fell behind and was removed from the ISR. Check the lagging broker's disk I/O, network latency, and resource utilisation.
+  present: true
+
+- name: ISR Shrunk (state-change log)
+  warning_value: 3
+  critical_value: 20
+  duration: 5m
+  content: \"Shrinking ISR from\"
+  source: "/var/log/kafka/state-change.log"
+  description: ISR shrink logged in state-change log. Indicates replication performance issues.
+  present: true
+
+- name: Offline Partition
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"OfflinePartition\"
+  source: "/var/log/kafka/state-change.log"
+  description: A partition has no active leader. Restore the failed broker or trigger partition reassignment.
+  present: true
+
+
+######## KAFKA BROKER — SECURITY & AUTHENTICATION ########
+
+- name: Authorization Failure
+  warning_value: 1
+  critical_value: 10
+  duration: 5m
+  content: \"Authorization failed\"
+  source: "/var/log/kafka/kafka-authorizer.log"
+  description: A client request was denied by the ACL authoriser. If unexpected, investigate potential misconfiguration or security breach.
+  present: true
+
+- name: Authentication Failure
+  warning_value: 1
+  critical_value: 20
+  duration: 5m
+  content: \"Failed authentication\"
+  source: "/var/log/kafka/server.log"
+  description: Client failed SASL/mTLS authentication. Check client credentials, SASL configuration, and SCRAM user store.
+  present: true
+
+
+######## KAFKA BROKER — JVM GC ########
+
+- name: Broker Full GC Event
+  warning_value: 1
+  critical_value: 3
+  duration: 15m
+  content: \"Full GC\"
+  source: "/var/log/kafka/kafkaServer-gc.log"
+  description: Stop-the-world full GC occurred. If frequent, increase heap size. Kafka recommends G1GC with -XX:MaxGCPauseMillis=20.
+  present: true
+
+- name: Broker Long GC Pause
+  warning_value: 1
+  critical_value: 3
+  duration: 15m
+  content: 'GC.* pause .* [0-9]{4,}ms'
+  source: "/var/log/kafka/kafkaServer-gc.log"
+  description: GC pause exceeding 1s can cause consumer lag spikes and request timeouts. Tune JVM heap (4-8 GB recommended).
+  present: true
+
+- name: Broker G1GC Mark Abort
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  content: \"concurrent-mark-abort\"
+  source: "/var/log/kafka/kafkaServer-gc.log"
+  description: G1GC marking cycle aborted due to heap pressure, often preceding an OOM. Review heap sizing immediately.
+  present: true
+
+- name: Broker GC OOM
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"OutOfMemoryError\"
+  source: "/var/log/kafka/kafkaServer-gc.log"
+  description: JVM heap exhausted as detected in GC log. Increase -Xmx immediately.
+  present: true
+
+
+######## KRAFT CONTROLLER — QUORUM & LEADER ELECTION ########
+
+- name: Controller No Quorum Leader
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"the leader is (none)\"
+  source: "/var/log/kafka/controller.log"
+  description: The KRaft quorum has no elected leader. The cluster cannot process metadata changes. Check connectivity between all controller nodes.
+  present: true
+
+- name: Controller FATAL Error
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: '] FATAL '
+  source: "/var/log/kafka/controller.log"
+  description: Fatal condition in the controller process. Investigate the full stack trace immediately.
+  present: true
+
+- name: Controller ERROR
+  warning_value: 3
+  critical_value: 20
+  duration: 5m
+  content: '] ERROR '
+  source: "/var/log/kafka/controller.log"
+  description: Error in the controller log. Any error indicates a significant operational event.
+  present: true
+
+- name: Controller OOM
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"OutOfMemoryError\"
+  source: "/var/log/kafka/controller.log"
+  description: Controller JVM heap exhausted. Increase controller heap — larger clusters require more memory for in-memory metadata.
+  present: true
+
+- name: Controller Quorum Instability
+  warning_value: 3
+  critical_value: 20
+  duration: 15m
+  content: \"Completed transition to Unattached\"
+  source: "/var/log/kafka/controller.log"
+  description: Controller is frequently losing its quorum attachment. May indicate network instability between controller nodes. A few occurrences per week can be normal but sustained frequency is not.
+  present: true
+
+- name: Controller Metadata Load Error
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"MetadataLoadError\"
+  source: "/var/log/kafka/controller.log"
+  description: The BrokerMetadataListener encountered errors loading the metadata log. Data integrity risk; investigate immediately.
+  present: true
+
+
+######## KAFKA CONNECT — WORKER HEALTH ########
+
+- name: Connect Worker FATAL Error
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: '] FATAL '
+  source: "/var/log/kafka/connect.log"
+  description: The Connect worker process has encountered a fatal error. Restart the worker and investigate the root cause.
+  present: true
+
+- name: Connect Worker Startup Failure
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"Failed to start worker\"
+  source: "/var/log/kafka/connect.log"
+  description: Worker failed to start, typically due to configuration errors. Validate connect-distributed.properties.
+  present: true
+
+
+######## KAFKA CONNECT — CONNECTOR & TASK STATE ########
+
+- name: Connect Sink Task FAILED
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: 'WorkerSinkTask.*FAILED'
+  source: "/var/log/kafka/connect.log"
+  description: A sink connector task has transitioned to FAILED state. Connect does NOT automatically restart failed tasks. Restart via REST API POST /connectors/{name}/tasks/{id}/restart.
+  present: true
+
+- name: Connect Source Task FAILED
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: 'WorkerSourceTask.*FAILED'
+  source: "/var/log/kafka/connect.log"
+  description: A source connector task has transitioned to FAILED state. Connect does NOT automatically restart failed tasks. Restart via REST API POST /connectors/{name}/tasks/{id}/restart.
+  present: true
+
+- name: Connect Offset Commit Failure
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  content: \"Failed to commit offsets\"
+  source: "/var/log/kafka/connect.log"
+  description: Offset commit failed, typically due to consumer group rebalance timeout. Increase session.timeout.ms or reduce max.poll.records.
+  present: true
+
+- name: Connect Deserialization Error
+  warning_value: 1
+  critical_value: 10
+  duration: 5m
+  content: \"DeserializationException\"
+  source: "/var/log/kafka/connect.log"
+  description: Schema or serialisation mismatch. Check schema registry configuration and producer schema compatibility settings.
+  present: true
+
+- name: Connect Worker REST API Unreachable
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  content: \"Connection refused.*8083\"
+  source: "/var/log/kafka/connect.log"
+  description: The Connect worker REST API is unreachable — indicates a worker crash or network issue.
+  present: true
+
+- name: Connect Broker Connection Loss
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  content: \"Disconnected from node\"
+  source: "/var/log/kafka/connect.log"
+  description: Connect worker lost connectivity to a Kafka broker. Check broker health and network path between Connect and Kafka.
+  present: true

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/log_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/log_alert_rules.yml
@@ -20,7 +20,6 @@ axonops_log_alert_rule:
   content: \"Fatal error during KafkaServer startup\"
   source: "/var/log/kafka/server.log"
   description: Broker failed to start. Check port conflicts, config errors, or permissions. Verify server.properties and listener ports.
-  present: true
 
 - name: Broker JVM OOM
   warning_value: 1
@@ -29,7 +28,6 @@ axonops_log_alert_rule:
   content: \"OutOfMemoryError\"
   source: "/var/log/kafka/server.log"
   description: JVM heap exhausted. Increase -Xmx, review message sizes, check for memory leaks in custom interceptors or serialisers.
-  present: true
 
 - name: Broker FATAL Error
   warning_value: 1
@@ -38,7 +36,6 @@ axonops_log_alert_rule:
   content: '] FATAL '
   source: "/var/log/kafka/server.log"
   description: Fatal condition causing broker abort. Investigate immediately; check full stack trace.
-  present: true
 
 - name: Kafka Storage Exception
   warning_value: 1
@@ -47,7 +44,6 @@ axonops_log_alert_rule:
   content: \"KafkaStorageException\"
   source: "/var/log/kafka/server.log"
   description: Disk-level failure. Check disk health, SMART status, and filesystem mount state.
-  present: true
 
 - name: Data Directory Failure
   warning_value: 1
@@ -56,7 +52,6 @@ axonops_log_alert_rule:
   content: \"Failed to create or validate data directory\"
   source: "/var/log/kafka/server.log"
   description: Kafka cannot access a log directory. Verify directory exists, permissions are correct, and the filesystem is mounted and writable.
-  present: true
 
 - name: Log Flush IO Error
   warning_value: 1
@@ -65,7 +60,6 @@ axonops_log_alert_rule:
   content: \"Error while flushing log\"
   source: "/var/log/kafka/server.log"
   description: Typically java.io.IOException — No space left on device. Expand storage, reduce retention, or delete unused topics.
-  present: true
 
 - name: Disk Lock Error
   warning_value: 1
@@ -74,7 +68,6 @@ axonops_log_alert_rule:
   content: \"Disk error while locking directory\"
   source: "/var/log/kafka/server.log"
   description: Another process is holding the data directory lock or the filesystem is read-only. Ensure no duplicate Kafka processes are running.
-  present: true
 
 
 ######## KAFKA BROKER — REPLICATION & PARTITION HEALTH ########
@@ -86,7 +79,6 @@ axonops_log_alert_rule:
   content: \"under replicated\"
   source: "/var/log/kafka/server.log"
   description: Partitions have fewer in-sync replicas than the replication factor. Risk of data loss if another broker fails.
-  present: true
 
 - name: ISR Shrunk
   warning_value: 3
@@ -95,7 +87,6 @@ axonops_log_alert_rule:
   content: \"ISR shrunk\"
   source: "/var/log/kafka/server.log"
   description: A replica fell behind and was removed from the ISR. Check the lagging broker's disk I/O, network latency, and resource utilisation.
-  present: true
 
 - name: ISR Shrunk (state-change log)
   warning_value: 3
@@ -104,7 +95,6 @@ axonops_log_alert_rule:
   content: \"Shrinking ISR from\"
   source: "/var/log/kafka/state-change.log"
   description: ISR shrink logged in state-change log. Indicates replication performance issues.
-  present: true
 
 - name: Offline Partition
   warning_value: 1
@@ -113,7 +103,6 @@ axonops_log_alert_rule:
   content: \"OfflinePartition\"
   source: "/var/log/kafka/state-change.log"
   description: A partition has no active leader. Restore the failed broker or trigger partition reassignment.
-  present: true
 
 
 ######## KAFKA BROKER — SECURITY & AUTHENTICATION ########
@@ -125,7 +114,6 @@ axonops_log_alert_rule:
   content: \"Authorization failed\"
   source: "/var/log/kafka/kafka-authorizer.log"
   description: A client request was denied by the ACL authoriser. If unexpected, investigate potential misconfiguration or security breach.
-  present: true
 
 - name: Authentication Failure
   warning_value: 1
@@ -134,7 +122,6 @@ axonops_log_alert_rule:
   content: \"Failed authentication\"
   source: "/var/log/kafka/server.log"
   description: Client failed SASL/mTLS authentication. Check client credentials, SASL configuration, and SCRAM user store.
-  present: true
 
 
 ######## KAFKA BROKER — JVM GC ########
@@ -146,7 +133,6 @@ axonops_log_alert_rule:
   content: \"Full GC\"
   source: "/var/log/kafka/kafkaServer-gc.log"
   description: Stop-the-world full GC occurred. If frequent, increase heap size. Kafka recommends G1GC with -XX:MaxGCPauseMillis=20.
-  present: true
 
 - name: Broker Long GC Pause
   warning_value: 1
@@ -155,7 +141,6 @@ axonops_log_alert_rule:
   content: 'GC.* pause .* [0-9]{4,}ms'
   source: "/var/log/kafka/kafkaServer-gc.log"
   description: GC pause exceeding 1s can cause consumer lag spikes and request timeouts. Tune JVM heap (4-8 GB recommended).
-  present: true
 
 - name: Broker G1GC Mark Abort
   warning_value: 1
@@ -164,7 +149,6 @@ axonops_log_alert_rule:
   content: \"concurrent-mark-abort\"
   source: "/var/log/kafka/kafkaServer-gc.log"
   description: G1GC marking cycle aborted due to heap pressure, often preceding an OOM. Review heap sizing immediately.
-  present: true
 
 - name: Broker GC OOM
   warning_value: 1
@@ -173,7 +157,6 @@ axonops_log_alert_rule:
   content: \"OutOfMemoryError\"
   source: "/var/log/kafka/kafkaServer-gc.log"
   description: JVM heap exhausted as detected in GC log. Increase -Xmx immediately.
-  present: true
 
 
 ######## KRAFT CONTROLLER — QUORUM & LEADER ELECTION ########
@@ -185,7 +168,6 @@ axonops_log_alert_rule:
   content: \"the leader is (none)\"
   source: "/var/log/kafka/controller.log"
   description: The KRaft quorum has no elected leader. The cluster cannot process metadata changes. Check connectivity between all controller nodes.
-  present: true
 
 - name: Controller FATAL Error
   warning_value: 1
@@ -194,7 +176,6 @@ axonops_log_alert_rule:
   content: '] FATAL '
   source: "/var/log/kafka/controller.log"
   description: Fatal condition in the controller process. Investigate the full stack trace immediately.
-  present: true
 
 - name: Controller ERROR
   warning_value: 3
@@ -203,7 +184,6 @@ axonops_log_alert_rule:
   content: '] ERROR '
   source: "/var/log/kafka/controller.log"
   description: Error in the controller log. Any error indicates a significant operational event.
-  present: true
 
 - name: Controller OOM
   warning_value: 1
@@ -212,7 +192,6 @@ axonops_log_alert_rule:
   content: \"OutOfMemoryError\"
   source: "/var/log/kafka/controller.log"
   description: Controller JVM heap exhausted. Increase controller heap — larger clusters require more memory for in-memory metadata.
-  present: true
 
 - name: Controller Quorum Instability
   warning_value: 3
@@ -221,7 +200,6 @@ axonops_log_alert_rule:
   content: \"Completed transition to Unattached\"
   source: "/var/log/kafka/controller.log"
   description: Controller is frequently losing its quorum attachment. May indicate network instability between controller nodes. A few occurrences per week can be normal but sustained frequency is not.
-  present: true
 
 - name: Controller Metadata Load Error
   warning_value: 1
@@ -230,7 +208,6 @@ axonops_log_alert_rule:
   content: \"MetadataLoadError\"
   source: "/var/log/kafka/controller.log"
   description: The BrokerMetadataListener encountered errors loading the metadata log. Data integrity risk; investigate immediately.
-  present: true
 
 
 ######## KAFKA CONNECT — WORKER HEALTH ########
@@ -242,7 +219,6 @@ axonops_log_alert_rule:
   content: '] FATAL '
   source: "/var/log/kafka/connect.log"
   description: The Connect worker process has encountered a fatal error. Restart the worker and investigate the root cause.
-  present: true
 
 - name: Connect Worker Startup Failure
   warning_value: 1
@@ -251,7 +227,6 @@ axonops_log_alert_rule:
   content: \"Failed to start worker\"
   source: "/var/log/kafka/connect.log"
   description: Worker failed to start, typically due to configuration errors. Validate connect-distributed.properties.
-  present: true
 
 
 ######## KAFKA CONNECT — CONNECTOR & TASK STATE ########
@@ -263,7 +238,6 @@ axonops_log_alert_rule:
   content: 'WorkerSinkTask.*FAILED'
   source: "/var/log/kafka/connect.log"
   description: A sink connector task has transitioned to FAILED state. Connect does NOT automatically restart failed tasks. Restart via REST API POST /connectors/{name}/tasks/{id}/restart.
-  present: true
 
 - name: Connect Source Task FAILED
   warning_value: 1
@@ -272,7 +246,6 @@ axonops_log_alert_rule:
   content: 'WorkerSourceTask.*FAILED'
   source: "/var/log/kafka/connect.log"
   description: A source connector task has transitioned to FAILED state. Connect does NOT automatically restart failed tasks. Restart via REST API POST /connectors/{name}/tasks/{id}/restart.
-  present: true
 
 - name: Connect Offset Commit Failure
   warning_value: 1
@@ -281,7 +254,6 @@ axonops_log_alert_rule:
   content: \"Failed to commit offsets\"
   source: "/var/log/kafka/connect.log"
   description: Offset commit failed, typically due to consumer group rebalance timeout. Increase session.timeout.ms or reduce max.poll.records.
-  present: true
 
 - name: Connect Deserialization Error
   warning_value: 1
@@ -290,7 +262,6 @@ axonops_log_alert_rule:
   content: \"DeserializationException\"
   source: "/var/log/kafka/connect.log"
   description: Schema or serialisation mismatch. Check schema registry configuration and producer schema compatibility settings.
-  present: true
 
 - name: Connect Worker REST API Unreachable
   warning_value: 1
@@ -299,7 +270,6 @@ axonops_log_alert_rule:
   content: \"Connection refused.*8083\"
   source: "/var/log/kafka/connect.log"
   description: The Connect worker REST API is unreachable — indicates a worker crash or network issue.
-  present: true
 
 - name: Connect Broker Connection Loss
   warning_value: 1
@@ -308,4 +278,3 @@ axonops_log_alert_rule:
   content: \"Disconnected from node\"
   source: "/var/log/kafka/connect.log"
   description: Connect worker lost connectivity to a Kafka broker. Check broker health and network path between Connect and Kafka.
-  present: true

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -6,63 +6,6 @@
 
 axonops_alert_rules:
 
-######## JVM ALERTS (all components) ########
-
-- name: JVM Heap Utilization High
-  dashboard: System
-  chart: JVM Heap Utilization
-  operator: '>='
-  warning_value: 80
-  critical_value: 90
-  duration: 5m
-  description: JVM heap usage is high. Increase -Xmx or investigate memory leaks in custom interceptors or serialisers.
-
-- name: JVM GC Time High
-  dashboard: System
-  chart: Time Spent On GC Per Minute - G1_Young
-  operator: '>='
-  warning_value: 30
-  critical_value: 60
-  duration: 5m
-  description: JVM is spending excessive time in garbage collection. Indicates heap pressure. Tune -XX:MaxGCPauseMillis=20 and review heap sizing (4-8 GB recommended for brokers).
-
-- name: JVM GC Rate High
-  dashboard: System
-  chart: GC Count rate per sec - G1_Young
-  operator: '>='
-  warning_value: 5
-  critical_value: 20
-  duration: 5m
-  description: High GC frequency indicates heap pressure. Review object allocation rates and increase -Xmx if sustained.
-
-- name: JVM Thread Count High
-  dashboard: System
-  chart: JVM Thread Count
-  operator: '>='
-  warning_value: 800
-  critical_value: 1200
-  duration: 10m
-  description: Unusually high thread count may indicate thread leaks in custom interceptors or connectors.
-
-- name: JVM File Descriptors High
-  dashboard: System
-  chart: "% File Descriptors Allocated"
-  operator: '>='
-  warning_value: 70
-  critical_value: 85
-  duration: 10m
-  description: Kafka opens one file descriptor per log segment. Exhausting the OS limit causes broker failure. Increase ulimit -n (recommended 100000+).
-
-- name: JVM CPU Utilization High
-  dashboard: System
-  chart: JVM Utilization
-  operator: '>='
-  warning_value: 80
-  critical_value: 95
-  duration: 5m
-  description: Sustained JVM CPU saturation indicates broker overload. Check request handler idle percent and partition distribution.
-
-
 ######## KAFKA CLUSTER HEALTH — MUST ALERT ########
 # These three alerts are the minimum every Kafka cluster must have.
 

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -11,7 +11,7 @@ axonops_alert_rules:
 
 - name: No Active Controller
   dashboard: Kafka Overview
-  chart: Active Controllers
+  chart: Active Controller
   operator: '<'
   warning_value: 1
   critical_value: 1
@@ -20,7 +20,7 @@ axonops_alert_rules:
 
 - name: Multiple Active Controllers
   dashboard: Kafka Overview
-  chart: Active Controllers
+  chart: Active Controller
   operator: '>='
   warning_value: 2
   critical_value: 2
@@ -28,7 +28,7 @@ axonops_alert_rules:
   description: More than one active controller — split-brain condition. Page immediately.
 
 - name: Offline Partitions
-  dashboard: Kafka Overview
+  dashboard: Kafka Replication
   chart: Offline Partitions
   operator: '>='
   warning_value: 1
@@ -66,15 +66,6 @@ axonops_alert_rules:
   duration: 1m
   description: Partitions below min.insync.replicas. Producers using acks=all will receive NotEnoughReplicas and writes will fail.
 
-- name: Under Min ISR Partitions (Overview)
-  dashboard: Kafka Overview
-  chart: Under min insync replicas partitions
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: Cluster-level view of partitions below min.insync.replicas. Producers using acks=all will receive NotEnoughReplicas.
-
 - name: ISR Shrinks High
   dashboard: Kafka Replication
   chart: IsrShrinks per Sec by Host
@@ -86,15 +77,6 @@ axonops_alert_rules:
 
 
 ######## KRAFT CONTROLLER ########
-
-- name: Fenced Broker Count
-  dashboard: Kafka Controller
-  chart: Fenced Broker Count
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: One or more brokers are fenced (registered but not active). Fenced brokers do not serve traffic. Investigate why the broker failed to unfence.
 
 - name: Controller Metadata Error Rate
   dashboard: Kafka Controller
@@ -177,18 +159,9 @@ axonops_alert_rules:
 
 ######## KAFKA CONNECT ########
 
-- name: Connect Connector Failed
-  dashboard: Connect Workers
-  chart: Connector Failed
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: One or more connectors are in FAILED state. Connect does NOT automatically restart failed connectors. Restart via REST API POST /connectors/{name}/restart.
-
 - name: Connect Tasks Failed
-  dashboard: Connect Overview
-  chart: Connector Tasks Failed
+  dashboard: Connect Workers
+  chart: Connector Failed Tasks
   operator: '>='
   warning_value: 1
   critical_value: 1
@@ -242,7 +215,7 @@ axonops_alert_rules:
 
 - name: Connect Workers Rebalancing
   dashboard: Connect Overview
-  chart: Connectors Rebalancing
+  chart: Rebalances
   operator: '>='
   warning_value: 1
   critical_value: 1

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -1,7 +1,6 @@
 ######## Kafka Monitoring Metric Alert Rules ########
 # Comprehensive alert rule set for Apache Kafka clusters monitored by AxonOps.
-# Covers: JVM, Broker cluster health, replication, KRaft controller, network,
-# storage, Kafka Connect, and consumer lag.
+# All dashboard and chart names verified against AxonOps Kafka dashboard panels.
 # These rules are applied to ALL clusters in the organisation.
 # Override or extend per-cluster in config/<org>/<cluster>/metric_alert_rules.yml
 
@@ -9,63 +8,63 @@ axonops_alert_rules:
 
 ######## JVM ALERTS (all components) ########
 
-- name: JVM Heap Usage High
+- name: JVM Heap Utilization High
   dashboard: System
-  chart: JVM Heap Memory Usage
+  chart: JVM Heap Utilization
   operator: '>='
   warning_value: 80
   critical_value: 90
   duration: 5m
-  description: JVM heap usage is high. Increase -Xmx or investigate memory leaks.
+  description: JVM heap usage is high. Increase -Xmx or investigate memory leaks in custom interceptors or serialisers.
 
-- name: JVM Full GC Occurred
+- name: JVM GC Time High
   dashboard: System
-  chart: JVM GC Old Generation Collection Count
+  chart: Time Spent On GC Per Minute - G1_Young
   operator: '>='
-  warning_value: 1
-  critical_value: 5
+  warning_value: 30
+  critical_value: 60
   duration: 5m
-  description: Full (stop-the-world) GC event occurred. Investigate heap sizing. Expected to be rare with G1GC.
+  description: JVM is spending excessive time in garbage collection. Indicates heap pressure. Tune -XX:MaxGCPauseMillis=20 and review heap sizing (4-8 GB recommended for brokers).
 
-- name: JVM GC Pause Duration High
+- name: JVM GC Rate High
   dashboard: System
-  chart: JVM GC Pause Duration
+  chart: GC Count rate per sec - G1_Young
   operator: '>='
-  warning_value: 1000
-  critical_value: 5000
+  warning_value: 5
+  critical_value: 20
   duration: 5m
-  description: GC pause exceeding 1s can trigger consumer rebalances and ISR shrinkage. Tune -XX:MaxGCPauseMillis=20.
+  description: High GC frequency indicates heap pressure. Review object allocation rates and increase -Xmx if sustained.
 
-- name: JVM Thread Deadlock Detected
+- name: JVM Thread Count High
   dashboard: System
-  chart: JVM Thread Deadlock Count
+  chart: JVM Thread Count
   operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: JVM threads are deadlocked. Capture a thread dump (jstack) and restart the affected process.
+  warning_value: 800
+  critical_value: 1200
+  duration: 10m
+  description: Unusually high thread count may indicate thread leaks in custom interceptors or connectors.
 
-- name: JVM File Descriptor Usage High
+- name: JVM File Descriptors High
   dashboard: System
-  chart: JVM Open File Descriptors
+  chart: "% File Descriptors Allocated"
   operator: '>='
   warning_value: 70
   critical_value: 85
   duration: 10m
   description: Kafka opens one file descriptor per log segment. Exhausting the OS limit causes broker failure. Increase ulimit -n (recommended 100000+).
 
-- name: JVM Process CPU High
+- name: JVM CPU Utilization High
   dashboard: System
-  chart: JVM Process CPU Load
+  chart: JVM Utilization
   operator: '>='
   warning_value: 80
   critical_value: 95
   duration: 5m
-  description: Sustained CPU saturation on the JVM process. Check request handler idle percent and partition distribution.
+  description: Sustained JVM CPU saturation indicates broker overload. Check request handler idle percent and partition distribution.
 
 
 ######## KAFKA CLUSTER HEALTH — MUST ALERT ########
-# These three alerts are the minimum set every Kafka cluster must have.
+# These three alerts are the minimum every Kafka cluster must have.
 
 - name: No Active Controller
   dashboard: Kafka Overview
@@ -95,7 +94,7 @@ axonops_alert_rules:
   description: Partitions with no active leader are unreadable and unwritable. Restore the failed broker.
 
 - name: Unclean Leader Elections
-  dashboard: Kafka Replication
+  dashboard: Kafka Overview
   chart: Unclean Leader Elections Per Sec
   operator: '>='
   warning_value: 1
@@ -124,41 +123,23 @@ axonops_alert_rules:
   duration: 1m
   description: Partitions below min.insync.replicas. Producers using acks=all will receive NotEnoughReplicas and writes will fail.
 
-- name: At Min ISR Partitions
-  dashboard: Kafka Replication
-  chart: At Min ISR Partitions
+- name: Under Min ISR Partitions (Overview)
+  dashboard: Kafka Overview
+  chart: Under min insync replicas partitions
   operator: '>='
   warning_value: 1
-  critical_value: 5
-  duration: 5m
-  description: Partitions at exactly min.insync.replicas. One more broker failure would block writes. Use as early warning.
+  critical_value: 1
+  duration: 1m
+  description: Cluster-level view of partitions below min.insync.replicas. Producers using acks=all will receive NotEnoughReplicas.
 
-- name: ISR Shrink Rate High
+- name: ISR Shrinks High
   dashboard: Kafka Replication
-  chart: ISR Shrink Rate
+  chart: IsrShrinks per Sec by Host
   operator: '>='
   warning_value: 1
   critical_value: 5
   duration: 5m
   description: Replicas are falling out of sync. Expected value is 0 in steady state. Sustained shrinks indicate disk I/O or network degradation.
-
-- name: Failed ISR Updates
-  dashboard: Kafka Replication
-  chart: Failed ISR Updates Per Sec
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: ISR update to the controller failed. Expected value is 0. Indicates controller communication issues.
-
-- name: Offline Replica Count
-  dashboard: Kafka Replication
-  chart: Offline Replica Count
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: One or more replicas are offline. Investigate the broker(s) hosting those replicas.
 
 
 ######## KRAFT CONTROLLER ########
@@ -170,18 +151,9 @@ axonops_alert_rules:
   warning_value: 1
   critical_value: 1
   duration: 5m
-  description: One or more brokers are fenced (registered but not active). Fenced brokers do not serve traffic.
+  description: One or more brokers are fenced (registered but not active). Fenced brokers do not serve traffic. Investigate why the broker failed to unfence.
 
-- name: Timed Out Broker Heartbeats
-  dashboard: Kafka Controller
-  chart: Timed Out Broker Heartbeat Count
-  operator: '>='
-  warning_value: 1
-  critical_value: 5
-  duration: 5m
-  description: Broker heartbeats are timing out on the active controller. Indicates network issues between broker and controller nodes.
-
-- name: Controller Metadata Errors
+- name: Controller Metadata Error Rate
   dashboard: Kafka Controller
   chart: Metadata Error Rate
   operator: '>='
@@ -190,59 +162,23 @@ axonops_alert_rules:
   duration: 1m
   description: Errors during metadata log processing on the controller. Investigate immediately.
 
-- name: Broker Metadata Load Errors
+- name: Raft Commit Latency High
   dashboard: Kafka Controller
-  chart: Broker Metadata Load Error Count
+  chart: Commit Latency Avg
   operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: The BrokerMetadataListener encountered errors loading the metadata log. Risk of broker state inconsistency.
-
-- name: Broker Metadata Apply Errors
-  dashboard: Kafka Controller
-  chart: Broker Metadata Apply Error Count
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: The BrokerMetadataPublisher failed to apply a new MetadataImage. Indicates a serious broker state issue.
-
-- name: Broker Metadata Lag High
-  dashboard: Kafka Controller
-  chart: Broker Last Applied Record Lag Ms
-  operator: '>='
-  warning_value: 10000
-  critical_value: 30000
+  warning_value: 500
+  critical_value: 2000
   duration: 5m
-  description: Brokers are falling behind applying metadata records from the controller. May indicate slow disk or network between broker and controllers.
-
-- name: Metadata Snapshot Age High
-  dashboard: Kafka Controller
-  chart: Latest Snapshot Generated Age Ms
-  operator: '>='
-  warning_value: 1800000
-  critical_value: 3600000
-  duration: 15m
-  description: No new metadata snapshot generated in over an hour. Long periods without snapshots increase startup recovery time.
+  description: Average commit latency for the raft log is high, indicating quorum throughput degradation.
 
 - name: Preferred Replica Imbalance
-  dashboard: Kafka Controller
-  chart: Preferred Replica Imbalance Count
+  dashboard: Kafka Overview
+  chart: Preferred Replica Imbalance
   operator: '>='
   warning_value: 1
   critical_value: 10
   duration: 15m
-  description: Partition leaders are not distributed optimally. Run preferred replica election or enable auto.leader.rebalance.enable.
-
-- name: Leader Election Rate High
-  dashboard: Kafka Controller
-  chart: Leader Election Rate
-  operator: '>='
-  warning_value: 1
-  critical_value: 5
-  duration: 5m
-  description: Leader elections occurring indicates broker failures or instability. Expected to be 0 in steady state.
+  description: Partition leaders are not distributed optimally across brokers. Run preferred replica election or enable auto.leader.rebalance.enable.
 
 
 ######## NETWORK & REQUEST PROCESSING ########
@@ -254,7 +190,7 @@ axonops_alert_rules:
   warning_value: 30
   critical_value: 10
   duration: 5m
-  description: Network I/O threads are saturated. Increase num.network.threads or scale the broker.
+  description: Network I/O threads are saturated. Normal range is above 30%. Increase num.network.threads or scale the broker.
 
 - name: Request Handler Avg Idle Percent Low
   dashboard: Kafka Performance
@@ -263,7 +199,7 @@ axonops_alert_rules:
   warning_value: 30
   critical_value: 10
   duration: 5m
-  description: Request handler threads are saturated. Increase num.io.threads or reduce per-broker partition count.
+  description: Request handler threads are saturated. Normal range is above 30%. Increase num.io.threads or reduce per-broker partition count.
 
 - name: Request Queue Size High
   dashboard: Kafka Performance
@@ -272,190 +208,124 @@ axonops_alert_rules:
   warning_value: 200
   critical_value: 500
   duration: 5m
-  description: Requests backing up in the network queue, indicating handler saturation.
+  description: Requests are backing up in the network queue, indicating handler saturation. Correlate with request handler idle percent.
 
-- name: Produce Request P99 Latency High
+- name: Request Total Time High
   dashboard: Kafka Performance
-  chart: Produce Request Total Time Ms 99th Percentile
+  chart: Total time (produce/fetch) $percentile
   operator: '>='
   warning_value: 500
   critical_value: 1000
   duration: 5m
-  description: P99 produce latency above 500ms indicates broker pressure. Above 1s is critical.
-
-- name: Fetch Consumer Request P99 Latency High
-  dashboard: Kafka Performance
-  chart: Fetch Consumer Request Total Time Ms 99th Percentile
-  operator: '>='
-  warning_value: 1000
-  critical_value: 3000
-  duration: 5m
-  description: Fetch latency above 1s suggests disk I/O pressure or broker overload.
-
-- name: Failed Produce Requests
-  dashboard: Kafka Performance
-  chart: Failed Produce Requests Per Sec
-  operator: '>='
-  warning_value: 1
-  critical_value: 10
-  duration: 5m
-  description: Produce requests are failing. Investigate min.insync.replicas violations, ACL errors, or quota throttling.
-
-- name: Failed Fetch Requests
-  dashboard: Kafka Performance
-  chart: Failed Fetch Requests Per Sec
-  operator: '>='
-  warning_value: 1
-  critical_value: 10
-  duration: 5m
-  description: Fetch requests failing at the broker level. Check for NotLeaderForPartition errors or authorization issues.
-
-
-######## THROUGHPUT & MESSAGE VALIDATION ########
-
-- name: Invalid Magic Number Records
-  dashboard: Kafka Performance
-  chart: Invalid Magic Number Records Per Sec
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: Malformed record batches arriving at broker. Expected value is 0. Indicates corrupted data or mismatched client protocol version.
-
-- name: Invalid CRC Records
-  dashboard: Kafka Performance
-  chart: Invalid Message CRC Records Per Sec
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: CRC checksum validation failures. Expected value is 0. Indicates data corruption in transit or on the producer side.
-
-- name: No-Key Compacted Topic Records
-  dashboard: Kafka Performance
-  chart: No Key Compacted Topic Records Per Sec
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: Records without a key written to a compacted topic. Such records cannot be properly compacted.
+  description: P99 request latency above 500ms indicates broker pressure. Above 1s is critical.
 
 
 ######## STORAGE ########
 
-- name: Offline Log Directory Count
-  dashboard: Kafka Overview
-  chart: Offline Log Directory Count
+- name: Log Directories Offline
+  dashboard: Kafka Topics
+  chart: Log Directories Offline
   operator: '>='
   warning_value: 1
   critical_value: 1
   duration: 1m
   description: A log directory has gone offline (disk failure or filesystem unmount). Broker may still serve other partitions but data is unavailable on the failed directory.
 
-- name: Log Flush P99 Latency High
-  dashboard: Kafka Performance
-  chart: Log Flush Rate And Time Ms 99th Percentile
-  operator: '>='
-  warning_value: 100
-  critical_value: 500
-  duration: 5m
-  description: Disk flush latency above 100ms P99 indicates disk I/O pressure.
-
-- name: Disk Free Space Low
+- name: Disk Usage High
   dashboard: System
   chart: Disk % Usage $mountpoint
   operator: '>='
   warning_value: 75
   critical_value: 90
   duration: 15m
-  description: Kafka logs will consume all available disk space if retention is not well-configured. Review retention or expand capacity.
+  description: Kafka logs will consume all available disk space if retention is not well-configured. Review retention settings or expand capacity.
 
 
 ######## KAFKA CONNECT ########
 
-- name: Connect Task Startup Failure Rate High
-  dashboard: Kafka Connect
-  chart: Task Startup Failure Percentage
+- name: Connect Connector Failed
+  dashboard: Connect Workers
+  chart: Connector Failed
   operator: '>='
   warning_value: 1
   critical_value: 1
   duration: 5m
-  description: Connect tasks are failing to start. Investigate connector configuration and resource availability.
+  description: One or more connectors are in FAILED state. Connect does NOT automatically restart failed connectors. Restart via REST API POST /connectors/{name}/restart.
 
-- name: Connect Connector Startup Failure Rate High
-  dashboard: Kafka Connect
-  chart: Connector Startup Failure Percentage
+- name: Connect Tasks Failed
+  dashboard: Connect Overview
+  chart: Connector Tasks Failed
   operator: '>='
   warning_value: 1
   critical_value: 1
   duration: 5m
-  description: Connectors are failing during startup. Check connector config, plugin classpath, and credentials.
+  description: One or more connector tasks have failed. Connect does NOT automatically restart failed tasks. Restart via REST API POST /connectors/{name}/tasks/{id}/restart.
 
 - name: Connect Task Running Ratio Low
-  dashboard: Kafka Connect
-  chart: Task Running Ratio
+  dashboard: Connect Tasks
+  chart: Connector Task Running Ratio
   operator: '<'
   warning_value: 75
   critical_value: 50
   duration: 5m
-  description: A task is spending more than half its time not running (paused or backpressured).
+  description: A task is spending more than half its time not running (paused or backpressured). Investigate downstream system performance.
 
-- name: Connect Offset Commit Failure Rate High
-  dashboard: Kafka Connect
-  chart: Offset Commit Failure Percentage
-  operator: '>='
-  warning_value: 5
-  critical_value: 20
+- name: Connect Task Commit Success Rate Low
+  dashboard: Connect Tasks
+  chart: Connector Task Commit Success %
+  operator: '<'
+  warning_value: 95
+  critical_value: 80
   duration: 5m
-  description: More than 5% of offset commit attempts are failing. Indicates consumer group instability or timeout issues.
+  description: Offset commit success rate is low. Indicates consumer group instability or timeout issues. Increase session.timeout.ms or reduce max.poll.records.
 
 - name: Connect DLQ Produce Failures
-  dashboard: Kafka Connect
-  chart: Dead Letter Queue Produce Failures
+  dashboard: Connect Tasks
+  chart: Deadletter Produce Failures
   operator: '>='
   warning_value: 1
   critical_value: 1
   duration: 5m
-  description: Failed writes to the dead letter queue mean error records are being silently lost. Check DLQ topic configuration.
+  description: Failed writes to the dead letter queue mean error records are being silently lost. Check DLQ topic configuration and broker connectivity.
 
 - name: Connect Record Errors High
-  dashboard: Kafka Connect
-  chart: Total Record Errors
+  dashboard: Connect Tasks
+  chart: Record Errors
   operator: '>='
   warning_value: 1
   critical_value: 100
   duration: 5m
   description: Record processing errors are accumulating. Investigate upstream data quality or schema compatibility.
 
-- name: Connect Failed Authentication Rate
-  dashboard: Kafka Connect
-  chart: Failed Authentication Rate
+- name: Connect Failed Authentication
+  dashboard: Connect Overview
+  chart: Failed Authentication
   operator: '>='
   warning_value: 1
   critical_value: 10
   duration: 5m
   description: Connect worker cannot authenticate to Kafka. Check SASL/SSL configuration and credentials.
 
-- name: Connect Worker Rebalancing
-  dashboard: Kafka Connect
-  chart: Worker Rebalancing State
+- name: Connect Workers Rebalancing
+  dashboard: Connect Overview
+  chart: Connectors Rebalancing
   operator: '>='
   warning_value: 1
   critical_value: 1
   duration: 5m
-  description: Connect worker group is stuck in rebalancing. May indicate a failed worker or incompatible connector config.
+  description: Connect worker group is in rebalancing state. Sustained rebalancing (>5 min) may indicate a failed worker or incompatible connector config.
 
 
-######## CONSUMER LAG ########
+######## CONSUMER GROUPS ########
 
-- name: Consumer Lag High
-  dashboard: Kafka Overview
-  chart: Consumer Lag Max
+- name: Consumer Group Lag High
+  dashboard: Consumer Groups
+  chart: Consumer Group Lag
   operator: '>='
   warning_value: 10000
   critical_value: 100000
   duration: 5m
-  description: Consumer group is significantly behind. Investigate consumer throughput, partition distribution, or broker pressure.
+  description: Consumer group is significantly behind the latest offset. Investigate consumer throughput, partition distribution, or broker pressure.
 
 
 ######## SYSTEM ########
@@ -512,4 +382,4 @@ axonops_alert_rules:
   warning_value: 10
   critical_value: 50
   duration: 15m
-  description: Failed authentication requests against Kafka
+  description: Failed authentication requests against Kafka. Check SASL/SSL configuration and client credentials.

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -1,0 +1,515 @@
+######## Kafka Monitoring Metric Alert Rules ########
+# Comprehensive alert rule set for Apache Kafka clusters monitored by AxonOps.
+# Covers: JVM, Broker cluster health, replication, KRaft controller, network,
+# storage, Kafka Connect, and consumer lag.
+# These rules are applied to ALL clusters in the organisation.
+# Override or extend per-cluster in config/<org>/<cluster>/metric_alert_rules.yml
+
+axonops_alert_rules:
+
+######## JVM ALERTS (all components) ########
+
+- name: JVM Heap Usage High
+  dashboard: System
+  chart: JVM Heap Memory Usage
+  operator: '>='
+  warning_value: 80
+  critical_value: 90
+  duration: 5m
+  description: JVM heap usage is high. Increase -Xmx or investigate memory leaks.
+
+- name: JVM Full GC Occurred
+  dashboard: System
+  chart: JVM GC Old Generation Collection Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  description: Full (stop-the-world) GC event occurred. Investigate heap sizing. Expected to be rare with G1GC.
+
+- name: JVM GC Pause Duration High
+  dashboard: System
+  chart: JVM GC Pause Duration
+  operator: '>='
+  warning_value: 1000
+  critical_value: 5000
+  duration: 5m
+  description: GC pause exceeding 1s can trigger consumer rebalances and ISR shrinkage. Tune -XX:MaxGCPauseMillis=20.
+
+- name: JVM Thread Deadlock Detected
+  dashboard: System
+  chart: JVM Thread Deadlock Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: JVM threads are deadlocked. Capture a thread dump (jstack) and restart the affected process.
+
+- name: JVM File Descriptor Usage High
+  dashboard: System
+  chart: JVM Open File Descriptors
+  operator: '>='
+  warning_value: 70
+  critical_value: 85
+  duration: 10m
+  description: Kafka opens one file descriptor per log segment. Exhausting the OS limit causes broker failure. Increase ulimit -n (recommended 100000+).
+
+- name: JVM Process CPU High
+  dashboard: System
+  chart: JVM Process CPU Load
+  operator: '>='
+  warning_value: 80
+  critical_value: 95
+  duration: 5m
+  description: Sustained CPU saturation on the JVM process. Check request handler idle percent and partition distribution.
+
+
+######## KAFKA CLUSTER HEALTH — MUST ALERT ########
+# These three alerts are the minimum set every Kafka cluster must have.
+
+- name: No Active Controller
+  dashboard: Kafka Overview
+  chart: Active Controllers
+  operator: '<'
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: No active controller exists. The cluster cannot elect partition leaders. Page immediately.
+
+- name: Multiple Active Controllers
+  dashboard: Kafka Overview
+  chart: Active Controllers
+  operator: '>='
+  warning_value: 2
+  critical_value: 2
+  duration: 1m
+  description: More than one active controller — split-brain condition. Page immediately.
+
+- name: Offline Partitions
+  dashboard: Kafka Overview
+  chart: Offline Partitions
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Partitions with no active leader are unreadable and unwritable. Restore the failed broker.
+
+- name: Unclean Leader Elections
+  dashboard: Kafka Replication
+  chart: Unclean Leader Elections Per Sec
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: A partition leader was elected from a replica outside the ISR — potential data loss. Expected value is always 0.
+
+
+######## KAFKA REPLICATION ########
+
+- name: Under Replicated Partitions
+  dashboard: Kafka Replication
+  chart: Under Replicated Partitions
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Partitions have fewer ISR members than the replication factor. Data durability at risk. Investigate slow followers and network I/O.
+
+- name: Under Min ISR Partitions
+  dashboard: Kafka Replication
+  chart: Under Min ISR Partitions
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: Partitions below min.insync.replicas. Producers using acks=all will receive NotEnoughReplicas and writes will fail.
+
+- name: At Min ISR Partitions
+  dashboard: Kafka Replication
+  chart: At Min ISR Partitions
+  operator: '>='
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  description: Partitions at exactly min.insync.replicas. One more broker failure would block writes. Use as early warning.
+
+- name: ISR Shrink Rate High
+  dashboard: Kafka Replication
+  chart: ISR Shrink Rate
+  operator: '>='
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  description: Replicas are falling out of sync. Expected value is 0 in steady state. Sustained shrinks indicate disk I/O or network degradation.
+
+- name: Failed ISR Updates
+  dashboard: Kafka Replication
+  chart: Failed ISR Updates Per Sec
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: ISR update to the controller failed. Expected value is 0. Indicates controller communication issues.
+
+- name: Offline Replica Count
+  dashboard: Kafka Replication
+  chart: Offline Replica Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: One or more replicas are offline. Investigate the broker(s) hosting those replicas.
+
+
+######## KRAFT CONTROLLER ########
+
+- name: Fenced Broker Count
+  dashboard: Kafka Controller
+  chart: Fenced Broker Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: One or more brokers are fenced (registered but not active). Fenced brokers do not serve traffic.
+
+- name: Timed Out Broker Heartbeats
+  dashboard: Kafka Controller
+  chart: Timed Out Broker Heartbeat Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  description: Broker heartbeats are timing out on the active controller. Indicates network issues between broker and controller nodes.
+
+- name: Controller Metadata Errors
+  dashboard: Kafka Controller
+  chart: Metadata Error Rate
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: Errors during metadata log processing on the controller. Investigate immediately.
+
+- name: Broker Metadata Load Errors
+  dashboard: Kafka Controller
+  chart: Broker Metadata Load Error Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: The BrokerMetadataListener encountered errors loading the metadata log. Risk of broker state inconsistency.
+
+- name: Broker Metadata Apply Errors
+  dashboard: Kafka Controller
+  chart: Broker Metadata Apply Error Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: The BrokerMetadataPublisher failed to apply a new MetadataImage. Indicates a serious broker state issue.
+
+- name: Broker Metadata Lag High
+  dashboard: Kafka Controller
+  chart: Broker Last Applied Record Lag Ms
+  operator: '>='
+  warning_value: 10000
+  critical_value: 30000
+  duration: 5m
+  description: Brokers are falling behind applying metadata records from the controller. May indicate slow disk or network between broker and controllers.
+
+- name: Metadata Snapshot Age High
+  dashboard: Kafka Controller
+  chart: Latest Snapshot Generated Age Ms
+  operator: '>='
+  warning_value: 1800000
+  critical_value: 3600000
+  duration: 15m
+  description: No new metadata snapshot generated in over an hour. Long periods without snapshots increase startup recovery time.
+
+- name: Preferred Replica Imbalance
+  dashboard: Kafka Controller
+  chart: Preferred Replica Imbalance Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 10
+  duration: 15m
+  description: Partition leaders are not distributed optimally. Run preferred replica election or enable auto.leader.rebalance.enable.
+
+- name: Leader Election Rate High
+  dashboard: Kafka Controller
+  chart: Leader Election Rate
+  operator: '>='
+  warning_value: 1
+  critical_value: 5
+  duration: 5m
+  description: Leader elections occurring indicates broker failures or instability. Expected to be 0 in steady state.
+
+
+######## NETWORK & REQUEST PROCESSING ########
+
+- name: Network Processor Avg Idle Percent Low
+  dashboard: Kafka Performance
+  chart: Network Processor Avg Idle Percent
+  operator: '<'
+  warning_value: 30
+  critical_value: 10
+  duration: 5m
+  description: Network I/O threads are saturated. Increase num.network.threads or scale the broker.
+
+- name: Request Handler Avg Idle Percent Low
+  dashboard: Kafka Performance
+  chart: Request Handler Avg Idle Percent
+  operator: '<'
+  warning_value: 30
+  critical_value: 10
+  duration: 5m
+  description: Request handler threads are saturated. Increase num.io.threads or reduce per-broker partition count.
+
+- name: Request Queue Size High
+  dashboard: Kafka Performance
+  chart: Request Queue Size
+  operator: '>='
+  warning_value: 200
+  critical_value: 500
+  duration: 5m
+  description: Requests backing up in the network queue, indicating handler saturation.
+
+- name: Produce Request P99 Latency High
+  dashboard: Kafka Performance
+  chart: Produce Request Total Time Ms 99th Percentile
+  operator: '>='
+  warning_value: 500
+  critical_value: 1000
+  duration: 5m
+  description: P99 produce latency above 500ms indicates broker pressure. Above 1s is critical.
+
+- name: Fetch Consumer Request P99 Latency High
+  dashboard: Kafka Performance
+  chart: Fetch Consumer Request Total Time Ms 99th Percentile
+  operator: '>='
+  warning_value: 1000
+  critical_value: 3000
+  duration: 5m
+  description: Fetch latency above 1s suggests disk I/O pressure or broker overload.
+
+- name: Failed Produce Requests
+  dashboard: Kafka Performance
+  chart: Failed Produce Requests Per Sec
+  operator: '>='
+  warning_value: 1
+  critical_value: 10
+  duration: 5m
+  description: Produce requests are failing. Investigate min.insync.replicas violations, ACL errors, or quota throttling.
+
+- name: Failed Fetch Requests
+  dashboard: Kafka Performance
+  chart: Failed Fetch Requests Per Sec
+  operator: '>='
+  warning_value: 1
+  critical_value: 10
+  duration: 5m
+  description: Fetch requests failing at the broker level. Check for NotLeaderForPartition errors or authorization issues.
+
+
+######## THROUGHPUT & MESSAGE VALIDATION ########
+
+- name: Invalid Magic Number Records
+  dashboard: Kafka Performance
+  chart: Invalid Magic Number Records Per Sec
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Malformed record batches arriving at broker. Expected value is 0. Indicates corrupted data or mismatched client protocol version.
+
+- name: Invalid CRC Records
+  dashboard: Kafka Performance
+  chart: Invalid Message CRC Records Per Sec
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: CRC checksum validation failures. Expected value is 0. Indicates data corruption in transit or on the producer side.
+
+- name: No-Key Compacted Topic Records
+  dashboard: Kafka Performance
+  chart: No Key Compacted Topic Records Per Sec
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Records without a key written to a compacted topic. Such records cannot be properly compacted.
+
+
+######## STORAGE ########
+
+- name: Offline Log Directory Count
+  dashboard: Kafka Overview
+  chart: Offline Log Directory Count
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: A log directory has gone offline (disk failure or filesystem unmount). Broker may still serve other partitions but data is unavailable on the failed directory.
+
+- name: Log Flush P99 Latency High
+  dashboard: Kafka Performance
+  chart: Log Flush Rate And Time Ms 99th Percentile
+  operator: '>='
+  warning_value: 100
+  critical_value: 500
+  duration: 5m
+  description: Disk flush latency above 100ms P99 indicates disk I/O pressure.
+
+- name: Disk Free Space Low
+  dashboard: System
+  chart: Disk % Usage $mountpoint
+  operator: '>='
+  warning_value: 75
+  critical_value: 90
+  duration: 15m
+  description: Kafka logs will consume all available disk space if retention is not well-configured. Review retention or expand capacity.
+
+
+######## KAFKA CONNECT ########
+
+- name: Connect Task Startup Failure Rate High
+  dashboard: Kafka Connect
+  chart: Task Startup Failure Percentage
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Connect tasks are failing to start. Investigate connector configuration and resource availability.
+
+- name: Connect Connector Startup Failure Rate High
+  dashboard: Kafka Connect
+  chart: Connector Startup Failure Percentage
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Connectors are failing during startup. Check connector config, plugin classpath, and credentials.
+
+- name: Connect Task Running Ratio Low
+  dashboard: Kafka Connect
+  chart: Task Running Ratio
+  operator: '<'
+  warning_value: 75
+  critical_value: 50
+  duration: 5m
+  description: A task is spending more than half its time not running (paused or backpressured).
+
+- name: Connect Offset Commit Failure Rate High
+  dashboard: Kafka Connect
+  chart: Offset Commit Failure Percentage
+  operator: '>='
+  warning_value: 5
+  critical_value: 20
+  duration: 5m
+  description: More than 5% of offset commit attempts are failing. Indicates consumer group instability or timeout issues.
+
+- name: Connect DLQ Produce Failures
+  dashboard: Kafka Connect
+  chart: Dead Letter Queue Produce Failures
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Failed writes to the dead letter queue mean error records are being silently lost. Check DLQ topic configuration.
+
+- name: Connect Record Errors High
+  dashboard: Kafka Connect
+  chart: Total Record Errors
+  operator: '>='
+  warning_value: 1
+  critical_value: 100
+  duration: 5m
+  description: Record processing errors are accumulating. Investigate upstream data quality or schema compatibility.
+
+- name: Connect Failed Authentication Rate
+  dashboard: Kafka Connect
+  chart: Failed Authentication Rate
+  operator: '>='
+  warning_value: 1
+  critical_value: 10
+  duration: 5m
+  description: Connect worker cannot authenticate to Kafka. Check SASL/SSL configuration and credentials.
+
+- name: Connect Worker Rebalancing
+  dashboard: Kafka Connect
+  chart: Worker Rebalancing State
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Connect worker group is stuck in rebalancing. May indicate a failed worker or incompatible connector config.
+
+
+######## CONSUMER LAG ########
+
+- name: Consumer Lag High
+  dashboard: Kafka Overview
+  chart: Consumer Lag Max
+  operator: '>='
+  warning_value: 10000
+  critical_value: 100000
+  duration: 5m
+  description: Consumer group is significantly behind. Investigate consumer throughput, partition distribution, or broker pressure.
+
+
+######## SYSTEM ########
+
+- name: CPU usage per host
+  dashboard: System
+  chart: CPU usage per host
+  operator: '>='
+  warning_value: 90
+  critical_value: 99
+  duration: 1h
+  description: Detected High CPU usage
+
+- name: CPU is Underutilized
+  dashboard: System
+  chart: CPU usage per host
+  operator: <=
+  warning_value: 5
+  critical_value: 1
+  duration: 1w
+  description: CPU load has been very low for 1 week
+
+- name: Disk % Usage $mountpoint
+  dashboard: System
+  chart: Disk % Usage $mountpoint
+  operator: '>='
+  warning_value: 75
+  critical_value: 90
+  duration: 12h
+  description: Detected High disk utilization
+
+- name: Avg IO wait CPU per Host
+  dashboard: System
+  chart: Avg IO wait CPU per Host
+  operator: '>='
+  warning_value: 20
+  critical_value: 50
+  duration: 2h
+  description: Detected high Average IOWait
+
+- name: Used Memory Percentage
+  dashboard: System
+  chart: Used Memory Percentage
+  operator: '>='
+  warning_value: 80
+  critical_value: 90
+  duration: 1h
+  description: High memory utilization detected
+
+- name: Failed Auth Rate
+  dashboard: Kafka Controller
+  chart: Failed Auth Rate
+  operator: '>='
+  warning_value: 10
+  critical_value: 50
+  duration: 15m
+  description: Failed authentication requests against Kafka

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -13,8 +13,8 @@ axonops_alert_rules:
   dashboard: Kafka Overview
   chart: Active Controller
   operator: '>='
-  warning_value: 2
-  critical_value: 2
+  warning_value: 1
+  critical_value: 1
   duration: 1m
   description: More than one active controller — split-brain condition. Page immediately.
 
@@ -126,16 +126,6 @@ axonops_alert_rules:
   duration: 5m
   description: Requests are backing up in the network queue, indicating handler saturation. Correlate with request handler idle percent.
 
-- name: Request Total Time High
-  dashboard: Kafka Performance
-  chart: Total time (produce/fetch) $percentile
-  operator: '>='
-  warning_value: 500
-  critical_value: 1000
-  duration: 5m
-  description: P99 request latency above 500ms indicates broker pressure. Above 1s is critical.
-
-
 ######## KAFKA CONNECT ########
 
 - name: Connect Connector Failed
@@ -209,15 +199,6 @@ axonops_alert_rules:
   critical_value: 5
   duration: 15m
   description: Connect worker group is rebalancing repeatedly. A single rebalance is normal on worker join/leave; sustained or frequent rebalances (>15 min) indicate a failed worker or incompatible connector config.
-
-- name: Connect Failed Rebalances
-  dashboard: Connect Overview
-  chart: Failed Rebalances
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: Connect worker group rebalance failed to complete. More severe than a rebalance in progress — indicates split-brain or incompatible connector configuration during reconfiguration.
 
 - name: Connect Record Skipped High
   dashboard: Connect Tasks

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -9,15 +9,6 @@ axonops_alert_rules:
 ######## KAFKA CLUSTER HEALTH — MUST ALERT ########
 # These three alerts are the minimum every Kafka cluster must have.
 
-- name: No Active Controller
-  dashboard: Kafka Overview
-  chart: Active Controller
-  operator: '<'
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: No active controller exists. The cluster cannot elect partition leaders. Page immediately.
-
 - name: Multiple Active Controllers
   dashboard: Kafka Overview
   chart: Active Controller

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -165,15 +165,6 @@ axonops_alert_rules:
 
 ######## STORAGE ########
 
-- name: Log Directories Offline
-  dashboard: Kafka Topics
-  chart: Log Directories Offline
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: A log directory has gone offline (disk failure or filesystem unmount). Broker may still serve other partitions but data is unavailable on the failed directory.
-
 - name: Disk Usage High
   dashboard: System
   chart: Disk % Usage $mountpoint

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -147,15 +147,6 @@ axonops_alert_rules:
 
 ######## STORAGE ########
 
-- name: Log Directories Offline
-  dashboard: Kafka Topics
-  chart: Log Directories Offline
-  operator: '>='
-  warning_value: 1
-  critical_value: 1
-  duration: 1m
-  description: A Kafka log directory has gone offline (disk failure or filesystem unmount). Broker may still serve other partitions but data on the failed directory is unavailable. Check disk health immediately.
-
 - name: Disk Usage High
   dashboard: System
   chart: Disk % Usage $mountpoint

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -136,18 +136,6 @@ axonops_alert_rules:
   description: P99 request latency above 500ms indicates broker pressure. Above 1s is critical.
 
 
-######## STORAGE ########
-
-- name: Disk Usage High
-  dashboard: System
-  chart: Disk % Usage $mountpoint
-  operator: '>='
-  warning_value: 75
-  critical_value: 90
-  duration: 15m
-  description: Kafka logs will consume all available disk space if retention is not well-configured. Review retention settings or expand capacity.
-
-
 ######## KAFKA CONNECT ########
 
 - name: Connect Connector Failed
@@ -218,9 +206,9 @@ axonops_alert_rules:
   chart: Rebalances
   operator: '>='
   warning_value: 1
-  critical_value: 1
-  duration: 5m
-  description: Connect worker group is in rebalancing state. Sustained rebalancing (>5 min) may indicate a failed worker or incompatible connector config.
+  critical_value: 5
+  duration: 15m
+  description: Connect worker group is rebalancing repeatedly. A single rebalance is normal on worker join/leave; sustained or frequent rebalances (>15 min) indicate a failed worker or incompatible connector config.
 
 - name: Connect Failed Rebalances
   dashboard: Connect Overview

--- a/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
+++ b/examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME/metric_alert_rules.yml
@@ -147,6 +147,15 @@ axonops_alert_rules:
 
 ######## STORAGE ########
 
+- name: Log Directories Offline
+  dashboard: Kafka Topics
+  chart: Log Directories Offline
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 1m
+  description: A Kafka log directory has gone offline (disk failure or filesystem unmount). Broker may still serve other partitions but data on the failed directory is unavailable. Check disk health immediately.
+
 - name: Disk Usage High
   dashboard: System
   chart: Disk % Usage $mountpoint
@@ -158,6 +167,15 @@ axonops_alert_rules:
 
 
 ######## KAFKA CONNECT ########
+
+- name: Connect Connector Failed
+  dashboard: Connect Workers
+  chart: Connector Failed
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: One or more connectors are in FAILED state (connector-level, distinct from task failures). Connect does NOT automatically restart failed connectors. Restart via REST API POST /connectors/{name}/restart.
 
 - name: Connect Tasks Failed
   dashboard: Connect Workers
@@ -221,6 +239,24 @@ axonops_alert_rules:
   critical_value: 1
   duration: 5m
   description: Connect worker group is in rebalancing state. Sustained rebalancing (>5 min) may indicate a failed worker or incompatible connector config.
+
+- name: Connect Failed Rebalances
+  dashboard: Connect Overview
+  chart: Failed Rebalances
+  operator: '>='
+  warning_value: 1
+  critical_value: 1
+  duration: 5m
+  description: Connect worker group rebalance failed to complete. More severe than a rebalance in progress — indicates split-brain or incompatible connector configuration during reconfiguration.
+
+- name: Connect Record Skipped High
+  dashboard: Connect Tasks
+  chart: Record Skipped
+  operator: '>='
+  warning_value: 1
+  critical_value: 100
+  duration: 5m
+  description: Records are being silently skipped due to errors with errors.tolerance=all. Data loss in progress. Review upstream data quality and connector error handling configuration.
 
 
 ######## CONSUMER GROUPS ########

--- a/examples/configurations/kafka/kafka-alerts.yml
+++ b/examples/configurations/kafka/kafka-alerts.yml
@@ -46,30 +46,6 @@
           - cluster is defined and cluster | length > 0
         fail_msg: "org and cluster must be set via -e or AXONOPS_ORG / AXONOPS_CLUSTER environment variables"
 
-    - name: Load org-level metric alert rules
-      ansible.builtin.set_fact:
-        axonops_alert_rules: "{{ (axonops_alert_rules | default([])) + (lookup('file', item) | from_yaml).axonops_alert_rules }}"
-      with_fileglob:
-        - "config/{{ org }}/metric_alert_rules.yml"
-
-    - name: Load cluster-level metric alert rule overrides
-      ansible.builtin.set_fact:
-        axonops_alert_rules: "{{ (axonops_alert_rules | default([])) + (lookup('file', item) | from_yaml).axonops_alert_rules }}"
-      with_fileglob:
-        - "config/{{ org }}/{{ cluster }}/metric_alert_rules.yml"
-
-    - name: Load org-level log alert rules
-      ansible.builtin.set_fact:
-        axonops_log_alert_rule: "{{ (axonops_log_alert_rule | default([])) + (lookup('file', item) | from_yaml).axonops_log_alert_rule }}"
-      with_fileglob:
-        - "config/{{ org }}/log_alert_rules.yml"
-
-    - name: Load cluster-level log alert rule overrides
-      ansible.builtin.set_fact:
-        axonops_log_alert_rule: "{{ (axonops_log_alert_rule | default([])) + (lookup('file', item) | from_yaml).axonops_log_alert_rule }}"
-      with_fileglob:
-        - "config/{{ org }}/{{ cluster }}/log_alert_rules.yml"
-
   roles:
     - role: axonops.axonops.configurations
 

--- a/examples/configurations/kafka/kafka-alerts.yml
+++ b/examples/configurations/kafka/kafka-alerts.yml
@@ -1,0 +1,76 @@
+---
+# Kafka Alert Pack — Example Playbook
+#
+# Deploys the full Kafka monitoring alert pack to an AxonOps organisation.
+# Loads all metric and log alert rules from the config/ directory structure.
+#
+# Prerequisites:
+#   - axonops.axonops collection installed
+#   - AXONOPS_TOKEN environment variable set (or AXONOPS_USERNAME + AXONOPS_PASSWORD)
+#   - config/<org>/metric_alert_rules.yml and log_alert_rules.yml present
+#   - config/<org>/<cluster>/metric_alert_rules.yml and log_alert_rules.yml present
+#
+# Usage:
+#   AXONOPS_TOKEN=<token> ansible-playbook kafka-alerts.yml \
+#     -e org=<your-org> -e cluster=<your-cluster>
+#
+# Or with environment variables:
+#   export AXONOPS_ORG=<your-org>
+#   export AXONOPS_CLUSTER=<your-kafka-cluster>
+#   export AXONOPS_TOKEN=<your-token>
+#   ansible-playbook kafka-alerts.yml
+
+- name: Configure Kafka monitoring alerts in AxonOps
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    cluster_type: kafka
+
+  pre_tasks:
+    - name: Get org from environment if not set
+      ansible.builtin.set_fact:
+        org: "{{ lookup('env', 'AXONOPS_ORG') }}"
+      when: org is not defined
+
+    - name: Get cluster from environment if not set
+      ansible.builtin.set_fact:
+        cluster: "{{ lookup('env', 'AXONOPS_CLUSTER') }}"
+      when: cluster is not defined
+
+    - name: Validate required variables
+      ansible.builtin.assert:
+        that:
+          - org is defined and org | length > 0
+          - cluster is defined and cluster | length > 0
+        fail_msg: "org and cluster must be set via -e or AXONOPS_ORG / AXONOPS_CLUSTER environment variables"
+
+    - name: Load org-level metric alert rules
+      ansible.builtin.set_fact:
+        axonops_alert_rules: "{{ (axonops_alert_rules | default([])) + (lookup('file', item) | from_yaml).axonops_alert_rules }}"
+      with_fileglob:
+        - "config/{{ org }}/metric_alert_rules.yml"
+
+    - name: Load cluster-level metric alert rule overrides
+      ansible.builtin.set_fact:
+        axonops_alert_rules: "{{ (axonops_alert_rules | default([])) + (lookup('file', item) | from_yaml).axonops_alert_rules }}"
+      with_fileglob:
+        - "config/{{ org }}/{{ cluster }}/metric_alert_rules.yml"
+
+    - name: Load org-level log alert rules
+      ansible.builtin.set_fact:
+        axonops_log_alert_rule: "{{ (axonops_log_alert_rule | default([])) + (lookup('file', item) | from_yaml).axonops_log_alert_rule }}"
+      with_fileglob:
+        - "config/{{ org }}/log_alert_rules.yml"
+
+    - name: Load cluster-level log alert rule overrides
+      ansible.builtin.set_fact:
+        axonops_log_alert_rule: "{{ (axonops_log_alert_rule | default([])) + (lookup('file', item) | from_yaml).axonops_log_alert_rule }}"
+      with_fileglob:
+        - "config/{{ org }}/{{ cluster }}/log_alert_rules.yml"
+
+  roles:
+    - role: axonops.axonops.configurations
+
+# code: language=ansible

--- a/roles/configurations/README.md
+++ b/roles/configurations/README.md
@@ -37,17 +37,27 @@ AXONOPS_PASSWORD: secret
 
 ## Kafka Alert Pack
 
-A comprehensive set of default Kafka alert rules is provided in `examples/configurations/kafka/`. It covers:
+A comprehensive set of default Kafka alert rules is provided in `examples/configurations/kafka/`. The pack is split into two files per scope level:
 
-- **JVM** — heap usage, GC pauses, thread deadlocks, file descriptor exhaustion
-- **Broker cluster health** — active controller count, offline partitions, unclean leader elections (the three must-alert metrics)
-- **Replication** — under-replicated partitions, ISR shrink rate, offline replicas, min-ISR violations
-- **KRaft controller** — fenced brokers, metadata errors, broker metadata lag, snapshot age
-- **Network & request processing** — idle percent thresholds, P99 produce/fetch latency, failed requests
-- **Storage** — offline log directories, log flush latency, disk usage
-- **Kafka Connect** — task/connector startup failures, offset commit failures, DLQ failures, authentication errors
-- **Consumer lag** — consumer group lag max
-- **Log-based alerts** — broker `server.log`, KRaft `controller.log`, GC log, Connect `connect.log`, authorizer log
+**Metric alert rules** (`metric_alert_rules.yml`) — 31 rules covering:
+
+- **Broker cluster health** — active controller count, offline partitions, unclean leader elections (the minimum three alerts every cluster must have)
+- **Replication** — under-replicated partitions, ISR shrink rate, under-min-ISR partitions
+- **KRaft controller** — metadata error rate, raft commit latency, preferred replica imbalance
+- **Network & request processing** — network and request handler idle percent, request queue depth, request total time
+- **Storage** — disk usage percentage
+- **Kafka Connect** — connector/task failures, task running ratio, offset commit success rate, DLQ produce failures, record errors and skips, authentication failures, rebalance failures
+- **Consumer groups** — consumer group lag
+- **System** — CPU usage, disk usage, I/O wait, memory usage, authentication failure rate
+
+**Log-based alert rules** (`log_alert_rules.yml`) — 31 rules covering:
+
+- **Broker startup and availability** — startup failure, OOM, FATAL errors, storage exceptions, data directory failures, log flush I/O errors, disk lock errors (`server.log`)
+- **Replication and partition health** — under-replicated partitions, ISR shrink events (`server.log`, `state-change.log`)
+- **Security and authentication** — authorisation failures (`kafka-authorizer.log`), authentication failures (`server.log`)
+- **JVM GC** — full GC events, long GC pauses, G1GC mark abort, OOM (`kafkaServer-gc.log`)
+- **KRaft controller** — no-quorum leader, FATAL and ERROR conditions, OOM, quorum instability, metadata load errors (`controller.log`)
+- **Kafka Connect** — worker FATAL errors, startup failures, task FAILED transitions, offset commit failures, deserialisation errors, REST API unreachable, broker connection loss (`connect.log`)
 
 ### Quick Start
 

--- a/roles/configurations/README.md
+++ b/roles/configurations/README.md
@@ -34,3 +34,39 @@ AXONOPS_PASSWORD: secret
   roles:
     - role: axonops.axonops.configurations
 ```
+
+## Kafka Alert Pack
+
+A comprehensive set of default Kafka alert rules is provided in `examples/configurations/kafka/`. It covers:
+
+- **JVM** — heap usage, GC pauses, thread deadlocks, file descriptor exhaustion
+- **Broker cluster health** — active controller count, offline partitions, unclean leader elections (the three must-alert metrics)
+- **Replication** — under-replicated partitions, ISR shrink rate, offline replicas, min-ISR violations
+- **KRaft controller** — fenced brokers, metadata errors, broker metadata lag, snapshot age
+- **Network & request processing** — idle percent thresholds, P99 produce/fetch latency, failed requests
+- **Storage** — offline log directories, log flush latency, disk usage
+- **Kafka Connect** — task/connector startup failures, offset commit failures, DLQ failures, authentication errors
+- **Consumer lag** — consumer group lag max
+- **Log-based alerts** — broker `server.log`, KRaft `controller.log`, GC log, Connect `connect.log`, authorizer log
+
+### Quick Start
+
+```bash
+# 1. Copy the example config for your org and cluster
+cp -r examples/configurations/kafka/config/REPLACE_WITH_ORG_NAME \
+      examples/configurations/kafka/config/<your-org>
+
+mv examples/configurations/kafka/config/<your-org>/REPLACE_WITH_CLUSTER_NAME \
+   examples/configurations/kafka/config/<your-org>/<your-cluster>
+
+# 2. Review and customise thresholds
+#    Edit: examples/configurations/kafka/config/<your-org>/metric_alert_rules.yml
+#    Edit: examples/configurations/kafka/config/<your-org>/log_alert_rules.yml
+
+# 3. Deploy
+cd examples/configurations/kafka
+AXONOPS_TOKEN=<your-token> ansible-playbook kafka-alerts.yml \
+  -e org=<your-org> -e cluster=<your-cluster>
+```
+
+Thresholds are starting points calibrated for typical production workloads. Re-evaluate per-cluster against observed steady-state behaviour, especially consumer lag (`Consumer Lag High`, default warning at 10,000 messages).


### PR DESCRIPTION
## Summary

Closes #85.

Adds a production-ready Kafka monitoring alert pack to the `configurations` role — verified against a live AxonOps Kafka cluster.

**Metric alerts (27 rules)** covering:
- Cluster health must-alerts: active controller count, offline partitions, unclean leader elections
- Replication: under-replicated partitions, under-min-ISR, ISR shrink rate
- KRaft controller: metadata error rate, raft commit latency, preferred replica imbalance
- Network & request processing: network/request handler idle percent, queue size, P99 latency
- Kafka Connect: task/connector failures, failed rebalances, DLQ failures, record errors/skips, failed auth, rebalance storms
- Consumer groups: consumer group lag
- System: CPU, memory, disk, IO wait

**Log alerts (31 rules)** covering:
- Broker `server.log`: startup failure, OOM, storage exceptions, replication errors, auth failures
- KRaft `controller.log`: quorum errors, FATAL/ERROR/WARN, no-leader condition
- GC log: full GC, long pause, concurrent-mark-abort
- Connect `connect.log`: task failures, offset commit failures, deserialization errors
- Authorizer log: authorization failures

**Config structure** (`config/<org>/` + `config/<org>/<cluster>/` overrides):
```
examples/configurations/kafka/
├── config/
│   └── REPLACE_WITH_ORG_NAME/
│       ├── metric_alert_rules.yml
│       ├── log_alert_rules.yml
│       └── REPLACE_WITH_CLUSTER_NAME/
│           ├── metric_alert_rules.yml   # empty — cluster overrides
│           └── log_alert_rules.yml      # empty — cluster overrides
└── kafka-alerts.yml                     # ready-to-run example playbook
```

## Verification

All metric alert rules tested against a live AxonOps Kafka cluster. Rules that referenced counter-type panels (rejected by the `alert_rule` module) were corrected or removed. Rules referencing dashboards not present in the cluster (Kafka Topics) were removed.

## Test plan

- [ ] Copy `config/REPLACE_WITH_ORG_NAME` to a real org/cluster path
- [ ] Run `AXONOPS_TOKEN=<token> ansible-playbook kafka-alerts.yml -e org=<org> -e cluster=<cluster>`
- [ ] Verify alerts appear in AxonOps UI for the target cluster
- [ ] Run a second time to confirm idempotency (no duplicate alerts created)