### PR TITLE
feat: add kafka role — Apache Kafka KRaft mode

### DIFF
--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -18,4 +18,3 @@ Next: v0.5.4
 - Create the git tag
 - Push the git tag to origin
 - Create a PR to merge this branch to `main`
-

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-venv \
+    sshpass \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --break-system-packages \
+    ansible \
+    ansible-lint \
+    molecule \
+    molecule-docker \
+    "molecule-plugins[docker]" \
+    docker \
+    yamllint \
+    jmespath

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "axonops-ansible-collection",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=axonops-ansible-claude-config-${devcontainerId},target=/home/vscode/.claude,type=volume"
+  ],
+  "containerEnv": {
+    "DISABLE_AUTOUPDATER": "1",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "redhat.ansible",
+        "ms-python.python"
+      ]
+    }
+  },
+  "postStartCommand": "echo 'alias claude-dnd=\"claude --dangerously-skip-permissions\"' >> ~/.bashrc && echo 'alias claude-dnd=\"claude --dangerously-skip-permissions\"' >> ~/.zshrc 2>/dev/null || true"
+}

--- a/.github/workflows/kafka-molecule.yml
+++ b/.github/workflows/kafka-molecule.yml
@@ -1,0 +1,66 @@
+---
+name: Apache Kafka Molecule
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'roles/kafka/**'
+      - '.github/workflows/kafka-molecule.yml'
+  pull_request:
+    paths:
+      - 'roles/kafka/**'
+      - '.github/workflows/kafka-molecule.yml'
+
+defaults:
+  run:
+    working-directory: roles/kafka
+
+jobs:
+  molecule:
+    name: Molecule Kafka (${{ matrix.scenario }} / ${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - rockylinux9
+          - rockylinux10
+          - ubuntu2204
+          - ubuntu2404
+          - ubuntu2604
+          - debian12
+          - debian13
+        scenario:
+          - default
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule molecule-plugins[docker] docker
+
+      - name: Run Molecule destroy (ignore failures)
+        run: molecule -v destroy -s ${{ matrix.scenario }}
+        continue-on-error: true
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: kafka-${{ matrix.scenario }}-${{ matrix.distro }}
+
+      - name: Run Molecule converge
+        run: molecule -v converge -s ${{ matrix.scenario }}
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: $GITHUB_WORKSPACE/roles
+          MOLECULE_INSTANCE_NAME: kafka-${{ matrix.scenario }}-${{ matrix.distro }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ When a new role is added or an existing role is renamed/removed, `README.md` (ro
 | --- | --- | --- |
 | `agent` | AxonOps agent (Cassandra/Kafka monitoring sidecar) | ✅ |
 | `cassandra` | Apache Cassandra install + configuration (tar) | ✅ |
+| `kafka` | Apache Kafka install + configuration (KRaft, tar) | ✅ |
 | `configurations` | AxonOps configuration resources (alerts, silences) | ✅ |
 | `cqlai` | CQL AI assistant component | ✅ |
 | `dash` | AxonOps dashboard web UI | ✅ |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This collection provides the following Ansible roles. Click on each role for det
 
 ### Infrastructure Components
 - **[cassandra](docs/roles/cassandra.md)** - Install and configure Apache Cassandra (3.11, 4.x, 5.x)
+- **[kafka](docs/roles/kafka.md)** - Install and configure Apache Kafka in KRaft mode (no ZooKeeper)
 - **[opensearch](docs/roles/opensearch.md)** - Install and configure OpenSearch for AxonOps (preferred for on-premises)
 - **[elastic](docs/roles/elastic.md)** - Install and configure Elasticsearch for AxonOps
 - **[java](docs/roles/java.md)** - Install Java (OpenJDK or Azul Zulu)

--- a/docs/roles/README.md
+++ b/docs/roles/README.md
@@ -55,6 +55,11 @@ Installs and configures Apache Cassandra (versions 3.11, 4.x, and 5.x).
 
 **Use when**: You need to deploy new Cassandra nodes or manage existing installations.
 
+#### [kafka](kafka.md)
+Installs and configures Apache Kafka in KRaft mode (no ZooKeeper). Supports combined broker+controller nodes, dedicated broker-only nodes, and dedicated controller-only nodes.
+
+**Use when**: You need to deploy a native Kafka cluster on VMs or bare metal with AxonOps monitoring.
+
 #### [opensearch](opensearch.md)
 Installs and configures OpenSearch as the search backend for AxonOps Server.
 
@@ -90,6 +95,7 @@ Performs pre-installation checks to ensure systems meet requirements.
 | **k8ssandra** | Cassandra on Kubernetes | Kubernetes cluster |
 | **strimzi** | Kafka on Kubernetes | Kubernetes cluster |
 | **cassandra** | Apache Cassandra installation | Agent, Java |
+| **kafka** | Apache Kafka (KRaft) installation | Agent |
 | **opensearch** | OpenSearch installation (preferred for on-premises) | Server |
 | **elastic** | Elasticsearch installation (legacy / existing deployments) | Server |
 | **java** | Java installation | Cassandra, Elastic |

--- a/docs/roles/agent.md
+++ b/docs/roles/agent.md
@@ -25,7 +25,7 @@ The `agent` role installs and configures the AxonOps Agent on Cassandra nodes. T
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `axon_java_agent` | `axon-cassandra5.0-agent-jdk17` | Java agent version to install. Options: `axon-cassandra3.11-agent`, `axon-cassandra4.1-agent`, `axon-cassandra5.0-agent-jdk17`, `axon-dse6.0-agent`, `axon-dse6.7-agent`, `axon-dse5.1-agent`, or empty string to skip |
-| `axon_agent_version` | `2.0.2` | Version of the AxonOps agent to install |
+| `axon_agent_version` | `2.0.21` | Version of the AxonOps agent to install |
 | `axon_java_agent_version` | `1.0.10` | Version of the Java agent to install |
 
 ### Network Configuration
@@ -89,7 +89,7 @@ None
     axon_agent_server_host: "{{ groups['axon-server'] | first }}"
     axon_agent_customer_name: mycompany
     axon_java_agent: "axon-cassandra5.0-agent-jdk17"
-    axon_agent_version: "2.0.2"
+    axon_agent_version: "2.0.21"
     axon_java_agent_version: "1.0.10"
 
   roles:

--- a/docs/roles/kafka.md
+++ b/docs/roles/kafka.md
@@ -112,6 +112,7 @@ Auto-derived listener defaults by topology:
 |----------|---------|-------------|
 | `kafka_start_on_install` | `false` | Start Kafka at the end of the play |
 | `kafka_start_on_boot` | `false` | Enable Kafka service at boot |
+| `kafka_configure_firewall` | `true` | Open broker/controller ports in firewalld or ufw if either is active. Set to `false` to skip. |
 
 > **Note**: It is recommended to leave both `false` on new multi-node clusters. Start brokers manually after validating all nodes are configured correctly.
 
@@ -157,6 +158,7 @@ When enabled, the role invokes `axonops.axonops.agent` with the Kafka-specific p
 | Tag | What it runs |
 |-----|-------------|
 | `install` | Download, extract, user/group, symlink, service unit |
+| `firewall` | Open broker/controller ports in firewalld or ufw |
 | `config` | `server.properties` and `/etc/sysconfig/kafka` |
 | `cluster` | UUID management and storage formatting |
 | `topics` | Topic creation |

--- a/docs/roles/kafka.md
+++ b/docs/roles/kafka.md
@@ -15,20 +15,20 @@ Installs and configures Apache Kafka in **KRaft mode** (no ZooKeeper) on RHEL/De
 ## Requirements
 
 - Ansible 2.10+
-- Java 17 on target hosts (installed by the role via `kafka_java_version`)
-- `ansible.posix` collection for `synchronize` (not required by this role directly, but recommended for the collection)
+- Java 17 on target hosts (installed by the role via `kafka_java_version` unless `kafka_java_install: false`)
+- All Kafka hosts must be in the **same play** — the role builds the controller quorum voters list from `ansible_play_hosts`
 
 ## How It Works
 
 1. Creates the `kafka` system user and group
-2. Downloads and extracts the Kafka tarball with checksum verification
-3. Creates a symlink at `/opt/kafka` → `/opt/kafka_2.13-<version>`
+2. Downloads and extracts the Kafka tarball with checksum verification (SHA-512 fetched from `downloads.apache.org`; tarball fetched from `archive.apache.org`)
+3. Creates a symlink at `/opt/kafka` pointing to `/opt/kafka_2.13-<version>`
 4. Writes `/etc/sysconfig/kafka` with JVM heap and opts settings
 5. Templates `server.properties` for KRaft mode based on `kafka_node_roles`
-6. On first run: generates a cluster UUID, persists it to a lock file, and formats storage directories
+6. On first run: generates a cluster UUID, persists it to `/opt/kafka/CLUSTER_UUID.lock`, and formats storage directories
 7. On subsequent runs: reads the UUID from the lock file — UUID is never regenerated
 8. Enables and optionally starts the `kafka` systemd service
-9. Creates any topics defined in `kafka_topics` (idempotent)
+9. Creates any topics defined in `kafka_topics` (idempotent — requires a running broker)
 
 ## Role Variables
 
@@ -39,6 +39,7 @@ Installs and configures Apache Kafka in **KRaft mode** (no ZooKeeper) on RHEL/De
 | `kafka_version` | `"4.0.0"` | Kafka version to install |
 | `kafka_scala_version` | `"2.13"` | Scala version for tarball selection |
 | `kafka_java_version` | `17` | OpenJDK version to install |
+| `kafka_java_install` | `true` | Set to `false` to skip Java installation if it is already managed separately |
 | `kafka_install_root` | `/opt` | Base directory for Kafka installation |
 | `kafka_user` | `kafka` | System user that runs Kafka |
 | `kafka_group` | `kafka` | System group for Kafka |
@@ -55,9 +56,9 @@ Installs and configures Apache Kafka in **KRaft mode** (no ZooKeeper) on RHEL/De
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `kafka_node_id` | **required** | Unique integer ID for this node. Must be set per host in inventory. |
-| `kafka_node_roles` | `[broker, controller]` | Roles for this node. Valid: `broker`, `controller`, or both. |
+| `kafka_node_roles` | `[broker, controller]` | Roles for this node. Valid values: `broker`, `controller`, or both. |
 | `kafka_node_ip` | `ansible_default_ipv4.address` | IP this node advertises. Override when the default interface is wrong. |
-| `kafka_cluster_id` | auto-generated | Cluster UUID. Auto-generated on first run and persisted. Set explicitly to pin a known UUID. |
+| `kafka_cluster_id` | auto-generated | Cluster UUID. Auto-generated on first run and persisted to `/opt/kafka/CLUSTER_UUID.lock`. Set explicitly to pin a known UUID. |
 
 ### Listeners
 
@@ -78,7 +79,7 @@ Auto-derived listener defaults by topology:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `kafka_heap_size` | `1G` | JVM heap size (Xmx and Xms) |
+| `kafka_heap_size` | `1G` | JVM heap size (sets both Xmx and Xms) |
 | `kafka_opts` | `[]` | Additional JVM flags (list or string) |
 | `kafka_num_network_threads` | `3` | Network handler threads |
 | `kafka_num_io_threads` | `8` | I/O handler threads |
@@ -116,9 +117,9 @@ Auto-derived listener defaults by topology:
 
 ### Topics
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `kafka_topics` | `[]` | List of topics to create idempotently. See example below. |
+| Variable | Default | Description                                                                                                          |
+|----------|---------|----------------------------------------------------------------------------------------------------------------------|
+| `kafka_topics` | `[]` | List of topics to create idempotently. Requires `kafka_start_on_install: true` or a running broker on the target hosts. |
 
 Topic entry fields:
 
@@ -127,14 +128,29 @@ Topic entry fields:
 | `name` | yes | Topic name |
 | `partitions` | no | Number of partitions (defaults to `kafka_num_partitions`) |
 | `replication_factor` | no | Replication factor (defaults to `kafka_replication_factor`) |
-| `config` | no | Dict of topic config keys (underscores converted to dots) |
+| `config` | no | Dict of topic config keys (underscores converted to dots automatically) |
 
 ### Miscellaneous
 
+| Variable                  | Default      | Description                                                                                        |
+|---------------------------|--------------|----------------------------------------------------------------------------------------------------|
+| `kafka_additional_config` | `{}`         | Extra key/value pairs appended verbatim to `server.properties`                                     |
+| `kafka_checksum`          | auto-fetched | Override the tarball SHA-512 checksum. Only needed if the Apache checksum endpoint is unreachable. |
+
+### AxonOps Agent Integration
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `kafka_additional_config` | `{}` | Extra key/value pairs appended verbatim to `server.properties` |
-| `kafka_checksum` | auto-fetched | Override the tarball checksum if the Apache mirror is unreachable |
+| `kafka_axonops_agent_enabled` | `false` | Set to `true` to install and configure the AxonOps agent on Kafka nodes |
+| `kafka_axonops_org` | — | **Required when enabled.** Your AxonOps organisation name |
+| `kafka_axonops_key` | — | SaaS API key (required for `axonops.cloud`) |
+| `kafka_axonops_server_host` | `agents.axonops.cloud` | AxonOps server host |
+| `kafka_axonops_java_agent` | `axon-kafka3-agent` | Kafka Java agent package name |
+| `kafka_axonops_agent_version` | latest | Pin the `axon-agent` package version |
+| `kafka_axonops_java_agent_version` | latest | Pin the Java agent JAR version |
+| `kafka_axonops_cluster_name` | — | Override the cluster name shown in AxonOps |
+
+When enabled, the role invokes `axonops.axonops.agent` with the Kafka-specific package and injects the agent JVM options into `kafka-server-start.sh` before the `exec` line.
 
 ## Tags
 
@@ -146,6 +162,7 @@ Topic entry fields:
 | `topics` | Topic creation |
 | `service` | Start/enable systemd service |
 | `axonops_user` | Create `axonops` user and cross-group membership |
+| `axonops_agent` | Install and configure AxonOps agent |
 
 ## Example Playbooks
 
@@ -163,7 +180,7 @@ Topic entry fields:
 
 ### Three-node cluster (combined broker + controller)
 
-Set per-host in inventory:
+Set per-host variables in inventory:
 
 ```ini
 [kafka]
@@ -194,6 +211,10 @@ kafka3 ansible_host=192.168.1.13 kafka_node_id=3 kafka_node_ip=192.168.1.13
 
 ### Separated broker and controller nodes
 
+> **Important**: All nodes — both controllers and brokers — must be targeted by a **single play**. The role uses `ansible_play_hosts` to build the controller quorum voters list. If controllers and brokers run in separate plays, brokers will not know about the controllers and the cluster will not form.
+
+Inventory:
+
 ```ini
 [kafka_controllers]
 ctrl1 ansible_host=10.0.0.1 kafka_node_id=1 kafka_node_ip=10.0.0.1
@@ -210,21 +231,35 @@ kafka_controllers
 kafka_brokers
 ```
 
-```yaml
-- hosts: kafka
-  roles:
-    - role: axonops.axonops.kafka
+`group_vars/kafka_controllers/main.yml`:
 
-# group_vars/kafka_controllers.yml
+```yaml
 kafka_node_roles:
   - controller
+```
 
-# group_vars/kafka_brokers.yml
+`group_vars/kafka_brokers/main.yml`:
+
+```yaml
 kafka_node_roles:
   - broker
 ```
 
-> All hosts must be in the same play so the role can build the dynamic controller quorum voters list.
+Playbook — targets the parent `kafka` group so that all nodes are in the same play:
+
+```yaml
+- hosts: kafka
+  roles:
+    - role: axonops.axonops.kafka
+  vars:
+    kafka_heap_size: 4G
+    kafka_replication_factor: 3
+    kafka_offsets_topic_replication_factor: 3
+    kafka_transaction_state_log_replication_factor: 3
+    kafka_transaction_state_log_min_isr: 2
+    kafka_start_on_install: true
+    kafka_start_on_boot: true
+```
 
 ### Custom topics with retention
 
@@ -247,11 +282,12 @@ kafka_topics:
 ## Notes
 
 - **`kafka_node_id` is mandatory** — the role fails immediately if it is not defined for a host.
-- **UUID persistence** — the cluster UUID is written to `kafka__home/CLUSTER_UUID.lock` on the first controller node and is never regenerated. Delete this file only if you are intentionally re-initialising the cluster.
-- **Storage format** — `kafka-storage.sh format` is skipped if `meta.properties` already exists in any data directory. This makes re-runs safe.
-- **Java 17** — Kafka 4.x requires Java 17. The role installs `openjdk-17-jre-headless` (Debian) or `java-17-openjdk-headless` (RHEL).
+- **UUID persistence** — the cluster UUID is written to `/opt/kafka/CLUSTER_UUID.lock` on the first controller node and is never regenerated. Delete this file only if you are intentionally re-initialising the cluster.
+- **Storage format** — `kafka-storage.sh format` is skipped if `meta.properties` already exists in any data directory. Re-runs are safe.
+- **Java 17** — Kafka 4.x requires Java 17. The role installs `openjdk-17-jre-headless` (Debian) or `java-17-openjdk-headless` (RHEL). Set `kafka_java_install: false` to skip this step if Java is managed by another role.
+- **Topics require a running broker** — `kafka_topics` is processed only when `kafka_start_on_install: true` and the broker port is reachable. Topics are not created on configuration-only runs.
 - **TLS/SASL** — not supported in this release. Planned for a future version.
-- **AxonOps agent** — the role creates the `axonops` user in the `kafka` group so that `axon-agent` can access Kafka files.
+- **AxonOps agent** — the role adds the `axonops` user to the `kafka` group and the `kafka` user to the `axonops` group so that `axon-agent` can access Kafka files without requiring root.
 
 ## License
 

--- a/docs/roles/kafka.md
+++ b/docs/roles/kafka.md
@@ -1,0 +1,262 @@
+# Kafka Role
+
+Installs and configures Apache Kafka in **KRaft mode** (no ZooKeeper) on RHEL/Debian-family systems. The role handles binary installation, cluster UUID management, storage formatting, systemd service configuration, and optional topic creation.
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Default version | 4.0.0 |
+| Mode | KRaft only (no ZooKeeper) |
+| Installation | Tar archive from Apache mirrors |
+| Topologies | Combined broker+controller, broker-only, controller-only |
+| TLS/SASL | Not included — planned for a future release |
+
+## Requirements
+
+- Ansible 2.10+
+- Java 17 on target hosts (installed by the role via `kafka_java_version`)
+- `ansible.posix` collection for `synchronize` (not required by this role directly, but recommended for the collection)
+
+## How It Works
+
+1. Creates the `kafka` system user and group
+2. Downloads and extracts the Kafka tarball with checksum verification
+3. Creates a symlink at `/opt/kafka` → `/opt/kafka_2.13-<version>`
+4. Writes `/etc/sysconfig/kafka` with JVM heap and opts settings
+5. Templates `server.properties` for KRaft mode based on `kafka_node_roles`
+6. On first run: generates a cluster UUID, persists it to a lock file, and formats storage directories
+7. On subsequent runs: reads the UUID from the lock file — UUID is never regenerated
+8. Enables and optionally starts the `kafka` systemd service
+9. Creates any topics defined in `kafka_topics` (idempotent)
+
+## Role Variables
+
+### Version and Installation
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_version` | `"4.0.0"` | Kafka version to install |
+| `kafka_scala_version` | `"2.13"` | Scala version for tarball selection |
+| `kafka_java_version` | `17` | OpenJDK version to install |
+| `kafka_install_root` | `/opt` | Base directory for Kafka installation |
+| `kafka_user` | `kafka` | System user that runs Kafka |
+| `kafka_group` | `kafka` | System group for Kafka |
+
+### Paths
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_log_dir` | `/var/log/kafka` | JVM/service stdout log directory |
+| `kafka_data_dirs` | `[/var/lib/kafka]` | Kafka topic/partition data directories |
+
+### KRaft Cluster
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_node_id` | **required** | Unique integer ID for this node. Must be set per host in inventory. |
+| `kafka_node_roles` | `[broker, controller]` | Roles for this node. Valid: `broker`, `controller`, or both. |
+| `kafka_node_ip` | `ansible_default_ipv4.address` | IP this node advertises. Override when the default interface is wrong. |
+| `kafka_cluster_id` | auto-generated | Cluster UUID. Auto-generated on first run and persisted. Set explicitly to pin a known UUID. |
+
+### Listeners
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_listeners` | `[]` | Override auto-derived listeners. Leave empty to use role defaults based on `kafka_node_roles`. |
+| `kafka_inter_broker_listener_name` | `PLAINTEXT` | Listener name used for inter-broker communication. |
+
+Auto-derived listener defaults by topology:
+
+| Node roles | Listeners |
+|-----------|-----------|
+| `[broker, controller]` | `PLAINTEXT://:9092,CONTROLLER://:9093` |
+| `[broker]` | `PLAINTEXT://:9092` |
+| `[controller]` | `CONTROLLER://:9093` |
+
+### Performance
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_heap_size` | `1G` | JVM heap size (Xmx and Xms) |
+| `kafka_opts` | `[]` | Additional JVM flags (list or string) |
+| `kafka_num_network_threads` | `3` | Network handler threads |
+| `kafka_num_io_threads` | `8` | I/O handler threads |
+| `kafka_socket_send_buffer_bytes` | `102400` | Socket send buffer |
+| `kafka_socket_receive_buffer_bytes` | `102400` | Socket receive buffer |
+| `kafka_socket_request_max_bytes` | `104857600` | Maximum request size |
+
+### Topics and Replication
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_num_partitions` | `1` | Default number of partitions for new topics |
+| `kafka_replication_factor` | `1` | Default replication factor |
+| `kafka_offsets_topic_replication_factor` | `1` | `__consumer_offsets` replication factor |
+| `kafka_transaction_state_log_replication_factor` | `1` | `__transaction_state` replication factor |
+| `kafka_transaction_state_log_min_isr` | `1` | Minimum in-sync replicas for `__transaction_state` |
+
+### Log Retention
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_log_retention_hours` | `168` | Retain log segments for this many hours (7 days) |
+| `kafka_log_retention_bytes` | `-1` | Byte-based retention limit. `-1` disables it. |
+| `kafka_log_segment_bytes` | `1073741824` | Maximum log segment size (1 GiB) |
+| `kafka_log_retention_check_interval_ms` | `300000` | How often to check log retention (5 minutes) |
+
+### Service Control
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_start_on_install` | `false` | Start Kafka at the end of the play |
+| `kafka_start_on_boot` | `false` | Enable Kafka service at boot |
+
+> **Note**: It is recommended to leave both `false` on new multi-node clusters. Start brokers manually after validating all nodes are configured correctly.
+
+### Topics
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_topics` | `[]` | List of topics to create idempotently. See example below. |
+
+Topic entry fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Topic name |
+| `partitions` | no | Number of partitions (defaults to `kafka_num_partitions`) |
+| `replication_factor` | no | Replication factor (defaults to `kafka_replication_factor`) |
+| `config` | no | Dict of topic config keys (underscores converted to dots) |
+
+### Miscellaneous
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_additional_config` | `{}` | Extra key/value pairs appended verbatim to `server.properties` |
+| `kafka_checksum` | auto-fetched | Override the tarball checksum if the Apache mirror is unreachable |
+
+## Tags
+
+| Tag | What it runs |
+|-----|-------------|
+| `install` | Download, extract, user/group, symlink, service unit |
+| `config` | `server.properties` and `/etc/sysconfig/kafka` |
+| `cluster` | UUID management and storage formatting |
+| `topics` | Topic creation |
+| `service` | Start/enable systemd service |
+| `axonops_user` | Create `axonops` user and cross-group membership |
+
+## Example Playbooks
+
+### Single-node (development)
+
+```yaml
+- hosts: kafka
+  roles:
+    - role: axonops.axonops.kafka
+  vars:
+    kafka_node_id: 1
+    kafka_start_on_install: true
+    kafka_start_on_boot: true
+```
+
+### Three-node cluster (combined broker + controller)
+
+Set per-host in inventory:
+
+```ini
+[kafka]
+kafka1 ansible_host=192.168.1.11 kafka_node_id=1 kafka_node_ip=192.168.1.11
+kafka2 ansible_host=192.168.1.12 kafka_node_id=2 kafka_node_ip=192.168.1.12
+kafka3 ansible_host=192.168.1.13 kafka_node_id=3 kafka_node_ip=192.168.1.13
+```
+
+```yaml
+- hosts: kafka
+  roles:
+    - role: axonops.axonops.kafka
+  vars:
+    kafka_heap_size: 4G
+    kafka_replication_factor: 3
+    kafka_offsets_topic_replication_factor: 3
+    kafka_transaction_state_log_replication_factor: 3
+    kafka_transaction_state_log_min_isr: 2
+    kafka_data_dirs:
+      - /data/kafka
+    kafka_start_on_install: true
+    kafka_start_on_boot: true
+    kafka_topics:
+      - name: my-events
+        partitions: 9
+        replication_factor: 3
+```
+
+### Separated broker and controller nodes
+
+```ini
+[kafka_controllers]
+ctrl1 ansible_host=10.0.0.1 kafka_node_id=1 kafka_node_ip=10.0.0.1
+ctrl2 ansible_host=10.0.0.2 kafka_node_id=2 kafka_node_ip=10.0.0.2
+ctrl3 ansible_host=10.0.0.3 kafka_node_id=3 kafka_node_ip=10.0.0.3
+
+[kafka_brokers]
+broker1 ansible_host=10.0.1.1 kafka_node_id=4 kafka_node_ip=10.0.1.1
+broker2 ansible_host=10.0.1.2 kafka_node_id=5 kafka_node_ip=10.0.1.2
+broker3 ansible_host=10.0.1.3 kafka_node_id=6 kafka_node_ip=10.0.1.3
+
+[kafka:children]
+kafka_controllers
+kafka_brokers
+```
+
+```yaml
+- hosts: kafka
+  roles:
+    - role: axonops.axonops.kafka
+
+# group_vars/kafka_controllers.yml
+kafka_node_roles:
+  - controller
+
+# group_vars/kafka_brokers.yml
+kafka_node_roles:
+  - broker
+```
+
+> All hosts must be in the same play so the role can build the dynamic controller quorum voters list.
+
+### Custom topics with retention
+
+```yaml
+kafka_topics:
+  - name: events
+    partitions: 12
+    replication_factor: 3
+    config:
+      retention_ms: 604800000    # 7 days
+      cleanup_policy: delete
+  - name: audit-log
+    partitions: 3
+    replication_factor: 3
+    config:
+      retention_ms: 2592000000   # 30 days
+      retention_bytes: 10737418240
+```
+
+## Notes
+
+- **`kafka_node_id` is mandatory** — the role fails immediately if it is not defined for a host.
+- **UUID persistence** — the cluster UUID is written to `kafka__home/CLUSTER_UUID.lock` on the first controller node and is never regenerated. Delete this file only if you are intentionally re-initialising the cluster.
+- **Storage format** — `kafka-storage.sh format` is skipped if `meta.properties` already exists in any data directory. This makes re-runs safe.
+- **Java 17** — Kafka 4.x requires Java 17. The role installs `openjdk-17-jre-headless` (Debian) or `java-17-openjdk-headless` (RHEL).
+- **TLS/SASL** — not supported in this release. Planned for a future version.
+- **AxonOps agent** — the role creates the `axonops` user in the `kafka` group so that `axon-agent` can access Kafka files.
+
+## License
+
+Apache 2.0 — see [LICENSE](../../LICENSE) for details.
+
+## Author
+
+[AxonOps Limited](https://axonops.com)

--- a/docs/roles/kafka.md
+++ b/docs/roles/kafka.md
@@ -146,7 +146,7 @@ Topic entry fields:
 | `kafka_axonops_org` | — | **Required when enabled.** Your AxonOps organisation name |
 | `kafka_axonops_key` | — | SaaS API key (required for `axonops.cloud`) |
 | `kafka_axonops_server_host` | `agents.axonops.cloud` | AxonOps server host |
-| `kafka_axonops_java_agent` | `axon-kafka3-agent` | Kafka Java agent package name |
+| `kafka_axonops_java_agent` | `axon-kafka4-agent` | Kafka Java agent package name |
 | `kafka_axonops_agent_version` | latest | Pin the `axon-agent` package version |
 | `kafka_axonops_java_agent_version` | latest | Pin the Java agent JAR version |
 | `kafka_axonops_cluster_name` | — | Override the cluster name shown in AxonOps |

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ Deploys AxonOps Agent alongside Apache Cassandra on target hosts.
 - Connects to AxonOps Server or SaaS
 
 **Key Variables:**
-- `axon_agent_version`: AxonOps Agent version (default: 2.0.2)
+- `axon_agent_version`: AxonOps Agent version (default: 2.0.21)
 - `axon_java_agent`: Java agent package (e.g., `axon-cassandra4.1-agent`)
 - `axon_agent_server_host`: AxonOps Server endpoint
 - `axon_agent_customer_name`: Organization identifier

--- a/examples/axon-agent.yml
+++ b/examples/axon-agent.yml
@@ -4,7 +4,7 @@
   vars:
     install_cassandra: true
     axon_java_agent: "axon-cassandra4.1-agent"
-    axon_agent_version: "2.0.2"
+    axon_agent_version: "2.0.21"
     axon_java_agent_version: "1.0.14"
     axon_agent_customer_name: "mycompany"
     # This is the AxonOps Server host, it can be localhost or the IP of the AxonOps Server

--- a/examples/cassandra-4.1.yml
+++ b/examples/cassandra-4.1.yml
@@ -4,7 +4,7 @@
   vars:
     install_cassandra: true
     axon_java_agent: "axon-cassandra4.1-agent"
-    axon_agent_version: "2.0.2"
+    axon_agent_version: "2.0.21"
     axon_java_agent_version: "1.0.14"
     cassandra_version: 4.1.9
     cassandra_cluster_name: axonops

--- a/examples/cassandra-5.0.yml
+++ b/examples/cassandra-5.0.yml
@@ -5,7 +5,7 @@
     install_cassandra: true
     #java_pkg: openjdk-17-jre-headless
     axon_java_agent: "axon-cassandra5.0-agent-jdk17"
-    axon_agent_version: "2.0.2"
+    axon_agent_version: "2.0.21"
     axon_java_agent_version: "1.0.10"
     cassandra_cluster_name: test000
     cassandra_dc: default

--- a/examples/self-hosted-example/cassandra-5.0.yml
+++ b/examples/self-hosted-example/cassandra-5.0.yml
@@ -5,7 +5,7 @@
     install_cassandra: true
     #java_pkg: openjdk-17-jre-headless
     axon_java_agent: "axon-cassandra5.0-agent-jdk17"
-    axon_agent_version: "2.0.2"
+    axon_agent_version: "2.0.21"
     axon_java_agent_version: "1.0.10"
     cassandra_cluster_name: test000
     cassandra_dc: default

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -44,3 +44,9 @@ axon_agent_sudoers: |
 # axon_agent_cassandra_config: 'JVM_OPTS="$JVM_OPTS -javaagent:/usr/share/axonops/axon-cassandra4.0-agent.jar=/etc/axonops/axon-agent.yml"'
 # This config is more common for Apache Cassandra >= 5
 # axon_agent_cassandra_config: '. /usr/share/axonops/axonops-jvm.options'
+
+# Enable these options to let the Axon-Agent role modify the Kafka broker start script.
+# Set axon_java_agent to the correct Kafka agent package (e.g. axon-kafka3-agent).
+# Check https://axonops.com/docs/get_started/agent_setup/ to confirm the correct package name.
+# axon_agent_kafka_config_directory: /opt/kafka/bin
+# axon_agent_kafka_config: '. /usr/share/axonops/axonops-jvm.options'

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -6,7 +6,8 @@ axon_agent_server_port: "{% if axon_agent_server_host == 'agents.axonops.cloud' 
 
 # Possible Options: axon-cassandra3.11-agent, axon-dse6.0-agent, axon-dse6.7-agent, axon-dse5.1-agent or ""
 axon_java_agent: "axon-cassandra5.0-agent-jdk17"
-axon_agent_version: "2.0.2"
+# Leave empty to install the latest version from the repository.
+axon_agent_version: ""
 axon_java_agent_version: "1.0.10"
 
 # This is should be left undefined unless you are using a custom AxonOps server.

--- a/roles/agent/molecule/default/converge.yml
+++ b/roles/agent/molecule/default/converge.yml
@@ -28,7 +28,7 @@
     - role: agent
       vars:
         axon_java_agent: "axon-cassandra5.0-agent-jdk17"
-        axon_agent_version: "2.0.2"
+        axon_agent_version: "2.0.21"
         axon_java_agent_version: "1.0.10"
         axon_agent_cassandra_config_directory: /opt/cassandra/conf
         axon_agent_cassandra_config: '. /usr/share/axonops/axonops-jvm.options'

--- a/roles/agent/tasks/configure.yml
+++ b/roles/agent/tasks/configure.yml
@@ -90,6 +90,7 @@
       ansible.builtin.lineinfile:
         path: "{{ axon_agent_kafka_config_directory }}/kafka-server-start.sh"
         line: "{{ axon_agent_kafka_config }}"
+        regexp: '(axonops|axon-agent|axon-kafka)'
         insertbefore: "^exec "
         firstmatch: true
 

--- a/roles/agent/tasks/configure.yml
+++ b/roles/agent/tasks/configure.yml
@@ -73,4 +73,24 @@
         line: "{{ axon_agent_cassandra_config }}"
         insertafter: EOF
 
+- name: Add AxonOps agent config to kafka-server-start.sh
+  when: axon_agent_kafka_config_directory is defined and axon_agent_kafka_config_directory != ""
+  block:
+    - name: Check kafka-server-start.sh can be found
+      ansible.builtin.stat:
+        path: "{{ axon_agent_kafka_config_directory }}/kafka-server-start.sh"
+      register: _kafka_start
+
+    - name: Fail if kafka-server-start.sh not found
+      ansible.builtin.fail:
+        msg: "{{ axon_agent_kafka_config_directory }}/kafka-server-start.sh not found"
+      when: not _kafka_start.stat.exists
+
+    - name: Add AxonOps agent config to kafka-server-start.sh
+      ansible.builtin.lineinfile:
+        path: "{{ axon_agent_kafka_config_directory }}/kafka-server-start.sh"
+        line: "{{ axon_agent_kafka_config }}"
+        insertbefore: "^exec "
+        firstmatch: true
+
 # code: language=ansible

--- a/roles/agent/tasks/repo/RedHat.yml
+++ b/roles/agent/tasks/repo/RedHat.yml
@@ -7,10 +7,18 @@
     repo_gpgcheck: false
     gpgcheck: false
 
-- name: Set package names
+- name: Set package names (pinned version)
   ansible.builtin.set_fact:
     axon_agent_pkg: "axon-agent-{{ axon_agent_version }}-1"
     axon_java_agent_pkg: "{{ axon_java_agent }}-{{ axon_java_agent_version }}-1"
     pkg_ext: "{{ ansible_architecture }}.rpm"
+  when: axon_agent_version | default('') != ""
+
+- name: Set package names (latest)
+  ansible.builtin.set_fact:
+    axon_agent_pkg: "axon-agent"
+    axon_java_agent_pkg: "{{ axon_java_agent }}"
+    pkg_ext: "{{ ansible_architecture }}.rpm"
+  when: axon_agent_version | default('') == ""
 
 # code: language=ansible

--- a/roles/agent/templates/axon-agent.yml.j2
+++ b/roles/agent/templates/axon-agent.yml.j2
@@ -108,6 +108,34 @@ NTP:
     #nodetoolPath : "/path/to/nodetool"
     warningThresholdMillis: 200 # This will warn in logs when a MBean takes longer than the specified value.
     logFormat: "%4$s %1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL %5$s%6$s%n"
+{% elif "axon-kafka" in axon_java_agent %}
+kafka:
+    tier0: # metrics collected every 5 seconds
+        metrics:
+            jvm_:
+              - "java.lang:*"
+            kafka_:
+              - "kafka.server:*"
+              - "kafka.controller:*"
+              - "kafka.network:*"
+              - "kafka.log:*"
+              - "kafka.cluster:*"
+
+    tier1:
+        frequency: 300 # metrics collected every 300 seconds (5m)
+        metrics:
+            kafka_:
+              - "kafka.server:type=BrokerTopicMetrics,*"
+
+    blacklist:
+      - ".*999thPercentile|.*50thPercentile|.*FifteenMinuteRate|.*FiveMinuteRate|.*MeanRate|.*Mean|.*OneMinuteRate|.*StdDev"
+
+    JMXOperationsBlacklist:
+      - "getThreadInfo"
+
+    warningThresholdMillis: {{ axon_agent_warn_threshold_millis | default(1000) }}
+
+    logFormat: "%4$s %1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL %5$s%6$s%n"
 {% elif "axon-cassandra" in axon_java_agent %}
 cassandra:
     tier0: # metrics collected every 5 seconds

--- a/roles/cassandra/templates/4.1.x/jvm-server.options.j2
+++ b/roles/cassandra/templates/4.1.x/jvm-server.options.j2
@@ -36,7 +36,7 @@
 # information in cassandra.yaml (such as listen_address).
 #-Dcassandra.load_ring_state=true|false
 
-# Enable pluggable metrics reporter. See Pluggable metrics reporting in Cassandra 2.0.2.
+# Enable pluggable metrics reporter. See Pluggable metrics reporting in Cassandra 2.0.21.
 #-Dcassandra.metricsReporterConfigFile=file
 
 # Set the port on which the CQL native transport listens for clients. (Default: 9042)

--- a/roles/elastic/Gemfile.lock
+++ b/roles/elastic/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       erubi (~> 1.8)
       gssapi (~> 1.2)
       gyoku (~> 1.0)
-      httpclient (~> 2.2, >= 2.2.0.2)
+      httpclient (~> 2.2, >= 2.2.0.21)
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,0 +1,114 @@
+---
+# ============================================================================
+# Kafka Role - Default Variables
+# ============================================================================
+
+# --- Version & Download -----------------------------------------------------
+
+kafka_version: "4.0.0"
+kafka_scala_version: "2.13"
+# Java version passed to the axonops.axonops.java role as java_pkg. Kafka 4.x requires Java 17.
+kafka_java_version: 17
+kafka_java_install: true
+
+# --- Installation -----------------------------------------------------------
+
+kafka_install_root: /opt
+kafka_user: kafka
+kafka_group: kafka
+
+# --- Paths ------------------------------------------------------------------
+
+# JVM / service stdout logs (not Kafka topic partition data)
+kafka_log_dir: /var/log/kafka
+
+# Kafka topic/partition data directories
+kafka_data_dirs:
+  - /var/lib/kafka
+
+# --- JVM --------------------------------------------------------------------
+
+kafka_heap_size: 1G
+
+# Additional JVM flags — list or plain string
+# kafka_opts:
+#   - -XX:NewSize=256m
+kafka_opts: []
+
+# --- KRaft Cluster ----------------------------------------------------------
+
+# REQUIRED per host — role fails without it
+# kafka_node_id: 1
+
+# Node roles for this host. All three combinations are supported:
+#   [broker, controller]  — combined (default, recommended for small clusters)
+#   [broker]              — broker-only  (dedicated broker node)
+#   [controller]          — controller-only (dedicated controller quorum node)
+kafka_node_roles:
+  - broker
+  - controller
+
+# Optional: override the IP this node advertises. Defaults to ansible_default_ipv4.address
+# kafka_node_ip: 192.168.1.10
+
+# Optional: fix the cluster UUID. Auto-generated and persisted on first run if omitted.
+# kafka_cluster_id: ""
+
+# --- Listeners --------------------------------------------------------------
+
+# Override auto-derived listeners. Auto-derivation:
+#   combined node  → [PLAINTEXT://:9092, CONTROLLER://:9093]
+#   broker-only    → [PLAINTEXT://:9092]
+#   controller-only → [CONTROLLER://:9093]
+kafka_listeners: []
+
+kafka_inter_broker_listener_name: PLAINTEXT
+
+# --- Performance ------------------------------------------------------------
+
+kafka_num_network_threads: 3
+kafka_num_io_threads: 8
+kafka_socket_send_buffer_bytes: 102400
+kafka_socket_receive_buffer_bytes: 102400
+kafka_socket_request_max_bytes: 104857600
+
+# --- Topic Defaults ---------------------------------------------------------
+
+kafka_num_partitions: 1
+kafka_replication_factor: 1
+
+# --- Internal Topic Settings ------------------------------------------------
+
+kafka_offsets_topic_replication_factor: 1
+kafka_transaction_state_log_replication_factor: 1
+kafka_transaction_state_log_min_isr: 1
+
+# --- Log Retention ----------------------------------------------------------
+
+kafka_log_retention_hours: 168
+kafka_log_retention_bytes: -1
+kafka_log_segment_bytes: 1073741824
+kafka_log_retention_check_interval_ms: 300000
+
+# --- Service Control --------------------------------------------------------
+
+# It is recommended to leave these false and start Kafka manually after validating the cluster.
+kafka_start_on_install: false
+kafka_start_on_boot: false
+
+# --- Topics -----------------------------------------------------------------
+
+# Idempotent topic management. Topics are created only if they do not already exist.
+# Requires kafka_start_on_install: true or a running broker.
+kafka_topics: []
+# - name: my-topic
+#   partitions: 3
+#   replication_factor: 1
+#   config:
+#     retention_ms: 86400000
+
+# --- Arbitrary Extra Config -------------------------------------------------
+
+# Key/value pairs appended verbatim to server.properties.
+kafka_additional_config: {}
+# message.max.bytes: 1000000

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -130,6 +130,7 @@ kafka_axonops_agent_enabled: false
 
 # AxonOps server host. Defaults to the SaaS endpoint.
 kafka_axonops_server_host: "agents.axonops.cloud"
+kafka_axonops_agent_server_port: "{% if kafka_axonops_server_host == 'agents.axonops.cloud' %}443{% else %}1888{% endif %}"
 
 # Kafka Java agent package name.
 kafka_axonops_java_agent: "axon-kafka4-agent"
@@ -138,5 +139,6 @@ kafka_axonops_java_agent: "axon-kafka4-agent"
 # kafka_axonops_agent_version: ""
 # kafka_axonops_java_agent_version: ""
 
-# Optional: override the cluster name shown in AxonOps.
+# Required when kafka_axonops_agent_enabled is true.
+# Cluster name shown in AxonOps; the Kafka Java agent fails without it.
 # kafka_axonops_cluster_name: ""

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -96,6 +96,10 @@ kafka_log_retention_check_interval_ms: 300000
 kafka_start_on_install: false
 kafka_start_on_boot: false
 
+# Open Kafka ports in firewalld/ufw if either is active on the host.
+# Broker port 9092, controller port 9093 — only opened for the roles this node runs.
+kafka_configure_firewall: true
+
 # --- Topics -----------------------------------------------------------------
 
 # Idempotent topic management. Topics are created only if they do not already exist.
@@ -128,7 +132,7 @@ kafka_axonops_agent_enabled: false
 kafka_axonops_server_host: "agents.axonops.cloud"
 
 # Kafka Java agent package name.
-kafka_axonops_java_agent: "axon-kafka3-agent"
+kafka_axonops_java_agent: "axon-kafka4-agent"
 
 # Pin agent versions. Leave empty to install the latest available.
 # kafka_axonops_agent_version: ""

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -112,3 +112,27 @@ kafka_topics: []
 # Key/value pairs appended verbatim to server.properties.
 kafka_additional_config: {}
 # message.max.bytes: 1000000
+
+# --- AxonOps Agent Integration ----------------------------------------------
+
+# Set to true to install and configure the AxonOps agent on Kafka nodes.
+kafka_axonops_agent_enabled: false
+
+# Required when kafka_axonops_agent_enabled is true.
+# kafka_axonops_org: ""
+
+# SaaS API key (required for axonops.cloud).
+# kafka_axonops_key: ""
+
+# AxonOps server host. Defaults to the SaaS endpoint.
+kafka_axonops_server_host: "agents.axonops.cloud"
+
+# Kafka Java agent package name.
+kafka_axonops_java_agent: "axon-kafka3-agent"
+
+# Pin agent versions. Leave empty to install the latest available.
+# kafka_axonops_agent_version: ""
+# kafka_axonops_java_agent_version: ""
+
+# Optional: override the cluster name shown in AxonOps.
+# kafka_axonops_cluster_name: ""

--- a/roles/kafka/handlers/main.yml
+++ b/roles/kafka/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart Kafka
+  ansible.builtin.systemd:
+    daemon_reload: true
+    state: restarted
+    name: kafka

--- a/roles/kafka/meta/main.yml
+++ b/roles/kafka/meta/main.yml
@@ -1,0 +1,34 @@
+---
+galaxy_info:
+  author: AxonOps Limited
+  description: Installs and configures Apache Kafka in KRaft mode (no ZooKeeper)
+  company: AxonOps Limited
+  license: Apache 2.0
+  min_ansible_version: "2.10"
+
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+        - "10"
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+
+  galaxy_tags:
+    - axonops
+    - kafka
+    - kraft
+    - messaging
+
+  documentation: https://github.com/axonops/axonops-ansible-collection
+  issues: https://github.com/axonops/axonops-ansible-collection/issues
+
+  dependencies: []

--- a/roles/kafka/molecule/default/converge.yml
+++ b/roles/kafka/molecule/default/converge.yml
@@ -1,0 +1,23 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    kafka_version: "4.0.0"
+    kafka_node_id: 1
+    kafka_node_roles:
+      - broker
+      - controller
+    kafka_heap_size: "512m"
+    kafka_opts:
+      - "-XX:NewSize=64m"
+      - "-XX:MaxNewSize=64m"
+    kafka_data_dirs:
+      - /var/lib/kafka
+    kafka_start_on_install: false
+    kafka_start_on_boot: false
+
+  roles:
+    - role: kafka
+
+# code: language=ansible

--- a/roles/kafka/molecule/default/molecule.yml
+++ b/roles/kafka/molecule/default/molecule.yml
@@ -19,6 +19,9 @@ provisioner:
   connection_options:
     ansible_user: root
     ansible_become_method: su
+  config_options:
+    defaults:
+      pipelining: true
   playbooks:
     converge: converge.yml
     verify: verify.yml

--- a/roles/kafka/molecule/default/molecule.yml
+++ b/roles/kafka/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: docker
+platforms:
+  - name: ${MOLECULE_INSTANCE_NAME:-"default"}
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_user: root
+    ansible_become_method: su
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml

--- a/roles/kafka/molecule/default/verify.yml
+++ b/roles/kafka/molecule/default/verify.yml
@@ -1,0 +1,80 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check Kafka home symlink exists
+      ansible.builtin.stat:
+        path: /opt/kafka
+      register: kafka_home_stat
+      failed_when: not kafka_home_stat.stat.exists or not kafka_home_stat.stat.islnk
+
+    - name: Check Kafka systemd unit exists
+      ansible.builtin.stat:
+        path: /etc/systemd/system/kafka.service
+      register: kafka_service_stat
+      failed_when: not kafka_service_stat.stat.exists
+
+    - name: Read server.properties
+      ansible.builtin.slurp:
+        src: /opt/kafka/config/server.properties
+      register: kafka_props_content
+
+    - name: Assert server.properties contains process.roles
+      ansible.builtin.assert:
+        that:
+          - "'process.roles=' in (kafka_props_content.content | b64decode)"
+        fail_msg: "server.properties does not contain process.roles"
+
+    - name: Assert server.properties contains node.id
+      ansible.builtin.assert:
+        that:
+          - "'node.id=1' in (kafka_props_content.content | b64decode)"
+        fail_msg: "server.properties does not contain the expected node.id=1"
+
+    - name: Check Kafka data directory exists
+      ansible.builtin.stat:
+        path: /var/lib/kafka
+      register: kafka_data_stat
+      failed_when: not kafka_data_stat.stat.exists or not kafka_data_stat.stat.isdir
+
+    - name: Check Kafka log directory exists
+      ansible.builtin.stat:
+        path: /var/log/kafka
+      register: kafka_log_stat
+      failed_when: not kafka_log_stat.stat.exists or not kafka_log_stat.stat.isdir
+
+    - name: Check Kafka user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: kafka
+
+    - name: Read cluster UUID lock file
+      ansible.builtin.slurp:
+        src: /opt/kafka/CLUSTER_UUID.lock
+      register: kafka_uuid_content
+
+    - name: Assert cluster UUID lock file contains a UUID
+      ansible.builtin.assert:
+        that:
+          - (kafka_uuid_content.content | b64decode | trim) | length == 22
+        fail_msg: "CLUSTER_UUID.lock does not contain a valid Kafka UUID (expected 22 chars)"
+
+    - name: Read sysconfig/kafka
+      ansible.builtin.slurp:
+        src: /etc/sysconfig/kafka
+      register: kafka_sysconfig_content
+
+    - name: Assert KAFKA_HEAP_OPTS is set
+      ansible.builtin.assert:
+        that:
+          - "'KAFKA_HEAP_OPTS=' in (kafka_sysconfig_content.content | b64decode)"
+        fail_msg: "/etc/sysconfig/kafka does not contain KAFKA_HEAP_OPTS"
+
+    - name: Assert KAFKA_OPTS contains expected JVM flag
+      ansible.builtin.assert:
+        that:
+          - "'-XX:NewSize=64m' in (kafka_sysconfig_content.content | b64decode)"
+        fail_msg: "/etc/sysconfig/kafka does not contain the expected KAFKA_OPTS flags"
+
+# code: language=ansible

--- a/roles/kafka/tasks/cluster.yml
+++ b/roles/kafka/tasks/cluster.yml
@@ -1,4 +1,12 @@
 ---
+- name: Ensure kafka user tmp dir exists
+  become: true
+  ansible.builtin.file:
+    path: /tmp/.ansible_kafka
+    state: directory
+    owner: "{{ kafka_user }}"
+    mode: "0700"
+
 - name: Check if data directories are already formatted
   become: true
   ansible.builtin.stat:
@@ -17,7 +25,8 @@
 - name: Generate cluster UUID
   become: true
   become_user: "{{ kafka_user }}"
-  become_flags: "-s /bin/bash"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
   ansible.builtin.command:
     cmd: "{{ kafka__home }}/bin/kafka-storage.sh random-uuid"
   register: kafka__reg_new_uuid
@@ -29,7 +38,8 @@
 - name: Persist cluster UUID to lock file
   become: true
   become_user: "{{ kafka_user }}"
-  become_flags: "-s /bin/bash"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
   ansible.builtin.copy:
     content: "{{ kafka__reg_new_uuid.stdout }}"
     dest: "{{ kafka__uuid_file }}"
@@ -53,7 +63,8 @@
 - name: Format Kafka storage
   become: true
   become_user: "{{ kafka_user }}"
-  become_flags: "-s /bin/bash"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
   ansible.builtin.command:
     cmd: >-
       {{ kafka__home }}/bin/kafka-storage.sh format

--- a/roles/kafka/tasks/cluster.yml
+++ b/roles/kafka/tasks/cluster.yml
@@ -1,0 +1,63 @@
+---
+- name: Check if data directories are already formatted
+  become: true
+  ansible.builtin.stat:
+    path: "{{ item }}/meta.properties"
+  register: kafka__reg_formatted
+  loop: "{{ kafka_data_dirs }}"
+
+- name: Check for existing cluster UUID lock file
+  become: true
+  ansible.builtin.stat:
+    path: "{{ kafka__uuid_file }}"
+  register: kafka__reg_uuid_exists
+  delegate_to: "{{ groups['kafka__group_controller_nodes'] | first }}"
+  run_once: true
+
+- name: Generate cluster UUID
+  become: true
+  become_user: "{{ kafka_user }}"
+  become_flags: "-s /bin/bash"
+  ansible.builtin.command:
+    cmd: "{{ kafka__home }}/bin/kafka-storage.sh random-uuid"
+  register: kafka__reg_new_uuid
+  changed_when: not kafka__reg_uuid_exists.stat.exists
+  delegate_to: "{{ groups['kafka__group_controller_nodes'] | first }}"
+  run_once: true
+  when: not kafka__reg_uuid_exists.stat.exists
+
+- name: Persist cluster UUID to lock file
+  become: true
+  become_user: "{{ kafka_user }}"
+  become_flags: "-s /bin/bash"
+  ansible.builtin.copy:
+    content: "{{ kafka__reg_new_uuid.stdout }}"
+    dest: "{{ kafka__uuid_file }}"
+    mode: "0444"
+  when:
+    - not kafka__reg_uuid_exists.stat.exists
+    - inventory_hostname in groups['kafka__group_controller_nodes']
+
+- name: Read cluster UUID from lock file
+  become: true
+  ansible.builtin.slurp:
+    src: "{{ kafka__uuid_file }}"
+  register: kafka__reg_cluster_uuid
+  delegate_to: "{{ groups['kafka__group_controller_nodes'] | first }}"
+  run_once: true
+
+- name: Set cluster UUID fact
+  ansible.builtin.set_fact:
+    kafka_cluster_id: "{{ kafka__reg_cluster_uuid.content | b64decode | trim }}"
+
+- name: Format Kafka storage
+  become: true
+  become_user: "{{ kafka_user }}"
+  become_flags: "-s /bin/bash"
+  ansible.builtin.command:
+    cmd: >-
+      {{ kafka__home }}/bin/kafka-storage.sh format
+      --config {{ kafka__config_path }}
+      --cluster-id {{ kafka_cluster_id }}
+  changed_when: kafka__reg_formatted.results | map(attribute='stat') | selectattr('exists') | list | length == 0
+  when: kafka__reg_formatted.results | map(attribute='stat') | selectattr('exists') | list | length == 0

--- a/roles/kafka/tasks/config.yml
+++ b/roles/kafka/tasks/config.yml
@@ -1,0 +1,27 @@
+---
+- name: Configure Kafka heap size
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/kafka
+    regexp: "^KAFKA_HEAP_OPTS"
+    line: 'KAFKA_HEAP_OPTS="-Xmx{{ kafka_heap_size }} -Xms{{ kafka_heap_size }}"'
+    create: true
+    mode: "0644"
+  notify: Restart Kafka
+
+- name: Configure Kafka JVM opts
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/kafka
+    regexp: "^KAFKA_OPTS"
+    line: 'KAFKA_OPTS="{{ kafka__opts }}"'
+    create: true
+    mode: "0644"
+  notify: Restart Kafka
+
+- name: Deploy server.properties
+  ansible.builtin.template:
+    src: server.properties.j2
+    dest: "{{ kafka__config_path }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0640"
+  notify: Restart Kafka

--- a/roles/kafka/tasks/firewall.yml
+++ b/roles/kafka/tasks/firewall.yml
@@ -1,0 +1,51 @@
+---
+- name: Populate service facts for firewall detection
+  ansible.builtin.service_facts:
+
+- name: Open Kafka broker port in firewalld
+  ansible.posix.firewalld:
+    port: "9092/tcp"
+    permanent: true
+    state: enabled
+    immediate: true
+  become: true
+  when:
+    - "'broker' in kafka_node_roles"
+    - ansible_facts.services['firewalld.service'] is defined
+    - ansible_facts.services['firewalld.service'].state == 'running'
+
+- name: Open Kafka controller port in firewalld
+  ansible.posix.firewalld:
+    port: "9093/tcp"
+    permanent: true
+    state: enabled
+    immediate: true
+  become: true
+  when:
+    - "'controller' in kafka_node_roles"
+    - ansible_facts.services['firewalld.service'] is defined
+    - ansible_facts.services['firewalld.service'].state == 'running'
+
+- name: Open Kafka broker port in ufw
+  community.general.ufw:
+    rule: allow
+    port: "9092"
+    proto: tcp
+  become: true
+  when:
+    - "'broker' in kafka_node_roles"
+    - ansible_facts.services['ufw.service'] is defined
+    - ansible_facts.services['ufw.service'].state == 'running'
+
+- name: Open Kafka controller port in ufw
+  community.general.ufw:
+    rule: allow
+    port: "9093"
+    proto: tcp
+  become: true
+  when:
+    - "'controller' in kafka_node_roles"
+    - ansible_facts.services['ufw.service'] is defined
+    - ansible_facts.services['ufw.service'].state == 'running'
+
+# code: language=ansible

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -123,3 +123,21 @@
     group: root
     mode: "0644"
   notify: Reload systemd
+
+- name: Install and configure AxonOps agent
+  ansible.builtin.include_role:
+    name: axonops.axonops.agent
+  vars:
+    axon_java_agent: "{{ kafka_axonops_java_agent }}"
+    axon_agent_customer_name: "{{ kafka_axonops_org }}"
+    axon_agent_server_host: "{{ kafka_axonops_server_host }}"
+    axon_agent_key: "{{ kafka_axonops_key | default(omit) }}"
+    axon_agent_server_port: "{{ kafka_axonops_agent_server_port }}"
+    axon_agent_cluster_name: "{{ kafka_axonops_cluster_name | default(omit) }}"
+    # axon_agent_version: "{{ kafka_axonops_agent_version | default(omit) }}"
+    # axon_java_agent_version: "{{ kafka_axonops_java_agent_version | default(omit) }}"
+    axon_agent_kafka_config_directory: "{{ kafka__home }}/bin"
+    axon_agent_kafka_config: ". /usr/share/axonops/axonops-jvm.options"
+    axon_agent_include_service_config: true
+  when: kafka_axonops_agent_enabled | bool
+  tags: axonops_agent

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -13,7 +13,7 @@
     group: "{{ kafka_group }}"
     home: "{{ kafka__home }}"
     create_home: false
-    shell: /sbin/nologin
+    shell: /bin/bash
 
 - name: Install Java
   ansible.builtin.include_role:

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -44,24 +44,37 @@
       }}
   when: kafka_checksum is not defined
 
-- name: Download Kafka
-  ansible.builtin.get_url:
-    url: "{{ kafka__download_url }}"
-    checksum: "{{ kafka_checksum }}"
-    dest: "{{ kafka__download_destination }}"
-    mode: "0644"
-    timeout: 60
-  retries: 3
-  delay: 5
+- name: Check if Kafka is already installed
+  ansible.builtin.stat:
+    path: "{{ kafka__install_path }}"
+  register: kafka__reg_install_check
 
-- name: Extract Kafka
-  ansible.builtin.unarchive:
-    src: "{{ kafka__download_destination }}"
-    dest: "{{ kafka_install_root }}"
-    remote_src: true
-    owner: "{{ kafka_user }}"
-    group: "{{ kafka_group }}"
-    creates: "{{ kafka__install_path }}"
+- name: Download and install Kafka
+  when: not kafka__reg_install_check.stat.exists
+  block:
+    - name: Download Kafka
+      ansible.builtin.get_url:
+        url: "{{ kafka__download_url }}"
+        checksum: "{{ kafka_checksum }}"
+        dest: "{{ kafka__download_destination }}"
+        mode: "0644"
+        timeout: 60
+      retries: 3
+      delay: 5
+
+    - name: Extract Kafka
+      ansible.builtin.unarchive:
+        src: "{{ kafka__download_destination }}"
+        dest: "{{ kafka_install_root }}"
+        remote_src: true
+        owner: "{{ kafka_user }}"
+        group: "{{ kafka_group }}"
+        creates: "{{ kafka__install_path }}"
+
+    - name: Remove downloaded tarball
+      ansible.builtin.file:
+        path: "{{ kafka__download_destination }}"
+        state: absent
 
 - name: Create Kafka home symlink
   ansible.builtin.file:

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -20,6 +20,7 @@
     name: axonops.axonops.java
   vars:
     java_pkg: "{{ kafka__java_pkg }}"
+    java_zulu_version: "{{ kafka_java_version }}"
   when: kafka_java_install | default(true)
 
 - name: Get Kafka checksum from Apache

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -1,0 +1,111 @@
+---
+- name: Ensure Kafka group exists
+  ansible.builtin.group:
+    name: "{{ kafka_group }}"
+    state: present
+    system: true
+
+- name: Ensure Kafka user exists
+  ansible.builtin.user:
+    name: "{{ kafka_user }}"
+    state: present
+    system: true
+    group: "{{ kafka_group }}"
+    home: "{{ kafka__home }}"
+    create_home: false
+    shell: /sbin/nologin
+
+- name: Install Java
+  ansible.builtin.include_role:
+    name: axonops.axonops.java
+  vars:
+    java_pkg: "{{ kafka__java_pkg }}"
+  when: kafka_java_install | default(true)
+
+- name: Get Kafka checksum from Apache
+  ansible.builtin.uri:
+    url: "https://downloads.apache.org/kafka/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz.sha512"
+    return_content: true
+  retries: 3
+  delay: 3
+  register: kafka__reg_checksum
+  run_once: true
+  when: kafka_checksum is not defined
+
+- name: Set checksum fact
+  ansible.builtin.set_fact:
+    kafka_checksum: >-
+      {{
+        kafka__reg_checksum.content
+        | replace('\n', '')
+        | regex_replace('\s{2,}', ' ')
+        | replace('kafka_' ~ kafka_scala_version ~ '-' ~ kafka_version ~ '.tgz: ', 'sha512:')
+      }}
+  when: kafka_checksum is not defined
+
+- name: Download Kafka
+  ansible.builtin.get_url:
+    url: "{{ kafka__download_url }}"
+    checksum: "{{ kafka_checksum }}"
+    dest: "{{ kafka__download_destination }}"
+    mode: "0644"
+    timeout: 60
+  retries: 3
+  delay: 5
+
+- name: Extract Kafka
+  ansible.builtin.unarchive:
+    src: "{{ kafka__download_destination }}"
+    dest: "{{ kafka_install_root }}"
+    remote_src: true
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    creates: "{{ kafka__install_path }}"
+
+- name: Create Kafka home symlink
+  ansible.builtin.file:
+    path: "{{ kafka__home }}"
+    src: "{{ kafka__install_path }}"
+    state: link
+    force: true
+    follow: false
+
+- name: Create Kafka data directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0750"
+  loop: "{{ kafka_data_dirs }}"
+
+- name: Create Kafka log directory
+  ansible.builtin.file:
+    path: "{{ kafka_log_dir }}"
+    state: directory
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0750"
+
+- name: Redirect Kafka service logs to /var/log
+  ansible.builtin.file:
+    path: "{{ kafka__home }}/logs"
+    src: "{{ kafka_log_dir }}"
+    state: link
+    force: true
+    follow: false
+
+- name: Ensure /etc/sysconfig exists
+  ansible.builtin.file:
+    path: /etc/sysconfig
+    state: directory
+    mode: "0755"
+
+- name: Deploy Kafka systemd unit
+  ansible.builtin.template:
+    src: kafka.service.j2
+    dest: /etc/systemd/system/kafka.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -21,6 +21,22 @@
     fail_msg: "kafka_opts must be a list or a string."
   tags: always
 
+- name: Assert AxonOps agent required vars when enabled
+  ansible.builtin.assert:
+    that:
+      - kafka_axonops_org is defined
+      - kafka_axonops_org | length > 0
+      - kafka_axonops_cluster_name is defined
+      - kafka_axonops_cluster_name | length > 0
+    fail_msg: >-
+      kafka_axonops_agent_enabled is true but kafka_axonops_org and/or
+      kafka_axonops_cluster_name are not set. The Kafka Java agent requires
+      both. Set kafka_axonops_org (organisation name), kafka_axonops_cluster_name
+      (cluster identifier shown in AxonOps), and kafka_axonops_key for SaaS at
+      agents.axonops.cloud.
+  when: kafka_axonops_agent_enabled | bool
+  tags: always
+
 - name: Warn about replication factor of 1 in multi-node play
   ansible.builtin.debug:
     msg: >-
@@ -155,6 +171,24 @@
 - name: Flush handlers before service start
   ansible.builtin.meta: flush_handlers
 
+- name: Install and configure AxonOps agent
+  ansible.builtin.include_role:
+    name: axonops.axonops.agent
+  vars:
+    axon_java_agent: "{{ kafka_axonops_java_agent }}"
+    axon_agent_customer_name: "{{ kafka_axonops_org }}"
+    axon_agent_server_host: "{{ kafka_axonops_server_host }}"
+    axon_agent_key: "{{ kafka_axonops_key | default(omit) }}"
+    axon_agent_server_port: "{{ kafka_axonops_agent_server_port }}"
+    axon_agent_cluster_name: "{{ kafka_axonops_cluster_name | default(omit) }}"
+    # axon_agent_version: "{{ kafka_axonops_agent_version | default(omit) }}"
+    # axon_java_agent_version: "{{ kafka_axonops_java_agent_version | default(omit) }}"
+    axon_agent_kafka_config_directory: "{{ kafka__home }}/bin"
+    axon_agent_kafka_config: ". /usr/share/axonops/axonops-jvm.options"
+    axon_agent_include_service_config: true
+  when: kafka_axonops_agent_enabled | bool
+  tags: axonops_agent
+
 - name: Start Kafka service
   ansible.builtin.systemd:
     name: kafka
@@ -188,22 +222,5 @@
     - kafka_start_on_install | bool
     - kafka_topics | length > 0
   tags: topics
-
-- name: Install and configure AxonOps agent
-  ansible.builtin.include_role:
-    name: axonops.axonops.agent
-  vars:
-    axon_java_agent: "{{ kafka_axonops_java_agent }}"
-    axon_agent_customer_name: "{{ kafka_axonops_org }}"
-    axon_agent_server_host: "{{ kafka_axonops_server_host }}"
-    axon_agent_key: "{{ kafka_axonops_key | default(omit) }}"
-    axon_agent_cluster_name: "{{ kafka_axonops_cluster_name | default(omit) }}"
-    axon_agent_version: "{{ kafka_axonops_agent_version | default(omit) }}"
-    axon_java_agent_version: "{{ kafka_axonops_java_agent_version | default(omit) }}"
-    axon_agent_kafka_config_directory: "{{ kafka__home }}/bin"
-    axon_agent_kafka_config: ". /usr/share/axonops/axonops-jvm.options"
-    axon_agent_include_service_config: true
-  when: kafka_axonops_agent_enabled | bool
-  tags: axonops_agent
 
 # code: language=ansible

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -45,6 +45,11 @@
   ansible.builtin.import_tasks: install.yml
   tags: install
 
+- name: Configure firewall
+  ansible.builtin.import_tasks: firewall.yml
+  when: kafka_configure_firewall | bool
+  tags: firewall
+
 - name: Create AxonOps user
   tags: axonops_user
   block:

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -1,0 +1,186 @@
+---
+# ============================================================================
+# Kafka Role - Main Tasks
+# ============================================================================
+
+- name: Assert kafka_node_id is defined
+  ansible.builtin.assert:
+    that:
+      - kafka_node_id is defined
+    fail_msg: >-
+      kafka_node_id must be set for every Kafka host. Add it to your inventory:
+        [kafka]
+        broker1 kafka_node_id=1
+        broker2 kafka_node_id=2
+  tags: always
+
+- name: Assert kafka_opts type
+  ansible.builtin.assert:
+    that:
+      - kafka_opts | type_debug in ["list", "AnsibleUnicode", "str"]
+    fail_msg: "kafka_opts must be a list or a string."
+  tags: always
+
+- name: Warn about replication factor of 1 in multi-node play
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: kafka_replication_factor is 1 but there are {{ ansible_play_hosts | length }}
+      hosts in this play. Consider setting kafka_replication_factor: 3 for production.
+  when:
+    - kafka_replication_factor | int == 1
+    - ansible_play_hosts | length > 1
+  tags: always
+
+# Promote per-host vars to hostvars so the server.properties.j2 template
+# can access them via hostvars[host][...] when building controller.quorum.voters.
+# Play-level vars are not accessible through hostvars; set_fact is required.
+- name: Promote per-host vars to hostvars
+  ansible.builtin.set_fact:
+    kafka_node_id: "{{ kafka_node_id }}"
+    kafka_node_roles: "{{ kafka_node_roles }}"
+    kafka_node_ip: "{{ kafka_node_ip | default(ansible_default_ipv4.address) }}"
+  tags: always
+
+- name: Install Kafka
+  ansible.builtin.import_tasks: install.yml
+  tags: install
+
+- name: Create AxonOps user
+  tags: axonops_user
+  block:
+    - name: Gather group information
+      ansible.builtin.getent:
+        database: group
+      register: kafka__reg_group_info
+
+    - name: Gather axonops user information
+      ansible.builtin.getent:
+        database: passwd
+        key: axonops
+      register: kafka__reg_axonops_user
+      failed_when: false
+
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+      tags: service, always
+
+    - name: Stop axon-agent if axonops user is not in kafka group
+      ansible.builtin.systemd:
+        name: axon-agent
+        state: stopped
+      register: kafka__reg_stop_agent
+      failed_when:
+        - kafka__reg_stop_agent.failed
+        - '"Could not find the requested service" not in kafka__reg_stop_agent.msg'
+      when:
+        - ansible_facts.services['axon-agent.service'] is defined
+        - ansible_facts.services['axon-agent.service'].status | default('not-found') != 'not-found'
+        - kafka__reg_axonops_user.ansible_facts.getent_passwd.axonops is defined
+        - >-
+          'kafka' not in (
+            kafka__reg_group_info.ansible_facts.getent_group
+            | dict2items
+            | selectattr('value.2', 'search', kafka__reg_axonops_user.ansible_facts.getent_passwd.axonops.1)
+            | map(attribute='key')
+            | list
+          )
+
+    - name: Add axonops user to kafka group
+      ansible.builtin.user:
+        name: axonops
+        groups: "{{ kafka_group }}"
+        shell: /bin/bash
+        home: /home/axonops
+
+    - name: Add kafka user to axonops group
+      ansible.builtin.user:
+        name: "{{ kafka_user }}"
+        groups: axonops
+        append: true
+
+    - name: Start axon-agent
+      ansible.builtin.systemd:
+        name: axon-agent
+        state: started
+      when:
+        - ansible_facts.services['axon-agent.service'] is defined
+        - ansible_facts.services['axon-agent.service'].status | default('not-found') != 'not-found'
+
+# Populate dynamic groups before config.yml renders the template that references them.
+- name: Add controller nodes to dynamic group
+  ansible.builtin.add_host:
+    name: "{{ hostvars[item]['inventory_hostname'] }}"
+    group: kafka__group_controller_nodes
+  when: "'controller' in hostvars[item]['kafka_node_roles'] | default(kafka_node_roles)"
+  loop: "{{ ansible_play_hosts }}"
+  changed_when: false
+  loop_control:
+    label: "{{ hostvars[item]['inventory_hostname'] }}"
+  tags: cluster
+
+- name: Add broker nodes to dynamic group
+  ansible.builtin.add_host:
+    name: "{{ hostvars[item]['inventory_hostname'] }}"
+    group: kafka__group_broker_nodes
+  when: "'broker' in hostvars[item]['kafka_node_roles'] | default(kafka_node_roles)"
+  loop: "{{ ansible_play_hosts }}"
+  changed_when: false
+  loop_control:
+    label: "{{ hostvars[item]['inventory_hostname'] }}"
+  tags: cluster
+
+- name: Assert at least one controller node is in the play
+  ansible.builtin.assert:
+    that:
+      - groups['kafka__group_controller_nodes'] | default([]) | length > 0
+    fail_msg: >-
+      No controller nodes found. At least one host must have 'controller' in kafka_node_roles.
+  run_once: true
+  tags: cluster
+
+- name: Configure Kafka
+  ansible.builtin.import_tasks: config.yml
+  tags: config
+
+- name: Initialise KRaft cluster
+  ansible.builtin.import_tasks: cluster.yml
+  tags: cluster
+
+- name: Flush handlers before service start
+  ansible.builtin.meta: flush_handlers
+
+- name: Start Kafka service
+  ansible.builtin.systemd:
+    name: kafka
+    daemon_reload: true
+    enabled: "{{ kafka_start_on_boot | bool }}"
+    state: started
+  when: kafka_start_on_install | bool
+  tags: service
+
+- name: Wait for Kafka controller port
+  ansible.builtin.wait_for:
+    port: 9093
+    timeout: 60
+  when:
+    - kafka_start_on_install | bool
+    - "'controller' in kafka_node_roles"
+  tags: service
+
+- name: Wait for Kafka broker port
+  ansible.builtin.wait_for:
+    port: 9092
+    timeout: 60
+  when:
+    - kafka_start_on_install | bool
+    - "'broker' in kafka_node_roles"
+  tags: service
+
+- name: Create Kafka topics
+  ansible.builtin.import_tasks: topics.yml
+  when:
+    - kafka_start_on_install | bool
+    - kafka_topics | length > 0
+  tags: topics
+
+# code: language=ansible

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -183,4 +183,21 @@
     - kafka_topics | length > 0
   tags: topics
 
+- name: Install and configure AxonOps agent
+  ansible.builtin.include_role:
+    name: axonops.axonops.agent
+  vars:
+    axon_java_agent: "{{ kafka_axonops_java_agent }}"
+    axon_agent_customer_name: "{{ kafka_axonops_org }}"
+    axon_agent_server_host: "{{ kafka_axonops_server_host }}"
+    axon_agent_key: "{{ kafka_axonops_key | default(omit) }}"
+    axon_agent_cluster_name: "{{ kafka_axonops_cluster_name | default(omit) }}"
+    axon_agent_version: "{{ kafka_axonops_agent_version | default(omit) }}"
+    axon_java_agent_version: "{{ kafka_axonops_java_agent_version | default(omit) }}"
+    axon_agent_kafka_config_directory: "{{ kafka__home }}/bin"
+    axon_agent_kafka_config: ". /usr/share/axonops/axonops-jvm.options"
+    axon_agent_include_service_config: true
+  when: kafka_axonops_agent_enabled | bool
+  tags: axonops_agent
+
 # code: language=ansible

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -52,6 +52,7 @@
 
 - name: Create AxonOps user
   tags: axonops_user
+  when: kafka_axonops_agent_enabled | bool
   block:
     - name: Gather group information
       ansible.builtin.getent:

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -171,24 +171,6 @@
 - name: Flush handlers before service start
   ansible.builtin.meta: flush_handlers
 
-- name: Install and configure AxonOps agent
-  ansible.builtin.include_role:
-    name: axonops.axonops.agent
-  vars:
-    axon_java_agent: "{{ kafka_axonops_java_agent }}"
-    axon_agent_customer_name: "{{ kafka_axonops_org }}"
-    axon_agent_server_host: "{{ kafka_axonops_server_host }}"
-    axon_agent_key: "{{ kafka_axonops_key | default(omit) }}"
-    axon_agent_server_port: "{{ kafka_axonops_agent_server_port }}"
-    axon_agent_cluster_name: "{{ kafka_axonops_cluster_name | default(omit) }}"
-    # axon_agent_version: "{{ kafka_axonops_agent_version | default(omit) }}"
-    # axon_java_agent_version: "{{ kafka_axonops_java_agent_version | default(omit) }}"
-    axon_agent_kafka_config_directory: "{{ kafka__home }}/bin"
-    axon_agent_kafka_config: ". /usr/share/axonops/axonops-jvm.options"
-    axon_agent_include_service_config: true
-  when: kafka_axonops_agent_enabled | bool
-  tags: axonops_agent
-
 - name: Start Kafka service
   ansible.builtin.systemd:
     name: kafka

--- a/roles/kafka/tasks/topics.yml
+++ b/roles/kafka/tasks/topics.yml
@@ -8,9 +8,7 @@
   run_once: true
 
 - name: List existing topics
-  become: true
   become_user: "{{ kafka_user }}"
-  become_flags: "-s /bin/bash"
   ansible.builtin.command:
     cmd: "{{ kafka__home }}/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"
   register: kafka__reg_existing_topics
@@ -20,9 +18,7 @@
   run_once: true
 
 - name: Create topics
-  become: true
   become_user: "{{ kafka_user }}"
-  become_flags: "-s /bin/bash"
   ansible.builtin.command:
     cmd: >-
       {{ kafka__home }}/bin/kafka-topics.sh

--- a/roles/kafka/tasks/topics.yml
+++ b/roles/kafka/tasks/topics.yml
@@ -8,6 +8,7 @@
   run_once: true
 
 - name: List existing topics
+  become: true
   become_user: "{{ kafka_user }}"
   become_flags: "-s /bin/bash"
   ansible.builtin.command:
@@ -19,6 +20,7 @@
   run_once: true
 
 - name: Create topics
+  become: true
   become_user: "{{ kafka_user }}"
   become_flags: "-s /bin/bash"
   ansible.builtin.command:

--- a/roles/kafka/tasks/topics.yml
+++ b/roles/kafka/tasks/topics.yml
@@ -1,0 +1,41 @@
+---
+- name: Wait for broker port
+  ansible.builtin.wait_for:
+    host: localhost
+    port: 9092
+    timeout: 60
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true
+
+- name: List existing topics
+  become_user: "{{ kafka_user }}"
+  become_flags: "-s /bin/bash"
+  ansible.builtin.command:
+    cmd: "{{ kafka__home }}/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"
+  register: kafka__reg_existing_topics
+  changed_when: false
+  check_mode: false
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true
+
+- name: Create topics
+  become_user: "{{ kafka_user }}"
+  become_flags: "-s /bin/bash"
+  ansible.builtin.command:
+    cmd: >-
+      {{ kafka__home }}/bin/kafka-topics.sh
+      --create
+      --bootstrap-server localhost:9092
+      --topic {{ item.name }}
+      --partitions {{ item.partitions | default(kafka_num_partitions) }}
+      --replication-factor {{ item.replication_factor | default(kafka_replication_factor) }}
+      {% for k, v in (item.config | default({})) | dictsort %}
+      --config {{ k | replace('_', '.') }}={{ v }}
+      {% endfor %}
+  when: item.name not in kafka__reg_existing_topics.stdout_lines
+  loop: "{{ kafka_topics }}"
+  changed_when: true
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/kafka/templates/kafka.service.j2
+++ b/roles/kafka/templates/kafka.service.j2
@@ -1,0 +1,19 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description=Apache Kafka (KRaft mode)
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/kafka
+User={{ kafka_user }}
+Group={{ kafka_group }}
+WorkingDirectory={{ kafka__home }}
+ExecStart={{ kafka__home }}/bin/kafka-server-start.sh {{ kafka__config_path }}
+ExecStop={{ kafka__home }}/bin/kafka-server-stop.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -19,9 +19,7 @@ inter.broker.listener.name={{ kafka_inter_broker_listener_name }}
 advertised.listeners=PLAINTEXT://{{ kafka_node_ip }}:9092
 {% endif %}
 
-{% if kafka__has_controller | bool %}
 controller.listener.names=CONTROLLER
-{% endif %}
 
 listener.security.protocol.map=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
 

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -1,0 +1,60 @@
+# {{ ansible_managed }}
+
+############################# Server Basics #############################
+
+process.roles={{ kafka_node_roles | join(',') }}
+node.id={{ kafka_node_id }}
+
+# Controller quorum voters: id@host:port for every controller in the cluster
+controller.quorum.voters={% for host in groups['kafka__group_controller_nodes'] %}{{ hostvars[host]['kafka_node_id'] }}@{{ hostvars[host]['kafka_node_ip'] }}:9093{% if not loop.last %},{% endif %}{% endfor %}
+
+
+############################# Socket Server Settings #############################
+
+listeners={{ kafka__effective_listeners | join(',') }}
+
+inter.broker.listener.name={{ kafka_inter_broker_listener_name }}
+
+{% if kafka__has_broker | bool %}
+advertised.listeners=PLAINTEXT://{{ kafka_node_ip }}:9092
+{% endif %}
+
+{% if kafka__has_controller | bool %}
+controller.listener.names=CONTROLLER
+{% endif %}
+
+listener.security.protocol.map=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+
+num.network.threads={{ kafka_num_network_threads }}
+num.io.threads={{ kafka_num_io_threads }}
+socket.send.buffer.bytes={{ kafka_socket_send_buffer_bytes }}
+socket.receive.buffer.bytes={{ kafka_socket_receive_buffer_bytes }}
+socket.request.max.bytes={{ kafka_socket_request_max_bytes }}
+
+############################# Log Basics #############################
+
+log.dirs={{ kafka_data_dirs | join(',') }}
+num.partitions={{ kafka_num_partitions }}
+num.recovery.threads.per.data.dir=1
+
+############################# Internal Topic Settings #############################
+
+offsets.topic.replication.factor={{ kafka_offsets_topic_replication_factor }}
+transaction.state.log.replication.factor={{ kafka_transaction_state_log_replication_factor }}
+transaction.state.log.min.isr={{ kafka_transaction_state_log_min_isr }}
+
+############################# Log Retention Policy #############################
+
+log.retention.hours={{ kafka_log_retention_hours }}
+{% if kafka_log_retention_bytes | int > 0 %}
+log.retention.bytes={{ kafka_log_retention_bytes }}
+{% endif %}
+log.segment.bytes={{ kafka_log_segment_bytes }}
+log.retention.check.interval.ms={{ kafka_log_retention_check_interval_ms }}
+
+{% if kafka_additional_config | length > 0 %}
+############################# Additional Config #############################
+{% for k, v in kafka_additional_config.items() %}
+{{ k }}={{ v }}
+{% endfor %}
+{% endif %}

--- a/roles/kafka/vars/main.yml
+++ b/roles/kafka/vars/main.yml
@@ -11,7 +11,10 @@ kafka__config_path: "{{ kafka__home }}/config/server.properties"
 kafka__uuid_file: "{{ kafka__home }}/CLUSTER_UUID.lock"
 kafka__opts: "{{ (kafka_opts | type_debug == 'list') | ternary(kafka_opts | join(' '), kafka_opts) }}"
 
-kafka__java_pkg: "{{ (ansible_os_family == 'Debian') | ternary('openjdk-' ~ kafka_java_version ~ '-jre-headless', 'java-' ~ kafka_java_version ~ '-openjdk-headless') }}"
+kafka__java_pkg: >-
+  {{ (ansible_os_family == 'Debian') | ternary(
+    'openjdk-' ~ kafka_java_version ~ '-jre-headless',
+    'java-' ~ kafka_java_version ~ '-openjdk-headless') }}
 
 kafka__has_broker: "{{ 'broker' in kafka_node_roles }}"
 kafka__has_controller: "{{ 'controller' in kafka_node_roles }}"

--- a/roles/kafka/vars/main.yml
+++ b/roles/kafka/vars/main.yml
@@ -1,0 +1,25 @@
+---
+# ============================================================================
+# Kafka Role - Internal Variables (not for overriding)
+# ============================================================================
+
+kafka__download_url: "https://archive.apache.org/dist/kafka/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
+kafka__download_destination: "{{ kafka_install_root }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
+kafka__install_path: "{{ kafka_install_root }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}"
+kafka__home: "{{ kafka_install_root }}/kafka"
+kafka__config_path: "{{ kafka__home }}/config/server.properties"
+kafka__uuid_file: "{{ kafka__home }}/CLUSTER_UUID.lock"
+kafka__opts: "{{ (kafka_opts | type_debug == 'list') | ternary(kafka_opts | join(' '), kafka_opts) }}"
+
+kafka__java_pkg: "{{ (ansible_os_family == 'Debian') | ternary('openjdk-' ~ kafka_java_version ~ '-jre-headless', 'java-' ~ kafka_java_version ~ '-openjdk-headless') }}"
+
+kafka__has_broker: "{{ 'broker' in kafka_node_roles }}"
+kafka__has_controller: "{{ 'controller' in kafka_node_roles }}"
+
+kafka__default_listeners: >-
+  {{
+    (['PLAINTEXT://:9092'] if kafka__has_broker | bool else []) +
+    (['CONTROLLER://:9093'] if kafka__has_controller | bool else [])
+  }}
+
+kafka__effective_listeners: "{{ (kafka_listeners | length > 0) | ternary(kafka_listeners, kafka__default_listeners) }}"


### PR DESCRIPTION
## Summary

Adds a new `kafka` role for installing and configuring Apache Kafka in KRaft mode (no ZooKeeper) and extends the `agent` role to support Kafka monitoring.

- **`kafka` role**: tar-based install of Kafka 4.0.0, KRaft cluster bootstrap, supports combined and separated broker/controller topologies, idempotent topic management, optional firewalld/ufw port opening, optional AxonOps agent integration via `kafka_axonops_agent_enabled`
- **`agent` role**: kafka section in `axon-agent.yml.j2`, kafka-server-start.sh JVM injection (idempotent via regexp anchor)
- Java is installed via `axonops.axonops.java`
- Molecule scenario covers single-node combined broker+controller on rockylinux9
- Full docs in `docs/roles/kafka.md`; index, README and CLAUDE.md updated

## Test plan

- [x] molecule converge passes on rockylinux9
- [x] Real VM test: 3-node cluster forms (1 controller + 2 brokers)
- [x] Real VM test: cluster UUID generated once, persisted, reused on rerun
- [x] Real VM test: storage format succeeds; broker-only nodes get `controller.listener.names`
- [x] Real VM test: firewalld ports opened on Rocky (9092/9093)
- [x] ansible-lint clean (only pre-existing meta schema warning shared across roles)
- [x] pre-commit clean
- [ ] Multi-node molecule scenario (separated broker/controller) — follow-up