### PR TITLE
chore: release v0.5.4

### DIFF
--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -1,0 +1,21 @@
+Create a new GitHub release of this Ansible Collection following the steps in order:
+
+- Find out the next tag number to use:
+
+```sh
+git tag | sort -V
+```
+
+- Unless otherwise stated, use the next minor version. For example:
+
+Current: v0.5.3
+Next: v0.5.4
+
+- Create a new branch using the format `release/{tag}`
+- Update the version on @galaxy.yml to match the git tag version
+- Commit the changes
+- Push the changes
+- Create the git tag
+- Push the git tag to origin
+- Create a PR to merge this branch to `main`
+

--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -3,7 +3,7 @@ Create a new GitHub release of this Ansible Collection following the steps in or
 - Find out the next tag number to use:
 
 ```sh
-git tag | sort -V
+git tag | sort -V | tail -1
 ```
 
 - Unless otherwise stated, use the next minor version. For example:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: axonops
 name: axonops
-version: 0.5.3
+version: 0.5.4
 readme: README.md
 authors:
   - AxonOps <support@axonops.com>


### PR DESCRIPTION
## Summary
- Bump collection version to `0.5.4` in `galaxy.yml`
- Tagged `v0.5.4`

## Test plan
- [ ] CI passes on this branch
- [ ] Merge to `main` triggers Galaxy publish via `release.yml`