### PR TITLE
fix(cassandra): disable unsupported *_password_file keys (#102)

### DIFF
--- a/.github/workflows/cassandra-molecule.yml
+++ b/.github/workflows/cassandra-molecule.yml
@@ -35,7 +35,7 @@ jobs:
           - default
           - shenandoah
           - g1
-          - jks-password-files
+          # - jks-password-files  # disabled: *_password_file keys require Cassandra 6.0+ (CASSANDRA-13428), unsupported by this role — see #102
           - jks-inline-password
           - jks-tls-disabled
           - jks-empty-passwords

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,16 @@ All notable changes to this collection are documented here. The format is based 
 
 ## [Unreleased]
 
-### Changed
-
-- **cassandra**: JKS keystore/truststore passwords are now externalised to
-  `keystore_password_file:` / `truststore_password_file:` references in
-  `cassandra.yaml` by default. Each password is written to a separate mode
-  `0600` file owned by the cassandra user under `cassandra_conf_dir`, covering
-  both `server_encryption_options` and `client_encryption_options`. Set
-  `cassandra_use_password_files: false` to restore the previous inline
-  behaviour. See [docs/roles/cassandra.md](docs/roles/cassandra.md#password-files-default).
-  ([#99](https://github.com/axonops/axonops-ansible-collection/issues/99))
-
 ### Fixed
+
+- **cassandra**: `cassandra_use_password_files` no longer breaks Cassandra
+  startup. The `keystore_password_file:` / `truststore_password_file:` keys it
+  emitted were added in Apache Cassandra 6.0 (CASSANDRA-13428) and do not exist
+  in 4.1.x / 5.0.x, the only versions this role supports — Cassandra rejected
+  them with `Invalid yaml. Please remove properties [...]` and refused to boot.
+  The feature now defaults to `false` and is force-disabled with a warning if
+  enabled, falling back to inline `keystore_password:` / `truststore_password:`.
+  ([#102](https://github.com/axonops/axonops-ansible-collection/issues/102))
 
 - **cassandra**: `cassandra.yaml` template and the new password-file task have
   always read `cassandra_ssl_keystore_pass`, but the defaults file only

--- a/roles/cassandra/README.md
+++ b/roles/cassandra/README.md
@@ -30,24 +30,11 @@ cassandra_ssl_truststore_file: /etc/cassandra/conf/.truststore
 cassandra_ssl_truststore_pass: "{{ vault_truststore_password }}"
 ```
 
-#### Password files (default behaviour — changed)
+#### Password files (`cassandra_use_password_files`) — not supported
 
-> **⚠ Behaviour change.** Prior to this release, the role embedded JKS passwords inline in `cassandra.yaml`. By default the role now writes each password to a separate mode `0600` file owned by the cassandra user and emits `keystore_password_file:` / `truststore_password_file:` keys in `cassandra.yaml` instead. This affects both `server_encryption_options` and `client_encryption_options`. No data is lost; running the role updates `cassandra.yaml` and Cassandra is restarted via the existing handler.
+> **⚠ Not supported on this role's Cassandra versions.** The `keystore_password_file:` / `truststore_password_file:` keys were added in **Apache Cassandra 6.0** ([CASSANDRA-13428](https://issues.apache.org/jira/browse/CASSANDRA-13428)) and do **not** exist in Cassandra 4.1.x or 5.0.x — the only versions this role supports. On those versions Cassandra rejects the keys at startup with `Invalid yaml. Please remove properties [truststore_password_file, keystore_password_file]` and refuses to boot.
 
-Password files are written only when (a) the relevant TLS path is enabled and (b) the configured password is non-empty. Four files are written by default under `cassandra_conf_dir`:
-
-- `server_keystore_passwordfile.txt`
-- `server_truststore_passwordfile.txt`
-- `client_keystore_passwordfile.txt`
-- `client_truststore_passwordfile.txt`
-
-To opt out (keep the legacy inline behaviour):
-
-```yaml
-cassandra_use_password_files: false
-```
-
-See [docs/roles/cassandra.md](../../docs/roles/cassandra.md#password-files-default) for the full variable reference.
+For this reason `cassandra_use_password_files` defaults to `false` and the role **force-disables it with a warning** if you set it `true`, falling back to inline `keystore_password:` / `truststore_password:`. The variable is retained only so the path can be re-enabled once Cassandra 6.0+ becomes a supported target. Keep JKS passwords out of source control with Ansible Vault instead.
 
 ### PEM-based TLS (Cassandra 4.1+)
 

--- a/roles/cassandra/defaults/main.yml
+++ b/roles/cassandra/defaults/main.yml
@@ -237,12 +237,17 @@ cassandra_ssl_client_require_endpoint_verification: false
 cassandra_ssl_client_encryption_protocol: "TLS"
 
 # Externalised keystore/truststore passwords (cassandra.yaml *_password_file keys)
-# When true (default), the role writes the JKS passwords to mode 0600 files
-# under cassandra_conf_dir and emits keystore_password_file / truststore_password_file
-# in cassandra.yaml — keeping plaintext passwords out of the world-readable config.
-# Set to false to revert to inline keystore_password / truststore_password keys.
-# No files are written if TLS is disabled or the relevant password is empty.
-cassandra_use_password_files: true
+#
+# NOT SUPPORTED in this role. The keystore_password_file / truststore_password_file
+# keys were added in Apache Cassandra 6.0 (CASSANDRA-13428) and do not exist in
+# Cassandra 4.1.x or 5.0.x — the only versions this role supports. Enabling them on
+# those versions makes cassandra.yaml invalid and Cassandra refuses to start with:
+#   "Invalid yaml. Please remove properties [truststore_password_file, keystore_password_file]"
+#
+# This feature is therefore disabled by default and force-disabled by the role on any
+# supported version (the role warns if you set it true). It is kept only so the path
+# can be re-enabled once Cassandra 6.0+ becomes a supported target.
+cassandra_use_password_files: false
 cassandra_ssl_keystore_password_file: "{{ cassandra_conf_dir | default('/etc/cassandra') }}/server_keystore_passwordfile.txt"
 cassandra_ssl_truststore_password_file: "{{ cassandra_conf_dir | default('/etc/cassandra') }}/server_truststore_passwordfile.txt"
 cassandra_ssl_client_keystore_password_file: "{{ cassandra_conf_dir | default('/etc/cassandra') }}/client_keystore_passwordfile.txt"

--- a/roles/cassandra/molecule/jks-password-files/converge.yml
+++ b/roles/cassandra/molecule/jks-password-files/converge.yml
@@ -1,4 +1,10 @@
 ---
+# DISABLED — removed from CI (.github/workflows/cassandra-molecule.yml).
+# The keystore_password_file / truststore_password_file keys this scenario
+# exercises were added in Apache Cassandra 6.0 (CASSANDRA-13428) and do not
+# exist in 4.1.x / 5.0.x, the only versions this role supports. The role now
+# force-disables cassandra_use_password_files, so this scenario's assertions no
+# longer hold. Retained for re-enablement once Cassandra 6.0+ is supported. See #102.
 - name: Converge — cassandra role with JKS TLS and password files (default)
   hosts: all
   vars:

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -37,6 +37,28 @@
     cassandra_ssl_client_ssl_context_factory | default('') == 'pem'
   tags: always
 
+# keystore_password_file / truststore_password_file were added in Cassandra 6.0
+# (CASSANDRA-13428) and do not exist in 4.1.x / 5.0.x. Emitting them there makes
+# cassandra.yaml invalid and Cassandra refuses to start. This role only supports
+# 4.1.x / 5.0.x, so force the feature off and warn if it was enabled.
+- name: Warn and disable unsupported cassandra_use_password_files
+  when: cassandra_use_password_files | default(false) | bool
+  tags: always
+  block:
+    - name: Warn that cassandra_use_password_files is unsupported on this version
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: cassandra_use_password_files is enabled, but the
+          keystore_password_file / truststore_password_file keys it relies on were
+          introduced in Apache Cassandra 6.0 (CASSANDRA-13428) and do not exist in
+          {{ cassandra_version }}. They would make cassandra.yaml invalid and prevent
+          Cassandra from starting. Disabling the feature and falling back to inline
+          keystore_password / truststore_password keys.
+
+    - name: Force-disable cassandra_use_password_files on unsupported versions
+      ansible.builtin.set_fact:
+        cassandra_use_password_files: false
+
 - name: Import vars for 4.1
   ansible.builtin.include_vars: cassandra-4.1.yml
   when: cassandra_version.startswith('4.1')

--- a/roles/cassandra/templates/4.1.x/cassandra.yaml.j2
+++ b/roles/cassandra/templates/4.1.x/cassandra.yaml.j2
@@ -1511,7 +1511,7 @@ server_encryption_options:
 {% else %}
   # Set to a valid keystore if internode_encryption is dc, rack or all
   keystore: {{ cassandra_ssl_internode_keystore_file | default('conf/.keystore ')}}
-{% if cassandra_use_password_files | default(true) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_keystore_pass | default('') != '' %}
+{% if cassandra_use_password_files | default(false) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_keystore_pass | default('') != '' %}
   keystore_password_file: {{ cassandra_ssl_keystore_password_file }}
 {% elif cassandra_ssl_keystore_pass is defined and cassandra_ssl_keystore_pass != '' %}
   keystore_password: {{ cassandra_ssl_keystore_pass }}
@@ -1524,7 +1524,7 @@ server_encryption_options:
 #  outbound_keystore_password: cassandra
   # Set to a valid trustore if require_client_auth is true
   truststore: {{ cassandra_ssl_truststore_file | default("") }}
-{% if cassandra_use_password_files | default(true) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_truststore_pass | default('') != '' %}
+{% if cassandra_use_password_files | default(false) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_truststore_pass | default('') != '' %}
   truststore_password_file: {{ cassandra_ssl_truststore_password_file }}
 {% else %}
   truststore_password: {{ cassandra_ssl_truststore_pass | default("") }}
@@ -1579,7 +1579,7 @@ client_encryption_options:
 {% else %}
   # Set keystore and keystore_password to valid keystores if enabled is true
   keystore: {{ cassandra_ssl_client_keystore_file | default("conf/.keystore") }}
-{% if cassandra_use_password_files | default(true) | bool and cassandra_ssl_client_encryption_enabled | default(false) | bool and cassandra_ssl_client_keystore_pass | default('') != '' %}
+{% if cassandra_use_password_files | default(false) | bool and cassandra_ssl_client_encryption_enabled | default(false) | bool and cassandra_ssl_client_keystore_pass | default('') != '' %}
   keystore_password_file: {{ cassandra_ssl_client_keystore_password_file }}
 {% else %}
   keystore_password: {{ cassandra_ssl_client_keystore_pass | default("cassandra") }}

--- a/roles/cassandra/templates/5.0.x/cassandra.yaml.j2
+++ b/roles/cassandra/templates/5.0.x/cassandra.yaml.j2
@@ -1833,7 +1833,7 @@ server_encryption_options:
 {% else %}
   # Set to a valid keystore if internode_encryption is dc, rack or all
   keystore: {{ cassandra_ssl_internode_keystore_file | default('conf/.keystore ')}}
-{% if cassandra_use_password_files | default(true) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_keystore_pass | default('') != '' %}
+{% if cassandra_use_password_files | default(false) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_keystore_pass | default('') != '' %}
   keystore_password_file: {{ cassandra_ssl_keystore_password_file }}
 {% elif cassandra_ssl_keystore_pass is defined and cassandra_ssl_keystore_pass != '' %}
   keystore_password: {{ cassandra_ssl_keystore_pass }}
@@ -1846,7 +1846,7 @@ server_encryption_options:
 #  outbound_keystore_password: cassandra
   # Set to a valid trustore if require_client_auth is true
   truststore: {{ cassandra_ssl_truststore_file | default("") }}
-{% if cassandra_use_password_files | default(true) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_truststore_pass | default('') != '' %}
+{% if cassandra_use_password_files | default(false) | bool and cassandra_ssl_internode_encryption | default('none') != 'none' and cassandra_ssl_truststore_pass | default('') != '' %}
   truststore_password_file: {{ cassandra_ssl_truststore_password_file }}
 {% else %}
   truststore_password: {{ cassandra_ssl_truststore_pass | default("") }}
@@ -1901,7 +1901,7 @@ client_encryption_options:
 {% else %}
   # Set keystore and keystore_password to valid keystores if enabled is true
   keystore: {{ cassandra_ssl_client_keystore_file | default("conf/.keystore") }}
-{% if cassandra_use_password_files | default(true) | bool and cassandra_ssl_client_encryption_enabled | default(false) | bool and cassandra_ssl_client_keystore_pass | default('') != '' %}
+{% if cassandra_use_password_files | default(false) | bool and cassandra_ssl_client_encryption_enabled | default(false) | bool and cassandra_ssl_client_keystore_pass | default('') != '' %}
   keystore_password_file: {{ cassandra_ssl_client_keystore_password_file }}
 {% else %}
   keystore_password: {{ cassandra_ssl_client_keystore_pass | default("cassandra") }}
@@ -1909,7 +1909,7 @@ client_encryption_options:
   # Set trustore and truststore_password if require_client_auth is true
 {% if cassandra_ssl_client_truststore_file is defined and cassandra_ssl_client_truststore_file != '' %}
   truststore: "{{ cassandra_ssl_client_truststore_file }}"
-{% if cassandra_use_password_files | default(true) | bool and cassandra_ssl_client_encryption_enabled | default(false) | bool and cassandra_ssl_client_truststore_pass | default('') != '' %}
+{% if cassandra_use_password_files | default(false) | bool and cassandra_ssl_client_encryption_enabled | default(false) | bool and cassandra_ssl_client_truststore_pass | default('') != '' %}
   truststore_password_file: {{ cassandra_ssl_client_truststore_password_file }}
 {% else %}
   truststore_password: "{{ cassandra_ssl_client_truststore_pass | default('cassandra') }}"


### PR DESCRIPTION
## Summary
Fixes #102. The `cassandra_use_password_files` feature emitted `keystore_password_file:` / `truststore_password_file:` keys into `cassandra.yaml`. Those keys were added in **Apache Cassandra 6.0** ([CASSANDRA-13428](https://issues.apache.org/jira/browse/CASSANDRA-13428)) and do **not** exist in 4.1.x / 5.0.x — the only versions this role supports. Cassandra rejected the config at startup with `Invalid yaml. Please remove properties [truststore_password_file, keystore_password_file]` and refused to boot.

## Changes
- `defaults/main.yml`: `cassandra_use_password_files` now defaults to `false`; comment documents the 6.0+/unsupported constraint.
- `tasks/main.yml`: new guard block warns and force-disables the flag at runtime (via `set_fact`) before config render, so templates fall back to inline `keystore_password:` / `truststore_password:`.
- `templates/4.1.x` + `templates/5.0.x`: aligned `default()` guards with the new `false` default (removes latent re-break risk flagged in review).
- CI: `jks-password-files` molecule scenario removed from the matrix; scenario retained on disk with a disabled header for re-enablement once Cassandra 6.0+ is supported.
- `README.md` + `CHANGELOG.md` updated.

## Related
- Supersedes #101 (password-file write failed when config dir missing) — moot now the feature is off by default.
- Partially reverts the cassandra.yaml changes from #99 / #100 (commit ba52dfb).

## Test plan
- [ ] `molecule test` (default, g1, shenandoah, jks-inline-password, jks-tls-disabled, jks-empty-passwords) passes on rockylinux9, rockylinux10, ubuntu2204, ubuntu2404, debian12, debian13
- [ ] Confirm rendered `cassandra.yaml` with TLS enabled contains inline `keystore_password:` and **no** `*_password_file` keys
- [ ] Confirm warning fires + feature disables when `cassandra_use_password_files: true` is set