### PR TITLE
feat(alert_rule): add chart_query_index for selecting non-first chart…

### DIFF
--- a/plugins/modules/alert_rule.py
+++ b/plugins/modules/alert_rule.py
@@ -60,6 +60,22 @@ options:
             - It can be read from the environment variable AXONOPS_CLUSTER_TYPE.
         required: false
         type: str
+    chart_query_index:
+        description:
+            - Index into the referenced chart's details.queries[] array used to derive
+              the alert's metric expression. Defaults to 0, which matches the
+              long-standing implicit behaviour and is the right choice for the vast
+              majority of charts (a single query, or the first query being the one to
+              alert on).
+            - Set to 1 (or higher) when the chart has multiple queries and the one
+              you want to alert on is NOT the first. For example, a chart that
+              displays both "up" and "down" series side-by-side will have two
+              queries; only one is meaningful for a given alert.
+            - Out-of-range values fail the task with a clear message instead of
+              silently picking the wrong series.
+        required: false
+        type: int
+        default: 0
 
 '''
 
@@ -102,7 +118,8 @@ def run_module():
         'consistency': {'type': 'list', 'default': [],
                         'choices': ['', 'ALL', 'ANY', 'ONE', 'TWO', 'THREE', 'SERIAL', 'QUORUM', 'EACH_QUORUM',
                                     'LOCAL_ONE', 'LOCAL_QUORUM', 'LOCAL_SERIAL']},
-        'keyspace': {'type': 'list', 'default': []}
+        'keyspace': {'type': 'list', 'default': []},
+        'chart_query_index': {'type': 'int', 'default': 0}
     })
 
     module = AnsibleModule(
@@ -177,6 +194,20 @@ def run_module():
         # if it is not a list, we have a single element, we can use it directly
         new_chart = new_charts
 
+    # Validate chart_query_index once, here, while the chart is in hand.
+    # Both downstream uses (the metric-derivation branch below and the
+    # expression-build path further down) index into the same queries[] array,
+    # so checking once keeps the two paths consistent and the error message
+    # close to the YAML field that controls it.
+    chart_query_index = module.params['chart_query_index']
+    _chart_queries = (new_chart.get('details') or {}).get('queries') or []
+    if _chart_queries and not (0 <= chart_query_index < len(_chart_queries)):
+        module.fail_json(
+            msg=f"chart_query_index {chart_query_index} out of range for chart "
+                f"'{module.params['chart']}' (has {len(_chart_queries)} queries)"
+        )
+        return
+
     raw_query = None
     # check if it is an event base alert rather than metrics
     new_chart_filters = None
@@ -187,7 +218,7 @@ def run_module():
     # if it is not, get the chart query if not specified in the params
     elif not module.params['metric']:
         try:
-            raw_query = new_chart['details']['queries'][0]['query']
+            raw_query = new_chart['details']['queries'][chart_query_index]['query']
         except (TypeError, IndexError):
             module.fail_json(msg='Failed getting the metric query from the specified chart')
             return
@@ -343,7 +374,9 @@ def run_module():
     new_data_normalized = normalize_numbers(new_data)
     # Set up alert expression
     if new_chart['details']['queries']:
-        orig_query = new_chart['details']['queries'][0]['query']
+        # chart_query_index was bounds-checked once near the top, when new_chart
+        # was first finalized; safe to index directly.
+        orig_query = new_chart['details']['queries'][chart_query_index]['query']
         pattern = re.compile(r"\{([^}]*)\}")
         match = pattern.search(orig_query)
         label_filters_str = match.group(1)

--- a/tests/test_alert_rule_chart_query_index.yml
+++ b/tests/test_alert_rule_chart_query_index.yml
@@ -1,0 +1,138 @@
+---
+# Integration test for the chart_query_index parameter on
+# axonops.axonops.alert_rule. Mirrors the env-var convention used by
+# tests/run_dashboard_tests.sh.
+#
+# Three behaviours exercised:
+#   1. Default (chart_query_index: 0 implicit) — matches long-standing behaviour.
+#   2. Explicit non-zero index — alert's stored expr is derived from queries[N],
+#      not queries[0]. Verified against a chart with multiple queries.
+#   3. Out-of-range index — task fails with a clear error message instead of
+#      silently picking the wrong query (or IndexError).
+#
+# Required env (same as run_dashboard_tests.sh):
+#   AXONOPS_TOKEN, AXONOPS_TEST_URL, AXONOPS_TEST_ORG, AXONOPS_TEST_CLUSTER
+- name: Test alert_rule chart_query_index parameter
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    base_url: "{{ base_url | default('http://localhost:3000') }}"
+    org: "{{ org | default('testorg') }}"
+    cluster: "{{ cluster | default('test-cluster') }}"
+    # The "UP vs Down endpoints" chart on the Overview dashboard ships with
+    # two queries — use it as our two-query fixture. If the test cluster's
+    # dashboard schema changes, point these at any chart known to have at
+    # least two queries.
+    multi_query_chart_dashboard: Overview
+    multi_query_chart_title: UP vs Down endpoints
+    test_alert_prefix: ansible-test-alert_rule-chart_query_index
+
+  tasks:
+    # --- 1. Default index (queries[0]) — behaviour preserved ------------------
+    - name: Create alert with default chart_query_index (== 0)
+      axonops.axonops.alert_rule:
+        org: "{{ org }}"
+        cluster: "{{ cluster }}"
+        base_url: "{{ base_url }}"
+        name: "{{ test_alert_prefix }} default-idx"
+        dashboard: "{{ multi_query_chart_dashboard }}"
+        chart: "{{ multi_query_chart_title }}"
+        operator: ">="
+        warning_value: 1
+        critical_value: 2
+        duration: 5m
+        present: true
+      register: r_default
+
+    - name: Default-index alert should have been created (or no-op if already current)
+      ansible.builtin.assert:
+        that:
+          - r_default.failed is not defined or not r_default.failed
+
+    # --- 2. Explicit non-zero index (queries[1]) — new behaviour --------------
+    - name: Create alert with chart_query_index=1 (the second query)
+      axonops.axonops.alert_rule:
+        org: "{{ org }}"
+        cluster: "{{ cluster }}"
+        base_url: "{{ base_url }}"
+        name: "{{ test_alert_prefix }} explicit-idx-1"
+        dashboard: "{{ multi_query_chart_dashboard }}"
+        chart: "{{ multi_query_chart_title }}"
+        chart_query_index: 1
+        operator: ">="
+        warning_value: 1
+        critical_value: 2
+        duration: 5m
+        present: true
+      register: r_explicit_one
+
+    - name: Fetch the stored alerts to verify the two exprs differ
+      ansible.builtin.uri:
+        url: "{{ base_url }}/api/v1/alert-rules/{{ org }}/cassandra/{{ cluster }}"
+        method: GET
+        headers: "{{ {'Authorization': 'Bearer ' + lookup('env', 'AXONOPS_TOKEN')} if lookup('env', 'AXONOPS_TOKEN') else {} }}"
+        return_content: true
+        status_code: 200
+      register: stored_alerts
+
+    - name: Extract the two test alerts by name
+      ansible.builtin.set_fact:
+        alert_default: "{{ stored_alerts.json.metricrules | selectattr('alert', 'equalto', test_alert_prefix + ' default-idx') | first }}"
+        alert_idx_one: "{{ stored_alerts.json.metricrules | selectattr('alert', 'equalto', test_alert_prefix + ' explicit-idx-1') | first }}"
+
+    - name: Default-index and idx=1 alerts MUST have DIFFERENT exprs
+      ansible.builtin.assert:
+        that:
+          - alert_default.expr != alert_idx_one.expr
+        fail_msg: |
+          chart_query_index=1 produced the same expr as the default. Either the
+          chart has only one query (bad fixture) or the module didn't honor the
+          new param.
+          default: {{ alert_default.expr }}
+          idx=1:   {{ alert_idx_one.expr }}
+
+    # --- 3. Out-of-range index — task must fail clearly -----------------------
+    - name: Attempt alert with out-of-range chart_query_index
+      axonops.axonops.alert_rule:
+        org: "{{ org }}"
+        cluster: "{{ cluster }}"
+        base_url: "{{ base_url }}"
+        name: "{{ test_alert_prefix }} out-of-range-idx"
+        dashboard: "{{ multi_query_chart_dashboard }}"
+        chart: "{{ multi_query_chart_title }}"
+        chart_query_index: 99
+        operator: ">="
+        warning_value: 1
+        critical_value: 2
+        duration: 5m
+        present: true
+      register: r_oor
+      failed_when: false
+
+    - name: Out-of-range index should fail with the bounds-check error
+      ansible.builtin.assert:
+        that:
+          - r_oor.failed
+          - "'chart_query_index 99 out of range' in (r_oor.msg | default(''))"
+        fail_msg: |
+          Expected the task to fail with an out-of-range message; got
+          failed={{ r_oor.failed | default(false) }}, msg={{ r_oor.msg | default('<none>') }}
+
+    # --- Cleanup --------------------------------------------------------------
+    - name: Remove the two created test alerts
+      axonops.axonops.alert_rule:
+        org: "{{ org }}"
+        cluster: "{{ cluster }}"
+        base_url: "{{ base_url }}"
+        name: "{{ item }}"
+        dashboard: "{{ multi_query_chart_dashboard }}"
+        chart: "{{ multi_query_chart_title }}"
+        operator: ">="
+        warning_value: 1
+        critical_value: 2
+        duration: 5m
+        present: false
+      loop:
+        - "{{ test_alert_prefix }} default-idx"
+        - "{{ test_alert_prefix }} explicit-idx-1"


### PR DESCRIPTION
… queries

The alert_rule module previously hardcoded queries[0] in two places — once in the metric-derivation path (~line 190) and again in the expression-build path (~line 346). That made it impossible to alert on a chart whose meaningful query was not the first one (e.g. an "UP vs DOWN" panel where queries[0] is the UP series but you want to alert on DOWN).

Add chart_query_index (int, default 0). Bounds-check it once, where the new_chart is finalized, so both downstream paths can index without revalidating. Default of 0 keeps all existing behaviour identical.

Out-of-range values fail the task with a clear message instead of an IndexError or silently picking the wrong series.

Integration test in tests/test_alert_rule_chart_query_index.yml exercises the default, an explicit non-zero index, and the out-of-range failure mode against a chart with multiple queries.