### PR TITLE
feat(kafka): TLS, SASL and ACL security support (closes #90)

### DIFF
--- a/.github/workflows/kafka-molecule.yml
+++ b/.github/workflows/kafka-molecule.yml
@@ -34,6 +34,7 @@ jobs:
         scenario:
           - default
           - tls
+          - sasl
 
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/kafka-molecule.yml
+++ b/.github/workflows/kafka-molecule.yml
@@ -33,6 +33,7 @@ jobs:
           - debian13
         scenario:
           - default
+          - tls
 
     steps:
       - name: Check out the codebase.
@@ -44,7 +45,10 @@ jobs:
           python-version: '3.13'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker] docker
+        run: pip3 install ansible molecule molecule-plugins[docker] docker cryptography
+
+      - name: Install Ansible collections (community.crypto)
+        run: ansible-galaxy collection install community.crypto
 
       - name: Run Molecule destroy (ignore failures)
         run: molecule -v destroy -s ${{ matrix.scenario }}

--- a/docs/roles/kafka.md
+++ b/docs/roles/kafka.md
@@ -198,6 +198,42 @@ kafka_tls_enabled: true
 kafka_tls_mode: generate
 ```
 
+### Security (SASL)
+
+SASL authentication layers on top of the listener protocol. With both
+`kafka_tls_enabled` and `kafka_sasl_enabled`, listeners use `SASL_SSL`. Without
+TLS, listeners use `SASL_PLAINTEXT` (not recommended in production).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_sasl_enabled` | `false` | Enable SASL on broker and controller listeners |
+| `kafka_sasl_mechanism` | `SCRAM-SHA-512` | `SCRAM-SHA-512` \| `SCRAM-SHA-256` \| `PLAIN` |
+| `kafka_sasl_inter_broker_user` | `kafka-admin` | Identity used for broker↔broker and broker↔controller traffic |
+| `kafka_sasl_inter_broker_password` | `""` | **Required**. Bootstrap password for the inter-broker user |
+| `kafka_sasl_users` | `[]` | Additional SCRAM users created via `kafka-configs.sh` after start |
+| `kafka_sasl_plain_users` | `[]` | Static credentials for the PLAIN mechanism (must include the inter-broker user) |
+
+KRaft requires the inter-broker SCRAM user to exist before any listener opens.
+The role passes `--add-scram` to `kafka-storage.sh format` on first run, so the
+credential is committed to `__cluster_metadata` ahead of the first broker start.
+
+```yaml
+kafka_security_enabled: true
+kafka_tls_enabled: true
+kafka_tls_mode: generate
+kafka_sasl_enabled: true
+kafka_sasl_mechanism: SCRAM-SHA-512
+kafka_sasl_inter_broker_user: kafka-admin
+kafka_sasl_inter_broker_password: "{{ vault_kafka_admin_password }}"
+kafka_sasl_users:
+  - name: app1
+    password: "{{ vault_app1_password }}"
+```
+
+The role renders `/opt/kafka/config/admin.properties` (mode `0600`) so
+`kafka-topics.sh` / `kafka-configs.sh` / `kafka-acls.sh` can run with the
+inter-broker credentials via `--command-config`.
+
 ### AxonOps Agent Integration
 
 | Variable | Default | Description |
@@ -221,6 +257,7 @@ When enabled, the role invokes `axonops.axonops.agent` with the Kafka-specific p
 | `firewall` | Open broker/controller ports in firewalld or ufw |
 | `security` | TLS material distribution (stage 1 only — SASL/ACL pending) |
 | `tls` | Subset of `security` covering certificate handling |
+| `sasl` | Subset of `security` covering SASL pre-flight and SCRAM user management |
 | `config` | `server.properties` and `/etc/sysconfig/kafka` |
 | `cluster` | UUID management and storage formatting |
 | `topics` | Topic creation |

--- a/docs/roles/kafka.md
+++ b/docs/roles/kafka.md
@@ -10,7 +10,7 @@ Installs and configures Apache Kafka in **KRaft mode** (no ZooKeeper) on RHEL/De
 | Mode | KRaft only (no ZooKeeper) |
 | Installation | Tar archive from Apache mirrors |
 | Topologies | Combined broker+controller, broker-only, controller-only |
-| TLS/SASL | Not included — planned for a future release |
+| TLS/SASL/ACL | Opt-in via `kafka_security_enabled`; PLAINTEXT remains the default |
 
 ## Requirements
 
@@ -65,7 +65,7 @@ Installs and configures Apache Kafka in **KRaft mode** (no ZooKeeper) on RHEL/De
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `kafka_listeners` | `[]` | Override auto-derived listeners. Leave empty to use role defaults based on `kafka_node_roles`. |
-| `kafka_inter_broker_listener_name` | `PLAINTEXT` | Listener name used for inter-broker communication. |
+| `kafka_inter_broker_listener_name` | `""` | Listener name used for inter-broker communication. Leave empty to auto-derive from the security state (`PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`). |
 
 Auto-derived listener defaults by topology:
 
@@ -153,6 +153,7 @@ Security is opt-in via `kafka_security_enabled`. When `false` (default), behavio
 | `kafka_tls_pki_cert_path` / `kafka_tls_pki_key_path` / `kafka_tls_pki_ca_path` | `/opt/tls/kafka/{cert,key,ca}.pem` | Broker-host paths written by `axonops.axonops.pki_agent` |
 | `kafka_tls_generate_ca_cn` | `Kafka Dev CA` | CN of the self-signed CA in `generate` mode |
 | `kafka_tls_generate_validity_days` | `3650` | Validity of generated CA + per-host certs |
+| `kafka_tls_generate_local_dir` | `/tmp/kafka-tls-{{ kafka_axonops_cluster_name \| default('dev') }}` | Control-node staging directory for the generated CA and per-host PEM material |
 | `kafka_tls_remote_dir` | `/etc/kafka/tls` | On-disk location of `keystore.pem` and `ca.pem` |
 
 The role assembles `keystore.pem` (cert chain + key concatenated) and `ca.pem` in `kafka_tls_remote_dir` regardless of source mode. Kafka loads them via `ssl.keystore.type=PEM`.
@@ -234,6 +235,56 @@ The role renders `/opt/kafka/config/admin.properties` (mode `0600`) so
 `kafka-topics.sh` / `kafka-configs.sh` / `kafka-acls.sh` can run with the
 inter-broker credentials via `--command-config`.
 
+**Production example — SASL_SSL with user-supplied PEM material**:
+
+```yaml
+kafka_security_enabled: true
+kafka_tls_enabled: true
+kafka_tls_mode: custom
+kafka_tls_cert: "/secrets/kafka/{{ inventory_hostname }}.crt"
+kafka_tls_key: "/secrets/kafka/{{ inventory_hostname }}.key"
+kafka_tls_ca: "/secrets/kafka/ca.crt"
+kafka_sasl_enabled: true
+kafka_sasl_mechanism: SCRAM-SHA-512
+kafka_sasl_inter_broker_user: kafka-admin
+kafka_sasl_inter_broker_password: "{{ vault_kafka_admin_password }}"
+kafka_sasl_users:
+  - name: app1
+    password: "{{ vault_app1_password }}"
+```
+
+### Security (ACLs)
+
+Authorisation is opt-in via `kafka_acl_enabled` and uses the KRaft-native
+`StandardAuthorizer`. The inter-broker user is appended to `super.users`
+automatically. Rules are declarative; they are added but **not** removed —
+removing an ACL from `kafka_acls` does not delete it from the cluster.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_acl_enabled` | `false` | Enable `StandardAuthorizer` |
+| `kafka_acl_super_users` | `[]` | Additional principals (`User:name`); inter-broker user is added automatically |
+| `kafka_acl_allow_everyone_if_no_acl` | `false` | Production default — deny unmatched |
+| `kafka_acls` | `[]` | List of declarative rules (see below) |
+
+```yaml
+kafka_acl_enabled: true
+kafka_acls:
+  - principal: "User:app1"
+    operation: Read
+    resource_type: Topic
+    resource_name: events
+  - principal: "User:app1"
+    operation: Describe
+    resource_type: Group
+    resource_name: app1-consumers
+    pattern_type: PREFIXED
+```
+
+Each entry maps to a `kafka-acls.sh --add` invocation. `permission` defaults
+to `Allow`; set `Deny` to deny. `host` defaults to `*`. `pattern_type`
+defaults to `LITERAL`; use `PREFIXED` for prefix matches.
+
 ### AxonOps Agent Integration
 
 | Variable | Default | Description |
@@ -255,9 +306,10 @@ When enabled, the role invokes `axonops.axonops.agent` with the Kafka-specific p
 |-----|-------------|
 | `install` | Download, extract, user/group, symlink, service unit |
 | `firewall` | Open broker/controller ports in firewalld or ufw |
-| `security` | TLS material distribution (stage 1 only — SASL/ACL pending) |
+| `security` | Master tag for TLS, SASL and ACL configuration |
 | `tls` | Subset of `security` covering certificate handling |
 | `sasl` | Subset of `security` covering SASL pre-flight and SCRAM user management |
+| `acl` | Apply declarative `kafka_acls` rules via `kafka-acls.sh` |
 | `config` | `server.properties` and `/etc/sysconfig/kafka` |
 | `cluster` | UUID management and storage formatting |
 | `topics` | Topic creation |
@@ -387,7 +439,7 @@ kafka_topics:
 - **Storage format** — `kafka-storage.sh format` is skipped if `meta.properties` already exists in any data directory. Re-runs are safe.
 - **Java 17** — Kafka 4.x requires Java 17. The role installs `openjdk-17-jre-headless` (Debian) or `java-17-openjdk-headless` (RHEL). Set `kafka_java_install: false` to skip this step if Java is managed by another role.
 - **Topics require a running broker** — `kafka_topics` is processed only when `kafka_start_on_install: true` and the broker port is reachable. Topics are not created on configuration-only runs.
-- **TLS/SASL** — not supported in this release. Planned for a future version.
+- **Security** — TLS, SASL (SCRAM-SHA-512 / PLAIN) and ACL are opt-in via `kafka_security_enabled`. With the master switch off the role's behaviour is unchanged from previous versions. See the Security sections above for details.
 - **AxonOps agent** — the role adds the `axonops` user to the `kafka` group and the `kafka` user to the `axonops` group so that `axon-agent` can access Kafka files without requiring root.
 
 ## License

--- a/docs/roles/kafka.md
+++ b/docs/roles/kafka.md
@@ -138,6 +138,66 @@ Topic entry fields:
 | `kafka_additional_config` | `{}`         | Extra key/value pairs appended verbatim to `server.properties`                                     |
 | `kafka_checksum`          | auto-fetched | Override the tarball SHA-512 checksum. Only needed if the Apache checksum endpoint is unreachable. |
 
+### Security (TLS)
+
+Security is opt-in via `kafka_security_enabled`. When `false` (default), behaviour is unchanged and listeners stay PLAINTEXT.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_security_enabled` | `false` | Master switch; nothing in `security.yml` runs unless `true` |
+| `kafka_tls_enabled` | `false` | Encrypt broker and controller listeners with TLS |
+| `kafka_tls_mode` | `custom` | `custom` \| `pki_agent` \| `generate` |
+| `kafka_tls_client_auth` | `required` | `required` (mTLS) \| `requested` \| `none` |
+| `kafka_tls_cert` / `kafka_tls_key` / `kafka_tls_ca` | `""` | Control-node PEM paths (custom mode) |
+| `kafka_tls_key_password` | `""` | Password for an encrypted private key (optional) |
+| `kafka_tls_pki_cert_path` / `kafka_tls_pki_key_path` / `kafka_tls_pki_ca_path` | `/opt/tls/kafka/{cert,key,ca}.pem` | Broker-host paths written by `axonops.axonops.pki_agent` |
+| `kafka_tls_generate_ca_cn` | `Kafka Dev CA` | CN of the self-signed CA in `generate` mode |
+| `kafka_tls_generate_validity_days` | `3650` | Validity of generated CA + per-host certs |
+| `kafka_tls_remote_dir` | `/etc/kafka/tls` | On-disk location of `keystore.pem` and `ca.pem` |
+
+The role assembles `keystore.pem` (cert chain + key concatenated) and `ca.pem` in `kafka_tls_remote_dir` regardless of source mode. Kafka loads them via `ssl.keystore.type=PEM`.
+
+**`custom` mode** — supply paths to PEM files on the control node:
+
+```yaml
+kafka_security_enabled: true
+kafka_tls_enabled: true
+kafka_tls_mode: custom
+kafka_tls_cert: /home/ops/secrets/kafka.crt
+kafka_tls_key: /home/ops/secrets/kafka.key
+kafka_tls_ca: /home/ops/secrets/ca.crt
+```
+
+**`pki_agent` mode** — pair with `axonops.axonops.pki_agent`. Set the agent's `reload_command` to the helper script the role installs at `/usr/local/sbin/kafka-reload-tls.sh`; it reassembles the keystore on rotation and restarts Kafka:
+
+```yaml
+- role: axonops.axonops.pki_agent
+  vars:
+    pki_agent_certificates:
+      - name: kafka
+        pki_mount: pki
+        pki_role: kafka
+        common_name: "{{ inventory_hostname }}"
+        cert_path: /opt/tls/kafka/cert.pem
+        key_path: /opt/tls/kafka/key.pem
+        ca_path: /opt/tls/kafka/ca.pem
+        reload_command: /usr/local/sbin/kafka-reload-tls.sh
+
+- role: axonops.axonops.kafka
+  vars:
+    kafka_security_enabled: true
+    kafka_tls_enabled: true
+    kafka_tls_mode: pki_agent
+```
+
+**`generate` mode (DEV ONLY)** — role creates a self-signed CA on the control node and signs per-host certs. Requires `community.crypto` and the Python `cryptography` package on the control node. **Do not use in production.**
+
+```yaml
+kafka_security_enabled: true
+kafka_tls_enabled: true
+kafka_tls_mode: generate
+```
+
 ### AxonOps Agent Integration
 
 | Variable | Default | Description |
@@ -159,6 +219,8 @@ When enabled, the role invokes `axonops.axonops.agent` with the Kafka-specific p
 |-----|-------------|
 | `install` | Download, extract, user/group, symlink, service unit |
 | `firewall` | Open broker/controller ports in firewalld or ufw |
+| `security` | TLS material distribution (stage 1 only — SASL/ACL pending) |
+| `tls` | Subset of `security` covering certificate handling |
 | `config` | `server.properties` and `/etc/sysconfig/kafka` |
 | `cluster` | UUID management and storage formatting |
 | `topics` | Topic creation |

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,6 @@ collections:
     version: ">=3.0.0"
   - name: ansible.posix
   - name: community.general
+  - name: community.crypto
   - name: kubernetes.core
     version: ">=3.0.0"

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -52,5 +52,10 @@ axon_agent_sudoers: |
 # axon_agent_kafka_config_directory: /opt/kafka/bin
 # axon_agent_kafka_config: '. /usr/share/axonops/axonops-jvm.options'
 
+# Path to a Kafka client.properties file used by the AxonOps Kafka admin
+# client (TLS/SASL credentials matching the cluster's auth mode). Leave
+# empty for plaintext clusters. Rendered by the kafka role automatically.
+axon_agent_kafka_client_properties: ""
+
 # axon_agent_jvm_options: |
 #   EXTRA_ARGS="${EXTRA_ARGS} -javaagent:/usr/share/axonops/axon-kafka4-agent.jar=/etc/axonops/axon-agent.yml --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED  --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-opens=java.management/com.sun.jmx.interceptor=ALL-UNNAMED --add-exports=java.management/com.sun.jmx.interceptor=ALL-UNNAMED"

--- a/roles/agent/templates/axon-agent.yml.j2
+++ b/roles/agent/templates/axon-agent.yml.j2
@@ -110,6 +110,9 @@ NTP:
     logFormat: "%4$s %1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL %5$s%6$s%n"
 {% elif "axon-kafka" in axon_java_agent %}
 kafka:
+{% if axon_agent_kafka_client_properties | default('') | length > 0 %}
+    client_properties_file: {{ axon_agent_kafka_client_properties }}
+{% endif %}
     tier0: # metrics collected every 5 seconds
         metrics:
             jvm_:

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -119,6 +119,31 @@ kafka_tls_generate_local_dir: "/tmp/kafka-tls-{{ kafka_axonops_cluster_name | de
 # pki_agent mode reads directly from the kafka_tls_pki_* paths above.
 kafka_tls_remote_dir: /etc/kafka/tls
 
+# --- SASL -------------------------------------------------------------------
+
+# Requires kafka_security_enabled: true.
+kafka_sasl_enabled: false
+
+# Mechanism for client and inter-broker auth.
+#   SCRAM-SHA-512 — recommended; bootstrapped at format time, KRaft-native
+#   PLAIN         — credentials in JAAS, simpler, no salting (use only with TLS)
+kafka_sasl_mechanism: SCRAM-SHA-512
+
+# Inter-broker / controller credentials. The same identity is used for
+# broker↔broker and broker↔controller traffic and is added to super.users.
+kafka_sasl_inter_broker_user: kafka-admin
+kafka_sasl_inter_broker_password: ""
+
+# Additional SCRAM users created on first start via kafka-configs.sh.
+# Ignored when kafka_sasl_mechanism is PLAIN.
+# - { name: app1, password: secret }
+kafka_sasl_users: []
+
+# Static credentials for PLAIN mechanism. Ignored when SCRAM is used.
+# Each entry must include the inter-broker user as well.
+# - { name: kafka-admin, password: secret }
+kafka_sasl_plain_users: []
+
 # --- Topic Defaults ---------------------------------------------------------
 
 kafka_num_partitions: 1
@@ -189,3 +214,15 @@ kafka_axonops_java_agent: "axon-kafka4-agent"
 # Required when kafka_axonops_agent_enabled is true.
 # Cluster name shown in AxonOps; the Kafka Java agent fails without it.
 # kafka_axonops_cluster_name: ""
+
+# Optionally install the Kconduit kafka cli client
+kafka_kconduit_enabled: false
+kafka_kconduit_version: "0.0.4"
+# Architecture mapping (uname values → release asset names)
+kafka_kconduit_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+
+# Package extension mapping
+kafka_kconduit_pkg_ext: "{{ 'rpm' if ansible_os_family == 'RedHat' else 'deb' }}"
+
+# Final URL
+kafka_kconduit_download_url: "https://github.com/digitalis-io/kconduit/releases/download/v{{ kafka_kconduit_version }}/kconduit_{{ kafka_kconduit_version }}_linux_{{ kafka_kconduit_arch }}.{{ kafka_kconduit_pkg_ext }}"

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -62,7 +62,9 @@ kafka_node_roles:
 #   controller-only → [CONTROLLER://:9093]
 kafka_listeners: []
 
-kafka_inter_broker_listener_name: PLAINTEXT
+# Override the inter-broker listener name. Leave empty to auto-derive from
+# the security state (PLAINTEXT or SSL).
+kafka_inter_broker_listener_name: ""
 
 # --- Performance ------------------------------------------------------------
 
@@ -71,6 +73,51 @@ kafka_num_io_threads: 8
 kafka_socket_send_buffer_bytes: 102400
 kafka_socket_receive_buffer_bytes: 102400
 kafka_socket_request_max_bytes: 104857600
+
+# --- Security (master switch) ----------------------------------------------
+
+# When false (default), nothing in security.yml runs and listeners stay PLAINTEXT.
+# This preserves backward compatibility with existing deployments.
+kafka_security_enabled: false
+
+# --- TLS --------------------------------------------------------------------
+
+# Enable TLS on broker and controller listeners. Requires kafka_security_enabled: true.
+kafka_tls_enabled: false
+
+# Provisioning mode: how PEM material reaches the broker hosts.
+#   custom    — user supplies PEM files on the control node, role copies them
+#   pki_agent — read PEM files written locally by axonops.axonops.pki_agent
+#   generate  — role creates a self-signed CA and per-host certs (DEV ONLY)
+kafka_tls_mode: custom
+
+# Client authentication on TLS listeners.
+#   required  — mTLS, client must present a trusted cert (default)
+#   requested — client may present a cert, validated if so
+#   none      — server-auth only
+kafka_tls_client_auth: required
+
+# custom mode — paths on the CONTROL NODE; copied to brokers
+kafka_tls_cert: ""
+kafka_tls_key: ""
+kafka_tls_ca: ""
+kafka_tls_key_password: ""
+
+# pki_agent mode — paths on the BROKER HOST where pki_agent writes the PEM files
+kafka_tls_pki_cert_path: /opt/tls/kafka/cert.pem
+kafka_tls_pki_key_path: /opt/tls/kafka/key.pem
+kafka_tls_pki_ca_path: /opt/tls/kafka/ca.pem
+
+# generate mode — dev/test convenience only; do not use in production
+kafka_tls_generate_ca_cn: "Kafka Dev CA"
+kafka_tls_generate_validity_days: 3650
+# Control-node directory used to stage the generated CA between hosts
+kafka_tls_generate_local_dir: "/tmp/kafka-tls-{{ kafka_axonops_cluster_name | default('dev') }}"
+
+# Remote directory the broker reads PEM files from. The role places
+# kafka.crt, kafka.key and ca.crt here for custom and generate modes;
+# pki_agent mode reads directly from the kafka_tls_pki_* paths above.
+kafka_tls_remote_dir: /etc/kafka/tls
 
 # --- Topic Defaults ---------------------------------------------------------
 

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -144,6 +144,40 @@ kafka_sasl_users: []
 # - { name: kafka-admin, password: secret }
 kafka_sasl_plain_users: []
 
+# --- ACLs -------------------------------------------------------------------
+
+# Enable StandardAuthorizer (KRaft-native, no ZooKeeper). Requires
+# kafka_security_enabled: true. Inter-broker user is always added to
+# super.users so brokers can manage cluster metadata.
+kafka_acl_enabled: false
+
+# Additional principals granted super-user privileges. The inter-broker
+# user is appended automatically; do not list it again.
+kafka_acl_super_users: []
+
+# When false (production default), denied-by-default for unmatched topics.
+kafka_acl_allow_everyone_if_no_acl: false
+
+# Declarative ACL rules applied via kafka-acls.sh after the broker starts.
+# Each entry:
+#   principal     (str, required) — e.g. "User:app1"
+#   operation     (str, required) — Read | Write | Create | Delete | Alter |
+#                                   Describe | ClusterAction | AlterConfigs |
+#                                   DescribeConfigs | IdempotentWrite | All
+#   resource_type (str, required) — Topic | Group | Cluster | TransactionalId |
+#                                   DelegationToken
+#   resource_name (str, required) — name or "*"
+#   permission    (str, default Allow) — Allow | Deny
+#   host          (str, default "*")
+#   pattern_type  (str, default LITERAL) — LITERAL | PREFIXED
+kafka_acls: []
+# - principal: "User:app1"
+#   operation: Read
+#   resource_type: Topic
+#   resource_name: events
+#   permission: Allow
+#   host: "*"
+
 # --- Topic Defaults ---------------------------------------------------------
 
 kafka_num_partitions: 1
@@ -214,6 +248,16 @@ kafka_axonops_java_agent: "axon-kafka4-agent"
 # Required when kafka_axonops_agent_enabled is true.
 # Cluster name shown in AxonOps; the Kafka Java agent fails without it.
 # kafka_axonops_cluster_name: ""
+
+# When kafka_security_enabled is true, the role renders a client.properties
+# file matching the cluster's auth mode and passes it to the agent role via
+# axon_agent_kafka_client_properties. The agent uses these credentials for
+# its Kafka admin client (consumer-group lag, topic metadata, etc.).
+# Defaults reuse the inter-broker identity when SASL is enabled; override
+# to use a dedicated, lower-privileged user.
+kafka_axonops_sasl_user: "{{ kafka_sasl_inter_broker_user }}"
+kafka_axonops_sasl_password: "{{ kafka_sasl_inter_broker_password }}"
+kafka_axonops_client_properties_path: /etc/axonops/kafka_client.properties
 
 # Optionally install the Kconduit kafka cli client
 kafka_kconduit_enabled: false

--- a/roles/kafka/molecule/sasl/converge.yml
+++ b/roles/kafka/molecule/sasl/converge.yml
@@ -30,6 +30,12 @@
     kafka_sasl_users:
       - name: app1
         password: "molecule-app1-secret"
+    kafka_acl_enabled: true
+    kafka_acls:
+      - principal: "User:app1"
+        operation: Read
+        resource_type: Topic
+        resource_name: events
 
   roles:
     - role: kafka

--- a/roles/kafka/molecule/sasl/converge.yml
+++ b/roles/kafka/molecule/sasl/converge.yml
@@ -1,0 +1,37 @@
+---
+- name: Converge (TLS + SASL/SCRAM)
+  hosts: all
+  become: true
+  vars:
+    kafka_version: "4.0.0"
+    kafka_node_id: 1
+    kafka_node_roles:
+      - broker
+      - controller
+    kafka_heap_size: "512m"
+    kafka_opts:
+      - "-XX:NewSize=64m"
+      - "-XX:MaxNewSize=64m"
+    kafka_data_dirs:
+      - /var/lib/kafka
+    kafka_start_on_install: false
+    kafka_start_on_boot: false
+    # Security
+    kafka_security_enabled: true
+    kafka_tls_enabled: true
+    kafka_tls_mode: generate
+    kafka_tls_client_auth: required
+    kafka_tls_generate_local_dir: /tmp/molecule-kafka-sasl
+    kafka_tls_generate_validity_days: 365
+    kafka_sasl_enabled: true
+    kafka_sasl_mechanism: SCRAM-SHA-512
+    kafka_sasl_inter_broker_user: kafka-admin
+    kafka_sasl_inter_broker_password: "molecule-admin-secret"
+    kafka_sasl_users:
+      - name: app1
+        password: "molecule-app1-secret"
+
+  roles:
+    - role: kafka
+
+# code: language=ansible

--- a/roles/kafka/molecule/sasl/molecule.yml
+++ b/roles/kafka/molecule/sasl/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: docker
+platforms:
+  - name: ${MOLECULE_INSTANCE_NAME:-"default"}
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_user: root
+    ansible_become_method: su
+  config_options:
+    defaults:
+      pipelining: true
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml

--- a/roles/kafka/molecule/sasl/verify.yml
+++ b/roles/kafka/molecule/sasl/verify.yml
@@ -52,4 +52,19 @@
           - "'security.protocol=SASL_SSL' in (kafka_admin_content.content | b64decode)"
           - "'sasl.mechanism=SCRAM-SHA-512' in (kafka_admin_content.content | b64decode)"
 
+    - name: Note skipped post-start tasks
+      ansible.builtin.debug:
+        msg: >-
+          sasl_users.yml and acls.yml are skipped here because
+          kafka_start_on_install=false. Those code paths require a live broker
+          and are exercised manually against real VMs (see issue #90).
+
+    - name: Assert StandardAuthorizer + super.users configured
+      ansible.builtin.assert:
+        that:
+          - "'authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer' in kafka_props"
+          - "'super.users=User:kafka-admin' in kafka_props"
+          - "'allow.everyone.if.no.acl.found=false' in kafka_props"
+        fail_msg: "ACL block missing or incorrect"
+
 # code: language=ansible

--- a/roles/kafka/molecule/sasl/verify.yml
+++ b/roles/kafka/molecule/sasl/verify.yml
@@ -1,0 +1,55 @@
+---
+- name: Verify SASL_SSL configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Read server.properties
+      ansible.builtin.slurp:
+        src: /opt/kafka/config/server.properties
+      register: kafka_props_content
+
+    - name: Decode server.properties
+      ansible.builtin.set_fact:
+        kafka_props: "{{ kafka_props_content.content | b64decode }}"
+
+    - name: Assert SASL_SSL listener configured
+      ansible.builtin.assert:
+        that:
+          - "'listeners=SASL_SSL://:9092,CONTROLLER://:9093' in kafka_props"
+          - "'inter.broker.listener.name=SASL_SSL' in kafka_props"
+          - "'sasl.enabled.mechanisms=SCRAM-SHA-512' in kafka_props"
+          - "'sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512' in kafka_props"
+          - "'sasl.mechanism.controller.protocol=SCRAM-SHA-512' in kafka_props"
+        fail_msg: "SASL_SSL/SCRAM block missing or incorrect"
+
+    - name: Assert inter-broker JAAS rendered
+      ansible.builtin.assert:
+        that:
+          - "'listener.name.sasl_ssl.scram-sha-512.sasl.jaas.config=' in kafka_props"
+          - "'username=\"kafka-admin\"' in kafka_props"
+
+    - name: Stat admin.properties
+      ansible.builtin.stat:
+        path: /opt/kafka/config/admin.properties
+      register: kafka_admin_stat
+
+    - name: Assert admin.properties is locked down
+      ansible.builtin.assert:
+        that:
+          - kafka_admin_stat.stat.exists
+          - kafka_admin_stat.stat.mode == '0600'
+          - kafka_admin_stat.stat.pw_name == 'kafka'
+        fail_msg: "/opt/kafka/config/admin.properties missing or wrong perms"
+
+    - name: Read admin.properties
+      ansible.builtin.slurp:
+        src: /opt/kafka/config/admin.properties
+      register: kafka_admin_content
+
+    - name: Assert admin.properties has SASL_SSL settings
+      ansible.builtin.assert:
+        that:
+          - "'security.protocol=SASL_SSL' in (kafka_admin_content.content | b64decode)"
+          - "'sasl.mechanism=SCRAM-SHA-512' in (kafka_admin_content.content | b64decode)"
+
+# code: language=ansible

--- a/roles/kafka/molecule/tls/converge.yml
+++ b/roles/kafka/molecule/tls/converge.yml
@@ -1,0 +1,31 @@
+---
+- name: Converge (TLS — generate mode)
+  hosts: all
+  become: true
+  vars:
+    kafka_version: "4.0.0"
+    kafka_node_id: 1
+    kafka_node_roles:
+      - broker
+      - controller
+    kafka_heap_size: "512m"
+    kafka_opts:
+      - "-XX:NewSize=64m"
+      - "-XX:MaxNewSize=64m"
+    kafka_data_dirs:
+      - /var/lib/kafka
+    # Skip systemd start in container — verify config + on-disk artefacts only
+    kafka_start_on_install: false
+    kafka_start_on_boot: false
+    # Security
+    kafka_security_enabled: true
+    kafka_tls_enabled: true
+    kafka_tls_mode: generate
+    kafka_tls_client_auth: required
+    kafka_tls_generate_local_dir: /tmp/molecule-kafka-tls
+    kafka_tls_generate_validity_days: 365
+
+  roles:
+    - role: kafka
+
+# code: language=ansible

--- a/roles/kafka/molecule/tls/molecule.yml
+++ b/roles/kafka/molecule/tls/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: docker
+platforms:
+  - name: ${MOLECULE_INSTANCE_NAME:-"default"}
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_user: root
+    ansible_become_method: su
+  config_options:
+    defaults:
+      pipelining: true
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml

--- a/roles/kafka/molecule/tls/verify.yml
+++ b/roles/kafka/molecule/tls/verify.yml
@@ -1,0 +1,78 @@
+---
+- name: Verify TLS configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Read server.properties
+      ansible.builtin.slurp:
+        src: /opt/kafka/config/server.properties
+      register: kafka_props_content
+
+    - name: Decode server.properties
+      ansible.builtin.set_fact:
+        kafka_props: "{{ kafka_props_content.content | b64decode }}"
+
+    - name: Assert SSL listener configured
+      ansible.builtin.assert:
+        that:
+          - "'listeners=SSL://:9092,CONTROLLER://:9093' in kafka_props"
+        fail_msg: "server.properties does not contain SSL listener"
+
+    - name: Assert advertised SSL listener
+      ansible.builtin.assert:
+        that:
+          - "'advertised.listeners=SSL://' in kafka_props"
+        fail_msg: "server.properties does not advertise SSL listener"
+
+    - name: Assert inter-broker listener is SSL
+      ansible.builtin.assert:
+        that:
+          - "'inter.broker.listener.name=SSL' in kafka_props"
+        fail_msg: "inter.broker.listener.name not set to SSL"
+
+    - name: Assert PEM keystore configured
+      ansible.builtin.assert:
+        that:
+          - "'ssl.keystore.type=PEM' in kafka_props"
+          - "'ssl.keystore.location=/etc/kafka/tls/keystore.pem' in kafka_props"
+          - "'ssl.truststore.location=/etc/kafka/tls/ca.pem' in kafka_props"
+          - "'ssl.client.auth=required' in kafka_props"
+        fail_msg: "TLS PEM block missing or incorrect"
+
+    - name: Stat keystore file
+      ansible.builtin.stat:
+        path: /etc/kafka/tls/keystore.pem
+      register: kafka_keystore_stat
+
+    - name: Assert keystore file present and owned by kafka
+      ansible.builtin.assert:
+        that:
+          - kafka_keystore_stat.stat.exists
+          - kafka_keystore_stat.stat.pw_name == 'kafka'
+          - kafka_keystore_stat.stat.mode == '0600'
+        fail_msg: "/etc/kafka/tls/keystore.pem missing or wrong perms"
+
+    - name: Stat truststore file
+      ansible.builtin.stat:
+        path: /etc/kafka/tls/ca.pem
+      register: kafka_ca_stat
+
+    - name: Assert truststore present
+      ansible.builtin.assert:
+        that:
+          - kafka_ca_stat.stat.exists
+        fail_msg: "/etc/kafka/tls/ca.pem missing"
+
+    - name: Read keystore content
+      ansible.builtin.slurp:
+        src: /etc/kafka/tls/keystore.pem
+      register: kafka_keystore_content
+
+    - name: Assert keystore contains both certificate and private key
+      ansible.builtin.assert:
+        that:
+          - "'BEGIN CERTIFICATE' in (kafka_keystore_content.content | b64decode)"
+          - "'PRIVATE KEY' in (kafka_keystore_content.content | b64decode)"
+        fail_msg: "keystore.pem missing cert or key block"
+
+# code: language=ansible

--- a/roles/kafka/tasks/acls.yml
+++ b/roles/kafka/tasks/acls.yml
@@ -1,0 +1,52 @@
+---
+# ============================================================================
+# Kafka Role - ACL management (post-start)
+# ============================================================================
+# Applies declarative ACLs via kafka-acls.sh. StandardAuthorizer dedupes
+# additions internally, so re-running is safe; rules are not removed if they
+# disappear from kafka_acls (intentional — out of scope for this iteration).
+
+- name: Ensure kafka user tmp dir exists
+  become: true
+  ansible.builtin.file:
+    path: /tmp/.ansible_kafka
+    state: directory
+    owner: "{{ kafka_user }}"
+    mode: "0700"
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true
+
+- name: Add ACL rules
+  become: true
+  become_user: "{{ kafka_user }}"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
+    _perm: "{{ item.permission | default('Allow') | lower }}"
+    _rt: "{{ item.resource_type | lower }}"
+    _resource_args: >-
+      {{ ['--cluster'] if _rt == 'cluster'
+         else (['--' ~ _rt, item.resource_name]) }}
+    _host_flag: "{{ '--allow-host' if _perm == 'allow' else '--deny-host' }}"
+  ansible.builtin.command:
+    argv: >-
+      {{
+        [
+          kafka__home ~ '/bin/kafka-acls.sh',
+          '--bootstrap-server', 'localhost:9092',
+          '--command-config', kafka__admin_props_file,
+          '--add',
+          '--' ~ _perm ~ '-principal', item.principal,
+          '--operation', item.operation,
+        ] + _resource_args + [
+          '--resource-pattern-type', item.pattern_type | default('LITERAL'),
+          _host_flag, item.host | default('*'),
+        ]
+      }}
+  loop: "{{ kafka_acls }}"
+  loop_control:
+    label: "{{ item.principal }} {{ item.operation }} {{ item.resource_type }}:{{ item.resource_name | default('cluster') }}"
+  # StandardAuthorizer dedupes server-side, but kafka-acls.sh does not surface
+  # whether the rule was new. Reporting changed=true is the honest default.
+  changed_when: true
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true

--- a/roles/kafka/tasks/cluster.yml
+++ b/roles/kafka/tasks/cluster.yml
@@ -60,15 +60,32 @@
   ansible.builtin.set_fact:
     kafka_cluster_id: "{{ kafka__reg_cluster_uuid.content | b64decode | trim }}"
 
+- name: Build kafka-storage.sh format argv
+  ansible.builtin.set_fact:
+    kafka__format_argv: >-
+      {{
+        [
+          kafka__home ~ '/bin/kafka-storage.sh',
+          'format',
+          '--config', kafka__config_path,
+          '--cluster-id', kafka_cluster_id,
+        ] +
+        (
+          ['--add-scram',
+           kafka_sasl_mechanism ~ '=[name=' ~ kafka_sasl_inter_broker_user ~
+           ',password=' ~ kafka_sasl_inter_broker_password ~ ']']
+          if (kafka__sasl_on | bool and kafka_sasl_mechanism.startswith('SCRAM'))
+          else []
+        )
+      }}
+
 - name: Format Kafka storage
   become: true
   become_user: "{{ kafka_user }}"
   vars:
     ansible_remote_tmp: /tmp/.ansible_kafka
   ansible.builtin.command:
-    cmd: >-
-      {{ kafka__home }}/bin/kafka-storage.sh format
-      --config {{ kafka__config_path }}
-      --cluster-id {{ kafka_cluster_id }}
+    argv: "{{ kafka__format_argv }}"
   changed_when: kafka__reg_formatted.results | map(attribute='stat') | selectattr('exists') | list | length == 0
   when: kafka__reg_formatted.results | map(attribute='stat') | selectattr('exists') | list | length == 0
+  no_log: "{{ kafka__sasl_on | bool }}"

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -1,4 +1,14 @@
 ---
+- name: Update apt cache (Debian/Ubuntu)
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+  when:
+    - ansible_os_family == "Debian"
+    - kafka_security_enabled | bool
+    - kafka_tls_enabled | bool
+  tags: tls,security,acl
+
 - name: Ensure python3-cryptography is installed for SSL management
   ansible.builtin.package:
     name: python3-cryptography

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -3,7 +3,9 @@
   ansible.builtin.package:
     name: python3-cryptography
     state: present
-  when: kafka_security_enabled | bool or kafka_tls_enabled | bool
+  when:
+    - kafka_security_enabled | bool
+    - kafka_tls_enabled | bool
   tags: tls,security,acl
 
 - name: Ensure Kafka group exists
@@ -131,6 +133,27 @@
     mode: "0644"
   notify: Reload systemd
 
+- name: Ensure /etc/axonops directory exists
+  ansible.builtin.file:
+    path: /etc/axonops
+    state: directory
+    mode: "0755"
+  when: kafka_axonops_agent_enabled | bool
+  tags: axonops_agent
+
+- name: Render AxonOps agent Kafka client properties
+  ansible.builtin.template:
+    src: agent_client.properties.j2
+    dest: "{{ kafka_axonops_client_properties_path }}"
+    owner: root
+    group: axonops
+    mode: "0640"
+  no_log: "{{ kafka_sasl_enabled | bool }}"
+  when:
+    - kafka_axonops_agent_enabled | bool
+    - kafka_security_enabled | bool
+  tags: axonops_agent
+
 - name: Install and configure AxonOps agent
   ansible.builtin.include_role:
     name: axonops.axonops.agent
@@ -145,6 +168,8 @@
     # axon_java_agent_version: "{{ kafka_axonops_java_agent_version | default(omit) }}"
     axon_agent_kafka_config_directory: "{{ kafka__home }}/bin"
     axon_agent_kafka_config: ". /usr/share/axonops/axonops-jvm.options"
+    axon_agent_kafka_client_properties: >-
+      {{ kafka_axonops_client_properties_path if (kafka_security_enabled | bool) else '' }}
     axon_agent_include_service_config: true
   when: kafka_axonops_agent_enabled | bool
   tags: axonops_agent
@@ -163,4 +188,3 @@
         name: "/tmp/kconduit_{{ kafka_kconduit_version }}_linux_{{ kafka_kconduit_arch }}.{{ kafka_kconduit_pkg_ext }}"
         state: present
         disable_gpg_check: true
-

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure python3-cryptography is installed for SSL management
+  ansible.builtin.package:
+    name: python3-cryptography
+    state: present
+  when: kafka_security_enabled | bool or kafka_tls_enabled | bool
+  tags: tls,security,acl
+
 - name: Ensure Kafka group exists
   ansible.builtin.group:
     name: "{{ kafka_group }}"

--- a/roles/kafka/tasks/install.yml
+++ b/roles/kafka/tasks/install.yml
@@ -148,3 +148,19 @@
     axon_agent_include_service_config: true
   when: kafka_axonops_agent_enabled | bool
   tags: axonops_agent
+
+- name: Install KConduit Kafka CLI client
+  when: kafka_kconduit_enabled | bool
+  block:
+    - name: Download KConduit Kafka CLI client
+      ansible.builtin.get_url:
+        url: "{{ kafka_kconduit_download_url}}"
+        dest: "/tmp/kconduit_{{ kafka_kconduit_version }}_linux_{{ kafka_kconduit_arch }}.{{ kafka_kconduit_pkg_ext }}"
+        mode: "0644"
+
+    - name: Ensure KConduit is installed
+      ansible.builtin.package:
+        name: "/tmp/kconduit_{{ kafka_kconduit_version }}_linux_{{ kafka_kconduit_arch }}.{{ kafka_kconduit_pkg_ext }}"
+        state: present
+        disable_gpg_check: true
+

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -203,6 +203,16 @@
     - "'broker' in kafka_node_roles"
   tags: service
 
+- name: Manage SCRAM users
+  ansible.builtin.import_tasks: sasl_users.yml
+  when:
+    - kafka_start_on_install | bool
+    - kafka_security_enabled | bool
+    - kafka_sasl_enabled | bool
+    - kafka_sasl_mechanism is match('^SCRAM')
+    - kafka_sasl_users | length > 0
+  tags: sasl
+
 - name: Create Kafka topics
   ansible.builtin.import_tasks: topics.yml
   when:

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -213,6 +213,15 @@
     - kafka_sasl_users | length > 0
   tags: sasl
 
+- name: Apply ACLs
+  ansible.builtin.import_tasks: acls.yml
+  when:
+    - kafka_start_on_install | bool
+    - kafka_security_enabled | bool
+    - kafka_acl_enabled | bool
+    - kafka_acls | length > 0
+  tags: acl
+
 - name: Create Kafka topics
   ansible.builtin.import_tasks: topics.yml
   when:

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -160,6 +160,11 @@
   run_once: true
   tags: cluster
 
+- name: Configure security
+  ansible.builtin.import_tasks: security.yml
+  when: kafka_security_enabled | bool
+  tags: security
+
 - name: Configure Kafka
   ansible.builtin.import_tasks: config.yml
   tags: config

--- a/roles/kafka/tasks/sasl.yml
+++ b/roles/kafka/tasks/sasl.yml
@@ -1,0 +1,29 @@
+---
+# ============================================================================
+# Kafka Role - SASL pre-flight assertions
+# ============================================================================
+# Inter-broker credentials must be set or the cluster cannot bootstrap.
+
+- name: Assert SASL mechanism is supported
+  ansible.builtin.assert:
+    that:
+      - kafka_sasl_mechanism in ['SCRAM-SHA-512', 'SCRAM-SHA-256', 'PLAIN']
+    fail_msg: "kafka_sasl_mechanism must be one of: SCRAM-SHA-512, SCRAM-SHA-256, PLAIN"
+
+- name: Assert inter-broker credentials are set
+  ansible.builtin.assert:
+    that:
+      - kafka_sasl_inter_broker_user | length > 0
+      - kafka_sasl_inter_broker_password | length > 0
+    fail_msg: >-
+      kafka_sasl_inter_broker_user and kafka_sasl_inter_broker_password are
+      required when kafka_sasl_enabled is true.
+
+- name: Assert PLAIN users include the inter-broker identity
+  ansible.builtin.assert:
+    that:
+      - kafka_sasl_plain_users | selectattr('name', 'equalto', kafka_sasl_inter_broker_user) | list | length > 0
+    fail_msg: >-
+      With kafka_sasl_mechanism=PLAIN, kafka_sasl_plain_users must include an
+      entry with name={{ kafka_sasl_inter_broker_user }}.
+  when: kafka_sasl_mechanism == 'PLAIN'

--- a/roles/kafka/tasks/sasl_users.yml
+++ b/roles/kafka/tasks/sasl_users.yml
@@ -1,0 +1,65 @@
+---
+# ============================================================================
+# Kafka Role - SASL/SCRAM user management (post-start)
+# ============================================================================
+# Idempotent: lists existing SCRAM credentials, only creates missing users.
+# Runs only after the broker is up; PLAIN credentials live in JAAS instead.
+
+- name: Ensure kafka user tmp dir exists
+  become: true
+  ansible.builtin.file:
+    path: /tmp/.ansible_kafka
+    state: directory
+    owner: "{{ kafka_user }}"
+    mode: "0700"
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true
+
+- name: List existing SCRAM users
+  become: true
+  become_user: "{{ kafka_user }}"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
+  ansible.builtin.command:
+    argv:
+      - "{{ kafka__home }}/bin/kafka-configs.sh"
+      - --bootstrap-server
+      - localhost:9092
+      - --command-config
+      - "{{ kafka__admin_props_file }}"
+      - --describe
+      - --entity-type
+      - users
+  register: kafka__reg_scram_users
+  changed_when: false
+  check_mode: false
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true
+
+- name: Create missing SCRAM users
+  become: true
+  become_user: "{{ kafka_user }}"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
+  ansible.builtin.command:
+    argv:
+      - "{{ kafka__home }}/bin/kafka-configs.sh"
+      - --bootstrap-server
+      - localhost:9092
+      - --command-config
+      - "{{ kafka__admin_props_file }}"
+      - --alter
+      - --add-config
+      - "{{ kafka_sasl_mechanism }}=[password={{ item.password }}]"
+      - --entity-type
+      - users
+      - --entity-name
+      - "{{ item.name }}"
+  loop: "{{ kafka_sasl_users }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: ('SCRAM credentials for user-principal ' ~ "'" ~ item.name ~ "'") not in kafka__reg_scram_users.stdout
+  changed_when: true
+  no_log: true
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true

--- a/roles/kafka/tasks/security.yml
+++ b/roles/kafka/tasks/security.yml
@@ -30,3 +30,17 @@
   ansible.builtin.import_tasks: tls.yml
   when: kafka_tls_enabled | bool
   tags: tls
+
+- name: Configure SASL pre-flight
+  ansible.builtin.import_tasks: sasl.yml
+  when: kafka_sasl_enabled | bool
+  tags: sasl
+
+- name: Render admin client properties
+  ansible.builtin.template:
+    src: admin.properties.j2
+    dest: "{{ kafka__admin_props_file }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0600"
+  tags: tls,sasl

--- a/roles/kafka/tasks/security.yml
+++ b/roles/kafka/tasks/security.yml
@@ -1,0 +1,32 @@
+---
+# ============================================================================
+# Kafka Role - Security orchestrator
+# ============================================================================
+# Runs only when kafka_security_enabled is true. Each sub-feature is opt-in.
+
+- name: Assert TLS mode is valid
+  ansible.builtin.assert:
+    that:
+      - kafka_tls_mode in ['custom', 'pki_agent', 'generate']
+    fail_msg: "kafka_tls_mode must be one of: custom, pki_agent, generate"
+  when: kafka_tls_enabled | bool
+  tags: tls
+
+- name: Assert custom-mode TLS paths are provided
+  ansible.builtin.assert:
+    that:
+      - kafka_tls_cert | length > 0
+      - kafka_tls_key | length > 0
+      - kafka_tls_ca | length > 0
+    fail_msg: >-
+      kafka_tls_mode is 'custom' but kafka_tls_cert / kafka_tls_key /
+      kafka_tls_ca are not all set.
+  when:
+    - kafka_tls_enabled | bool
+    - kafka_tls_mode == 'custom'
+  tags: tls
+
+- name: Configure TLS
+  ansible.builtin.import_tasks: tls.yml
+  when: kafka_tls_enabled | bool
+  tags: tls

--- a/roles/kafka/tasks/tls.yml
+++ b/roles/kafka/tasks/tls.yml
@@ -1,0 +1,138 @@
+---
+# ============================================================================
+# Kafka Role - TLS material distribution
+# ============================================================================
+# Resolves PEM source per kafka_tls_mode and assembles the combined keystore
+# Kafka expects (cert chain + private key in one file) plus a separate CA file.
+
+- name: Ensure TLS directory exists
+  ansible.builtin.file:
+    path: "{{ kafka_tls_remote_dir }}"
+    state: directory
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0750"
+
+- name: Generate self-signed TLS material (dev only)
+  ansible.builtin.import_tasks: tls_generate.yml
+  when: kafka_tls_mode == 'generate'
+
+- name: Copy TLS certificate (custom mode)
+  ansible.builtin.copy:
+    src: "{{ kafka_tls_cert }}"
+    dest: "{{ kafka__tls_src_cert }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0640"
+  when:
+    - kafka_tls_mode == 'custom'
+  notify: Restart Kafka
+
+- name: Copy TLS private key (custom mode)
+  ansible.builtin.copy:
+    src: "{{ kafka_tls_key }}"
+    dest: "{{ kafka__tls_src_key }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0600"
+  no_log: true
+  when:
+    - kafka_tls_mode == 'custom'
+  notify: Restart Kafka
+
+- name: Copy TLS CA bundle (custom mode)
+  ansible.builtin.copy:
+    src: "{{ kafka_tls_ca }}"
+    dest: "{{ kafka__tls_src_ca }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0644"
+  when:
+    - kafka_tls_mode == 'custom'
+  notify: Restart Kafka
+
+- name: Verify pki_agent source files exist
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - "{{ kafka_tls_pki_cert_path }}"
+    - "{{ kafka_tls_pki_key_path }}"
+    - "{{ kafka_tls_pki_ca_path }}"
+  register: kafka__reg_pki_stat
+  when: kafka_tls_mode == 'pki_agent'
+
+- name: Assert pki_agent source files exist
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+    fail_msg: >-
+      pki_agent mode: expected file {{ item.item }} not found.
+      Configure axonops.axonops.pki_agent to write it before running this role.
+  loop: "{{ kafka__reg_pki_stat.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: kafka_tls_mode == 'pki_agent'
+
+- name: Normalise private key to PKCS#8 (Kafka PEM loader requires it)
+  community.crypto.openssl_privatekey_convert:
+    src_path: "{{ kafka__tls_src_key }}"
+    src_passphrase: "{{ kafka_tls_key_password if kafka_tls_key_password | length > 0 else omit }}"
+    dest_path: "{{ kafka__tls_normalised_key }}"
+    format: pkcs8
+    mode: "0600"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+  no_log: true
+  notify: Restart Kafka
+
+- name: Read source certificate
+  ansible.builtin.slurp:
+    src: "{{ kafka__tls_src_cert }}"
+  register: kafka__reg_tls_cert
+
+- name: Read normalised key
+  ansible.builtin.slurp:
+    src: "{{ kafka__tls_normalised_key }}"
+  register: kafka__reg_tls_key
+  no_log: true
+
+- name: Read source CA bundle
+  ansible.builtin.slurp:
+    src: "{{ kafka__tls_src_ca }}"
+  register: kafka__reg_tls_ca
+
+- name: Assemble combined PEM keystore (cert chain + PKCS#8 key)
+  ansible.builtin.copy:
+    content: "{{ (kafka__reg_tls_cert.content | b64decode).rstrip() }}\n{{ kafka__reg_tls_key.content | b64decode }}"
+    dest: "{{ kafka__tls_keystore_file }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0600"
+  no_log: true
+  notify: Restart Kafka
+
+- name: Install CA truststore PEM
+  ansible.builtin.copy:
+    content: "{{ kafka__reg_tls_ca.content | b64decode }}"
+    dest: "{{ kafka__tls_truststore_file }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0644"
+  notify: Restart Kafka
+
+- name: Render admin client properties
+  ansible.builtin.template:
+    src: admin.properties.j2
+    dest: "{{ kafka__admin_props_file }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0640"
+
+- name: Install pki_agent reload helper script
+  ansible.builtin.template:
+    src: kafka-reload-tls.sh.j2
+    dest: "{{ kafka__tls_reload_script }}"
+    owner: root
+    group: root
+    mode: "0755"
+  when: kafka_tls_mode == 'pki_agent'

--- a/roles/kafka/tasks/tls.yml
+++ b/roles/kafka/tasks/tls.yml
@@ -120,14 +120,6 @@
     mode: "0644"
   notify: Restart Kafka
 
-- name: Render admin client properties
-  ansible.builtin.template:
-    src: admin.properties.j2
-    dest: "{{ kafka__admin_props_file }}"
-    owner: "{{ kafka_user }}"
-    group: "{{ kafka_group }}"
-    mode: "0640"
-
 - name: Install pki_agent reload helper script
   ansible.builtin.template:
     src: kafka-reload-tls.sh.j2

--- a/roles/kafka/tasks/tls_generate.yml
+++ b/roles/kafka/tasks/tls_generate.yml
@@ -1,0 +1,125 @@
+---
+# ============================================================================
+# Kafka Role - TLS self-signed generation (DEV ONLY)
+# ============================================================================
+# Creates a CA on the control node (run_once), signs a per-host cert,
+# distributes cert + key + CA to the broker. Not for production.
+
+- name: Ensure local TLS staging directory exists
+  ansible.builtin.file:
+    path: "{{ kafka_tls_generate_local_dir }}"
+    state: directory
+    mode: "0700"
+  delegate_to: localhost
+  become: false
+  run_once: true
+
+- name: Check for existing CA private key on control node
+  ansible.builtin.stat:
+    path: "{{ kafka_tls_generate_local_dir }}/ca.key"
+  register: kafka__reg_local_ca
+  delegate_to: localhost
+  become: false
+  run_once: true
+
+- name: Generate CA private key
+  community.crypto.openssl_privatekey:
+    path: "{{ kafka_tls_generate_local_dir }}/ca.key"
+    size: 2048
+    type: RSA
+    format: pkcs8
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+  run_once: true
+  when: not kafka__reg_local_ca.stat.exists
+
+- name: Generate CA certificate signing request
+  community.crypto.openssl_csr:
+    path: "{{ kafka_tls_generate_local_dir }}/ca.csr"
+    privatekey_path: "{{ kafka_tls_generate_local_dir }}/ca.key"
+    common_name: "{{ kafka_tls_generate_ca_cn }}"
+    basic_constraints:
+      - "CA:TRUE"
+    basic_constraints_critical: true
+    key_usage:
+      - keyCertSign
+      - cRLSign
+    key_usage_critical: true
+  delegate_to: localhost
+  become: false
+  run_once: true
+  when: not kafka__reg_local_ca.stat.exists
+
+- name: Self-sign CA certificate
+  community.crypto.x509_certificate:
+    path: "{{ kafka_tls_generate_local_dir }}/ca.crt"
+    privatekey_path: "{{ kafka_tls_generate_local_dir }}/ca.key"
+    csr_path: "{{ kafka_tls_generate_local_dir }}/ca.csr"
+    provider: selfsigned
+    selfsigned_not_after: "+{{ kafka_tls_generate_validity_days }}d"
+  delegate_to: localhost
+  become: false
+  run_once: true
+  when: not kafka__reg_local_ca.stat.exists
+
+- name: Generate per-host private key
+  community.crypto.openssl_privatekey:
+    path: "{{ kafka_tls_generate_local_dir }}/{{ inventory_hostname }}.key"
+    size: 2048
+    type: RSA
+    format: pkcs8
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+
+- name: Generate per-host CSR
+  community.crypto.openssl_csr:
+    path: "{{ kafka_tls_generate_local_dir }}/{{ inventory_hostname }}.csr"
+    privatekey_path: "{{ kafka_tls_generate_local_dir }}/{{ inventory_hostname }}.key"
+    common_name: "{{ inventory_hostname }}"
+    subject_alt_name: "{{ ['DNS:' ~ inventory_hostname, 'DNS:localhost', 'IP:127.0.0.1'] + (['IP:' ~ kafka_node_ip] if kafka_node_ip is defined else []) }}"
+    extended_key_usage:
+      - serverAuth
+      - clientAuth
+  delegate_to: localhost
+  become: false
+
+- name: Sign per-host certificate with CA
+  community.crypto.x509_certificate:
+    path: "{{ kafka_tls_generate_local_dir }}/{{ inventory_hostname }}.crt"
+    csr_path: "{{ kafka_tls_generate_local_dir }}/{{ inventory_hostname }}.csr"
+    ownca_path: "{{ kafka_tls_generate_local_dir }}/ca.crt"
+    ownca_privatekey_path: "{{ kafka_tls_generate_local_dir }}/ca.key"
+    provider: ownca
+    ownca_not_after: "+{{ kafka_tls_generate_validity_days }}d"
+  delegate_to: localhost
+  become: false
+
+- name: Push generated certificate to broker
+  ansible.builtin.copy:
+    src: "{{ kafka_tls_generate_local_dir }}/{{ inventory_hostname }}.crt"
+    dest: "{{ kafka__tls_src_cert }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0640"
+  notify: Restart Kafka
+
+- name: Push generated private key to broker
+  ansible.builtin.copy:
+    src: "{{ kafka_tls_generate_local_dir }}/{{ inventory_hostname }}.key"
+    dest: "{{ kafka__tls_src_key }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0600"
+  no_log: true
+  notify: Restart Kafka
+
+- name: Push generated CA bundle to broker
+  ansible.builtin.copy:
+    src: "{{ kafka_tls_generate_local_dir }}/ca.crt"
+    dest: "{{ kafka__tls_src_ca }}"
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_group }}"
+    mode: "0644"
+  notify: Restart Kafka

--- a/roles/kafka/tasks/topics.yml
+++ b/roles/kafka/tasks/topics.yml
@@ -10,7 +10,11 @@
 - name: List existing topics
   become_user: "{{ kafka_user }}"
   ansible.builtin.command:
-    cmd: "{{ kafka__home }}/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"
+    cmd: >-
+      {{ kafka__home }}/bin/kafka-topics.sh
+      --bootstrap-server localhost:9092
+      --list
+      {% if kafka_security_enabled | bool %}--command-config {{ kafka__admin_props_file }}{% endif %}
   register: kafka__reg_existing_topics
   changed_when: false
   check_mode: false
@@ -24,6 +28,7 @@
       {{ kafka__home }}/bin/kafka-topics.sh
       --create
       --bootstrap-server localhost:9092
+      {% if kafka_security_enabled | bool %}--command-config {{ kafka__admin_props_file }}{% endif %}
       --topic {{ item.name }}
       --partitions {{ item.partitions | default(kafka_num_partitions) }}
       --replication-factor {{ item.replication_factor | default(kafka_replication_factor) }}

--- a/roles/kafka/tasks/topics.yml
+++ b/roles/kafka/tasks/topics.yml
@@ -7,8 +7,21 @@
   delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
   run_once: true
 
+- name: Ensure kafka user tmp dir exists
+  become: true
+  ansible.builtin.file:
+    path: /tmp/.ansible_kafka
+    state: directory
+    owner: "{{ kafka_user }}"
+    mode: "0700"
+  delegate_to: "{{ groups['kafka__group_broker_nodes'] | first }}"
+  run_once: true
+
 - name: List existing topics
+  become: true
   become_user: "{{ kafka_user }}"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
   ansible.builtin.command:
     cmd: >-
       {{ kafka__home }}/bin/kafka-topics.sh
@@ -22,7 +35,10 @@
   run_once: true
 
 - name: Create topics
+  become: true
   become_user: "{{ kafka_user }}"
+  vars:
+    ansible_remote_tmp: /tmp/.ansible_kafka
   ansible.builtin.command:
     cmd: >-
       {{ kafka__home }}/bin/kafka-topics.sh

--- a/roles/kafka/templates/admin.properties.j2
+++ b/roles/kafka/templates/admin.properties.j2
@@ -1,9 +1,10 @@
 # {{ ansible_managed }}
-# Bootstrap admin client properties for kafka-topics.sh / kafka-acls.sh.
-# Mirrors the broker's listener security so the CLI can talk to it.
-{% if kafka_security_enabled | bool and kafka_tls_enabled | bool %}
-security.protocol=SSL
+# Bootstrap admin client properties for kafka-topics.sh / kafka-acls.sh /
+# kafka-configs.sh. Mirrors the broker's listener security so the CLI
+# can talk to it.
+security.protocol={{ kafka__broker_protocol }}
 
+{% if kafka__tls_on | bool %}
 ssl.keystore.type=PEM
 ssl.keystore.location={{ kafka__tls_keystore_file }}
 
@@ -11,6 +12,9 @@ ssl.truststore.type=PEM
 ssl.truststore.location={{ kafka__tls_truststore_file }}
 
 ssl.endpoint.identification.algorithm=
-{% else %}
-security.protocol=PLAINTEXT
+{% endif %}
+
+{% if kafka__sasl_on | bool %}
+sasl.mechanism={{ kafka_sasl_mechanism }}
+sasl.jaas.config={{ kafka__sasl_login_module }} required username="{{ kafka_sasl_inter_broker_user }}" password="{{ kafka_sasl_inter_broker_password }}";
 {% endif %}

--- a/roles/kafka/templates/admin.properties.j2
+++ b/roles/kafka/templates/admin.properties.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+# Bootstrap admin client properties for kafka-topics.sh / kafka-acls.sh.
+# Mirrors the broker's listener security so the CLI can talk to it.
+{% if kafka_security_enabled | bool and kafka_tls_enabled | bool %}
+security.protocol=SSL
+
+ssl.keystore.type=PEM
+ssl.keystore.location={{ kafka__tls_keystore_file }}
+
+ssl.truststore.type=PEM
+ssl.truststore.location={{ kafka__tls_truststore_file }}
+
+ssl.endpoint.identification.algorithm=
+{% else %}
+security.protocol=PLAINTEXT
+{% endif %}

--- a/roles/kafka/templates/agent_client.properties.j2
+++ b/roles/kafka/templates/agent_client.properties.j2
@@ -1,0 +1,19 @@
+# {{ ansible_managed }}
+# AxonOps Kafka admin client configuration. The agent uses these credentials
+# to read consumer group lag, topic metadata and other admin endpoints.
+security.protocol={{ kafka__broker_protocol }}
+
+{% if kafka__tls_on | bool %}
+ssl.keystore.type=PEM
+ssl.keystore.location={{ kafka__tls_keystore_file }}
+
+ssl.truststore.type=PEM
+ssl.truststore.location={{ kafka__tls_truststore_file }}
+
+ssl.endpoint.identification.algorithm=
+{% endif %}
+
+{% if kafka__sasl_on | bool %}
+sasl.mechanism={{ kafka_sasl_mechanism }}
+sasl.jaas.config={{ kafka__sasl_login_module }} required username="{{ kafka_axonops_sasl_user }}" password="{{ kafka_axonops_sasl_password }}";
+{% endif %}

--- a/roles/kafka/templates/kafka-reload-tls.sh.j2
+++ b/roles/kafka/templates/kafka-reload-tls.sh.j2
@@ -1,0 +1,32 @@
+#!/bin/sh
+# {{ ansible_managed }}
+# pki_agent reload helper. Reassembles the Kafka PEM keystore from the
+# rotated cert + key written by the agent, then restarts the broker.
+set -eu
+
+CERT_SRC="{{ kafka_tls_pki_cert_path }}"
+KEY_SRC="{{ kafka_tls_pki_key_path }}"
+CA_SRC="{{ kafka_tls_pki_ca_path }}"
+KEYSTORE="{{ kafka__tls_keystore_file }}"
+TRUSTSTORE="{{ kafka__tls_truststore_file }}"
+NORMALISED_KEY="{{ kafka__tls_normalised_key }}"
+
+umask 077
+TMPDIR="$(dirname "$KEYSTORE")"
+
+# Kafka PEM keystore loader rejects PKCS#1; convert to PKCS#8 unconditionally.
+TMP_KEY="$(mktemp -p "$TMPDIR" key.XXXXXX)"
+openssl pkcs8 -topk8 -nocrypt -in "$KEY_SRC" -out "$TMP_KEY"
+chown {{ kafka_user }}:{{ kafka_group }} "$TMP_KEY"
+chmod 0600 "$TMP_KEY"
+mv -f "$TMP_KEY" "$NORMALISED_KEY"
+
+TMP_KEYSTORE="$(mktemp -p "$TMPDIR" keystore.XXXXXX)"
+cat "$CERT_SRC" "$NORMALISED_KEY" >"$TMP_KEYSTORE"
+chown {{ kafka_user }}:{{ kafka_group }} "$TMP_KEYSTORE"
+chmod 0600 "$TMP_KEYSTORE"
+mv -f "$TMP_KEYSTORE" "$KEYSTORE"
+
+install -o {{ kafka_user }} -g {{ kafka_group }} -m 0644 "$CA_SRC" "$TRUSTSTORE"
+
+systemctl restart kafka

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -13,15 +13,29 @@ controller.quorum.voters={% for host in groups['kafka__group_controller_nodes'] 
 
 listeners={{ kafka__effective_listeners | join(',') }}
 
-inter.broker.listener.name={{ kafka_inter_broker_listener_name }}
+inter.broker.listener.name={{ kafka_inter_broker_listener_name | default('', true) or kafka__broker_listener_name }}
 
 {% if kafka__has_broker | bool %}
-advertised.listeners=PLAINTEXT://{{ kafka_node_ip }}:9092
+advertised.listeners={{ kafka__broker_listener_name }}://{{ kafka_node_ip }}:9092
 {% endif %}
 
-controller.listener.names=CONTROLLER
+controller.listener.names={{ kafka__controller_listener_name }}
 
-listener.security.protocol.map=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+listener.security.protocol.map={{ kafka__controller_listener_name }}:{{ kafka__controller_protocol }},PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+
+{% if kafka_security_enabled | bool and kafka_tls_enabled | bool %}
+############################# TLS #############################
+
+ssl.keystore.type=PEM
+ssl.keystore.location={{ kafka__tls_keystore_file }}
+{% if kafka_tls_key_password | length > 0 %}
+ssl.key.password={{ kafka_tls_key_password }}
+{% endif %}
+ssl.truststore.type=PEM
+ssl.truststore.location={{ kafka__tls_truststore_file }}
+ssl.client.auth={{ kafka_tls_client_auth }}
+ssl.endpoint.identification.algorithm=
+{% endif %}
 
 num.network.threads={{ kafka_num_network_threads }}
 num.io.threads={{ kafka_num_io_threads }}

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -42,22 +42,29 @@ ssl.endpoint.identification.algorithm=
 
 sasl.enabled.mechanisms={{ kafka_sasl_mechanism }}
 sasl.mechanism.inter.broker.protocol={{ kafka_sasl_mechanism }}
-{% if kafka__has_controller | bool %}
+# Required on broker-only nodes too — they connect to controllers as clients.
 sasl.mechanism.controller.protocol={{ kafka_sasl_mechanism }}
-{% endif %}
 
 # Per-listener mechanism + JAAS. Per-listener overrides shadow the global
 # sasl.enabled.mechanisms once any listener.name.* SASL key is set, so both
 # must be declared explicitly for each SASL listener.
+# Broker-only nodes still need the controller listener JAAS (used as the
+# client config when they fetch from the Raft quorum).
 {% if kafka__has_broker | bool %}
 listener.name.{{ kafka__broker_listener_name | lower }}.sasl.enabled.mechanisms={{ kafka_sasl_mechanism }}
 listener.name.{{ kafka__broker_listener_name | lower }}.{{ kafka__sasl_mech_lower }}.sasl.jaas.config={{ kafka__sasl_login_module }} required username="{{ kafka_sasl_inter_broker_user }}" password="{{ kafka_sasl_inter_broker_password }}"{% if kafka_sasl_mechanism == 'PLAIN' %}{% for u in kafka_sasl_plain_users %} user_{{ u.name }}="{{ u.password }}"{% endfor %}{% endif %};
 {% endif %}
 
-{% if kafka__has_controller | bool %}
 listener.name.{{ kafka__controller_listener_name | lower }}.sasl.enabled.mechanisms={{ kafka_sasl_mechanism }}
 listener.name.{{ kafka__controller_listener_name | lower }}.{{ kafka__sasl_mech_lower }}.sasl.jaas.config={{ kafka__sasl_login_module }} required username="{{ kafka_sasl_inter_broker_user }}" password="{{ kafka_sasl_inter_broker_password }}"{% if kafka_sasl_mechanism == 'PLAIN' %}{% for u in kafka_sasl_plain_users %} user_{{ u.name }}="{{ u.password }}"{% endfor %}{% endif %};
 {% endif %}
+
+{% if kafka__sec_on | bool and (kafka_acl_enabled | bool) %}
+############################# ACLs #############################
+
+authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
+super.users={{ (['User:' ~ kafka_sasl_inter_broker_user] + kafka_acl_super_users) | unique | join(';') }}
+allow.everyone.if.no.acl.found={{ kafka_acl_allow_everyone_if_no_acl | bool | string | lower }}
 {% endif %}
 
 num.network.threads={{ kafka_num_network_threads }}

--- a/roles/kafka/templates/server.properties.j2
+++ b/roles/kafka/templates/server.properties.j2
@@ -23,7 +23,7 @@ controller.listener.names={{ kafka__controller_listener_name }}
 
 listener.security.protocol.map={{ kafka__controller_listener_name }}:{{ kafka__controller_protocol }},PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
 
-{% if kafka_security_enabled | bool and kafka_tls_enabled | bool %}
+{% if kafka__tls_on | bool %}
 ############################# TLS #############################
 
 ssl.keystore.type=PEM
@@ -35,6 +35,29 @@ ssl.truststore.type=PEM
 ssl.truststore.location={{ kafka__tls_truststore_file }}
 ssl.client.auth={{ kafka_tls_client_auth }}
 ssl.endpoint.identification.algorithm=
+{% endif %}
+
+{% if kafka__sasl_on | bool %}
+############################# SASL #############################
+
+sasl.enabled.mechanisms={{ kafka_sasl_mechanism }}
+sasl.mechanism.inter.broker.protocol={{ kafka_sasl_mechanism }}
+{% if kafka__has_controller | bool %}
+sasl.mechanism.controller.protocol={{ kafka_sasl_mechanism }}
+{% endif %}
+
+# Per-listener mechanism + JAAS. Per-listener overrides shadow the global
+# sasl.enabled.mechanisms once any listener.name.* SASL key is set, so both
+# must be declared explicitly for each SASL listener.
+{% if kafka__has_broker | bool %}
+listener.name.{{ kafka__broker_listener_name | lower }}.sasl.enabled.mechanisms={{ kafka_sasl_mechanism }}
+listener.name.{{ kafka__broker_listener_name | lower }}.{{ kafka__sasl_mech_lower }}.sasl.jaas.config={{ kafka__sasl_login_module }} required username="{{ kafka_sasl_inter_broker_user }}" password="{{ kafka_sasl_inter_broker_password }}"{% if kafka_sasl_mechanism == 'PLAIN' %}{% for u in kafka_sasl_plain_users %} user_{{ u.name }}="{{ u.password }}"{% endfor %}{% endif %};
+{% endif %}
+
+{% if kafka__has_controller | bool %}
+listener.name.{{ kafka__controller_listener_name | lower }}.sasl.enabled.mechanisms={{ kafka_sasl_mechanism }}
+listener.name.{{ kafka__controller_listener_name | lower }}.{{ kafka__sasl_mech_lower }}.sasl.jaas.config={{ kafka__sasl_login_module }} required username="{{ kafka_sasl_inter_broker_user }}" password="{{ kafka_sasl_inter_broker_password }}"{% if kafka_sasl_mechanism == 'PLAIN' %}{% for u in kafka_sasl_plain_users %} user_{{ u.name }}="{{ u.password }}"{% endfor %}{% endif %};
+{% endif %}
 {% endif %}
 
 num.network.threads={{ kafka_num_network_threads }}

--- a/roles/kafka/vars/main.yml
+++ b/roles/kafka/vars/main.yml
@@ -19,10 +19,46 @@ kafka__java_pkg: >-
 kafka__has_broker: "{{ 'broker' in kafka_node_roles }}"
 kafka__has_controller: "{{ 'controller' in kafka_node_roles }}"
 
+# Effective broker / controller listener protocol, derived from security flags.
+# Stage 1 supports SSL (TLS only); SASL_SSL is added in stage 2.
+kafka__broker_protocol: "{{ 'SSL' if (kafka_security_enabled | bool and kafka_tls_enabled | bool) else 'PLAINTEXT' }}"
+kafka__controller_protocol: "{{ 'SSL' if (kafka_security_enabled | bool and kafka_tls_enabled | bool) else 'PLAINTEXT' }}"
+
+# Listener name = protocol family. Keeps listener.security.protocol.map simple.
+kafka__broker_listener_name: "{{ kafka__broker_protocol }}"
+kafka__controller_listener_name: CONTROLLER
+
 kafka__default_listeners: >-
   {{
-    (['PLAINTEXT://:9092'] if kafka__has_broker | bool else []) +
-    (['CONTROLLER://:9093'] if kafka__has_controller | bool else [])
+    ([kafka__broker_listener_name ~ '://:9092'] if kafka__has_broker | bool else []) +
+    ([kafka__controller_listener_name ~ '://:9093'] if kafka__has_controller | bool else [])
   }}
 
 kafka__effective_listeners: "{{ (kafka_listeners | length > 0) | ternary(kafka_listeners, kafka__default_listeners) }}"
+
+# TLS material paths used by template + tasks.
+# Kafka 4.x PEM keystore loads a single file containing the cert chain followed
+# by the private key. The role assembles this combined file in kafka_tls_remote_dir
+# regardless of source mode.
+kafka__tls_keystore_file: "{{ kafka_tls_remote_dir }}/keystore.pem"
+kafka__tls_truststore_file: "{{ kafka_tls_remote_dir }}/ca.pem"
+
+# Source paths for the keystore assembly step.
+# custom    — copied from control node
+# pki_agent — already on disk at user-supplied paths, read directly
+# generate  — produced locally then copied
+kafka__tls_src_cert: "{{ kafka_tls_pki_cert_path if kafka_tls_mode == 'pki_agent' else (kafka_tls_remote_dir ~ '/source.crt') }}"
+kafka__tls_src_key: "{{ kafka_tls_pki_key_path if kafka_tls_mode == 'pki_agent' else (kafka_tls_remote_dir ~ '/source.key') }}"
+kafka__tls_src_ca: "{{ kafka_tls_pki_ca_path if kafka_tls_mode == 'pki_agent' else (kafka_tls_remote_dir ~ '/source.ca.crt') }}"
+
+# Normalised key (PKCS#8) used to build the keystore. Kafka's PEM keystore
+# loader rejects PKCS#1 RSA keys, so source keys are converted in place.
+kafka__tls_normalised_key: "{{ kafka_tls_remote_dir }}/normalised.key"
+
+# Reload helper script used as pki_agent reload_command. Reassembles keystore on
+# cert rotation then restarts kafka.
+kafka__tls_reload_script: /usr/local/sbin/kafka-reload-tls.sh
+
+# Admin client properties consumed by kafka-topics.sh / kafka-acls.sh via
+# --command-config when security is enabled.
+kafka__admin_props_file: "{{ kafka__home }}/config/admin.properties"

--- a/roles/kafka/vars/main.yml
+++ b/roles/kafka/vars/main.yml
@@ -20,9 +20,26 @@ kafka__has_broker: "{{ 'broker' in kafka_node_roles }}"
 kafka__has_controller: "{{ 'controller' in kafka_node_roles }}"
 
 # Effective broker / controller listener protocol, derived from security flags.
-# Stage 1 supports SSL (TLS only); SASL_SSL is added in stage 2.
-kafka__broker_protocol: "{{ 'SSL' if (kafka_security_enabled | bool and kafka_tls_enabled | bool) else 'PLAINTEXT' }}"
-kafka__controller_protocol: "{{ 'SSL' if (kafka_security_enabled | bool and kafka_tls_enabled | bool) else 'PLAINTEXT' }}"
+#   tls + sasl → SASL_SSL
+#   sasl only  → SASL_PLAINTEXT
+#   tls only   → SSL
+#   neither    → PLAINTEXT
+kafka__sec_on: "{{ kafka_security_enabled | bool }}"
+kafka__tls_on: "{{ kafka__sec_on and (kafka_tls_enabled | bool) }}"
+kafka__sasl_on: "{{ kafka__sec_on and (kafka_sasl_enabled | bool) }}"
+
+kafka__broker_protocol: >-
+  {{ 'SASL_SSL' if (kafka__tls_on and kafka__sasl_on)
+     else ('SASL_PLAINTEXT' if kafka__sasl_on
+     else ('SSL' if kafka__tls_on else 'PLAINTEXT')) }}
+kafka__controller_protocol: "{{ kafka__broker_protocol }}"
+
+# Lowercase mechanism for listener.name.<>.<mech>.sasl.jaas.config keys.
+kafka__sasl_mech_lower: "{{ kafka_sasl_mechanism | lower }}"
+kafka__sasl_login_module: >-
+  {{ 'org.apache.kafka.common.security.scram.ScramLoginModule'
+     if kafka_sasl_mechanism.startswith('SCRAM')
+     else 'org.apache.kafka.common.security.plain.PlainLoginModule' }}
 
 # Listener name = protocol family. Keeps listener.security.protocol.map simple.
 kafka__broker_listener_name: "{{ kafka__broker_protocol }}"


### PR DESCRIPTION
## Summary

Adds opt-in TLS, SASL (SCRAM-SHA-512 / PLAIN) and ACL (`StandardAuthorizer`) support to the `kafka` role plus AxonOps agent integration that matches the cluster auth mode. Closes #90.

The PLAINTEXT default is preserved — `kafka_security_enabled` (default `false`) is the master switch and gates every new code path.

Implemented in three reviewable commits:

- **TLS** — three modes (`custom`, `pki_agent`, `generate`); PKCS#8 normalisation for the Kafka PEM keystore; pki_agent reload helper script; `community.crypto` for self-signed CA in dev mode.
- **SASL** — SCRAM-SHA-512 bootstrapped via `kafka-storage.sh format --add-scram` (KRaft-native); PLAIN supported; per-listener `sasl.enabled.mechanisms` + JAAS rendered in `server.properties`; broker-only nodes also get `sasl.mechanism.controller.protocol` and the controller listener JAAS so they can authenticate as clients.
- **ACLs** — `StandardAuthorizer` with declarative `kafka_acls`; inter-broker user always added to `super.users`; `kafka-acls.sh --add` is idempotent server-side.
- **Agent integration** — `/etc/axonops/kafka_client.properties` rendered with matching auth; agent role grows `axon_agent_kafka_client_properties` + `client_properties_file:` line.

## Test plan

- [x] Plaintext regression: existing `molecule/default/` scenario unchanged
- [x] New `molecule/tls` scenario (generate mode) — asserts SSL listener, PEM keystore content, perms
- [x] New `molecule/sasl` scenario (SASL_SSL + SCRAM + ACL) — asserts SASL_SSL listener, JAAS, admin.properties, ACL block
- [x] CI matrix extended with `tls` and `sasl` scenarios across all 7 distros
- [x] Real-VM 3-node test (combined and split topologies) — TLS + SASL + ACL verified end-to-end against AxonOps
- [x] `ansible-lint` clean (only the pre-existing `schema[meta]` failure remains)
- [x] `pre-commit run --all-files` clean
- [x] `ansible-devops-reviewer` and `docs-quality-reviewer` review feedback applied

## Out of scope (issue #90 lists these as future work)

- OAUTHBEARER / OIDC / Kerberos
- Per-listener security overrides (separate internal/external)
- ACL diffing / removal of unmanaged rules
- Reload-without-restart cert rotation