### PR TITLE
Ansible timesyncd

### DIFF
--- a/docs/roles/preflight.md
+++ b/docs/roles/preflight.md
@@ -16,7 +16,7 @@ All preflight checks are enabled by default and can be individually disabled by 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `preflight_check_memory` | `true` | Check if system has sufficient memory |
-| `preflight_check_ntp` | `true` | Check if NTP/time synchronization is configured |
+| `preflight_check_ntp` | `true` | Verify active time synchronization (ntpd, chronyd, or systemd-timesyncd) |
 | `preflight_check_os` | `true` | Check if operating system is supported |
 | `preflight_check_cassandra_data_directory` | `true` | Check if Cassandra data directories have sufficient space |
 | `preflight_check_swap` | `true` | Check swap configuration (swap should be disabled for Cassandra) |

--- a/roles/preflight/README.md
+++ b/roles/preflight/README.md
@@ -7,7 +7,7 @@ Runs pre-flight checks on target hosts before deploying Cassandra or other AxonO
 | Variable | Default | Description |
 |---|---|---|
 | `preflight_check_memory` | `true` | Verify minimum memory requirements |
-| `preflight_check_ntp` | `true` | Verify NTP is configured |
+| `preflight_check_ntp` | `true` | Verify active time synchronization (ntpd, chronyd, or systemd-timesyncd) |
 | `preflight_check_os` | `true` | Verify OS is supported |
 | `preflight_check_cassandra_data_directory` | `true` | Verify data directory exists and has space |
 | `preflight_check_swap` | `true` | Verify swap is disabled |

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -1,22 +1,33 @@
 ---
-- name: Check NTP or Chrony
+- name: Check time synchronization (NTP, Chrony, or systemd-timesyncd)
   when: preflight_check_ntp is defined and preflight_check_ntp | bool
   block:
     - name: Check for NTP installation
       ansible.builtin.command: ntpd -v
       register: ntp_check
-      ignore_errors: true
+      changed_when: false
+      failed_when: false
 
     - name: Check for Chrony installation
       ansible.builtin.command: chronyd -v
       register: chrony_check
-      ignore_errors: true
+      changed_when: false
+      failed_when: false
 
-    - name: Assert Chrony is installed
+    - name: Check for systemd-timesyncd (active NTP synchronization)
+      ansible.builtin.command: timedatectl show --property=NTP --value
+      register: timesyncd_check
+      changed_when: false
+      failed_when: false
+
+    - name: Assert a time synchronization service is available
       ansible.builtin.assert:
         that:
-          - chrony_check.rc == 0 or ntp_check.rc == 0
-        fail_msg: "Neither NTP nor Chrony is installed."
+          - >-
+            chrony_check.rc == 0 or ntp_check.rc == 0
+            or (timesyncd_check.rc == 0 and (timesyncd_check.stdout | trim) == 'yes')
+        fail_msg: "No active time synchronization (ntpd, chronyd, or systemd-timesyncd)."
+        success_msg: "Time synchronization is active."
 
 - name: Assert OS is supported
   when: preflight_check_os is defined and preflight_check_os | bool

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -14,7 +14,9 @@
       changed_when: false
       failed_when: false
 
-    - name: Check for systemd-timesyncd (active NTP synchronization)
+    # timedatectl 'show' requires systemd >= 230; on older or non-systemd hosts
+    # this returns a non-zero rc and the check falls back to ntpd/chronyd above.
+    - name: Check for systemd-timesyncd
       ansible.builtin.command: timedatectl show --property=NTP --value
       register: timesyncd_check
       changed_when: false


### PR DESCRIPTION
timesyncd is the new default for ubuntu images and we should check that when ntp/chrony is missing.