### PR TITLE
feat(cassandra): add Apache Cassandra 3.11 support (closes #108)

### DIFF
--- a/.github/workflows/cassandra-molecule.yml
+++ b/.github/workflows/cassandra-molecule.yml
@@ -39,6 +39,7 @@ jobs:
           - jks-inline-password
           - jks-tls-disabled
           - jks-empty-passwords
+          - cassandra-3.11
 
     steps:
       - name: Check out the codebase.
@@ -72,7 +73,7 @@ jobs:
           MOLECULE_INSTANCE_NAME: cassandra-${{ matrix.scenario }}-${{ matrix.distro }}
 
       - name: Run Molecule verify
-        if: contains(matrix.scenario, 'jks-')
+        if: contains(matrix.scenario, 'jks-') || matrix.scenario == 'cassandra-3.11'
         run: molecule -v verify -s ${{ matrix.scenario }}
         env:
           PY_COLORS: '1'
@@ -82,7 +83,7 @@ jobs:
           MOLECULE_INSTANCE_NAME: cassandra-${{ matrix.scenario }}-${{ matrix.distro }}
 
       - name: Run Molecule idempotence
-        if: contains(matrix.scenario, 'jks-')
+        if: contains(matrix.scenario, 'jks-') || matrix.scenario == 'cassandra-3.11'
         run: molecule -v idempotence -s ${{ matrix.scenario }}
         env:
           PY_COLORS: '1'

--- a/.github/workflows/cassandra-molecule.yml
+++ b/.github/workflows/cassandra-molecule.yml
@@ -22,6 +22,7 @@ jobs:
     name: Molecule Cassandra (${{ matrix.scenario }} / ${{ matrix.distro }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         distro:
           - rockylinux9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this collection are documented here. The format is based 
 
 ## [Unreleased]
 
+### Added
+
+- **cassandra**: Apache Cassandra 3.11 support. The role now installs and
+  configures Cassandra 3.11.x via tar, using a dedicated `templates/3.11.x/`
+  set (legacy `cassandra.yaml` schema with `*_in_ms` / `*_in_mb` keys, single
+  `jvm.options` file, no `auto_optimise_*` / `commitlog_sync_group_window`
+  keys). The `java` role automatically picks Java 8 when `cassandra_version`
+  starts with `3.11`. New molecule scenario `cassandra-3.11` and example
+  playbook `examples/cassandra-3.11.yml`.
+  ([#108](https://github.com/axonops/axonops-ansible-collection/issues/108))
+
 ### Fixed
 
 - **cassandra**: `cassandra_use_password_files` no longer breaks Cassandra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ All notable changes to this collection are documented here. The format is based 
   (`Ubuntu, Debian, CentOS, RedHat, Rocky, Amazon`). All other roles
   already branch on `ansible_os_family`, which Amazon Linux reports
   as `RedHat`, so no further changes were required.
+- **cassandra**: jemalloc install on Amazon Linux. The
+  `epel-release` package is not available in the Amazon Linux
+  repositories (`No package epel-release available.`); skip that
+  task on Amazon Linux and install `jemalloc` directly from the
+  distribution's own repos (where it is shipped by default on
+  Amazon Linux 2023 and via `amazon-linux-extras` on AL2).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ All notable changes to this collection are documented here. The format is based 
   playbook `examples/cassandra-3.11.yml`.
   ([#108](https://github.com/axonops/axonops-ansible-collection/issues/108))
 
+### Added
+
+- **preflight**: Amazon Linux added to the supported-OS allowlist
+  (`Ubuntu, Debian, CentOS, RedHat, Rocky, Amazon`). All other roles
+  already branch on `ansible_os_family`, which Amazon Linux reports
+  as `RedHat`, so no further changes were required.
+
 ### Fixed
 
 - **cassandra**: `cassandra_jemalloc_enabled` default used Jinja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Fixed
 
+- **cassandra 3.11 cassandra.yaml**: socket buffer + index summary keys no
+  longer emit empty values that crash Cassandra at boot
+  (`Can not set int field … to null value` /
+  `internode_send_buff_size_in_bytes:`). The 3.11 vars file used to seed
+  `cassandra_{rpc,internode}_{send,recv}_buff_size_in_bytes` and
+  `cassandra_index_summary_capacity_in_mb` with `""`; the template's
+  `is defined` guard then evaluated true and rendered the key with no
+  value. The vars are now left undefined and the template guards also
+  reject empty strings, so Cassandra falls back to its JVM defaults
+  (or `net.ipv4.tcp_{r,w}mem` for the socket buffers). Also fixed two
+  mismatched-variable bugs carried over from the reference template:
+  `internode_recv_buff_size_in_bytes` was guarded by
+  `cassandra_rpc_recv_buff_size_in_bytes`, and `broadcast_address` was
+  guarded by `cassandra_memtable_broadcast_address`.
+
 - **cassandra 3.11 cassandra.yaml**: `key_cache_save_period`,
   `row_cache_save_period`, and `counter_cache_save_period` are now
   rendered as integer seconds. The shared role defaults are duration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Fixed
 
+- **cassandra**: `cassandra_jemalloc_enabled` default used Jinja
+  statement syntax (`{% true if ... %}`) instead of an expression,
+  causing `Encountered unknown tag 'true'` whenever the variable was
+  evaluated (e.g. by the jemalloc install task's `when:`). Now an
+  expression: `{{ ansible_facts['os_family'] == 'Debian' }}`.
+
 - **cassandra 3.11 cassandra.yaml**: unit-aware conversion of friendly
   defaults to legacy `_in_ms` / `_in_kb` / `_in_mb` /
   `_megabits_per_sec` keys. The shared role defaults carry units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Fixed
 
+- **cassandra 3.11 jvm.options**: render `-XX:ParallelGCThreads` and
+  `-XX:ConcGCThreads` only when set to a value `> 0`. Java 8's G1GC rejects
+  `0` for these (`The flag -XX:+UseG1GC can not be combined with
+  -XX:ParallelGCThreads=0`) and refuses to start. When unset (or `0`), the
+  lines are emitted as comments so the JVM auto-picks based on core count.
+
 - **cassandra**: `cassandra_use_password_files` no longer breaks Cassandra
   startup. The `keystore_password_file:` / `truststore_password_file:` keys it
   emitted were added in Apache Cassandra 6.0 (CASSANDRA-13428) and do not exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Fixed
 
+- **cassandra 3.11 cassandra.yaml**: unit-aware conversion of friendly
+  defaults to legacy `_in_ms` / `_in_kb` / `_in_mb` /
+  `_megabits_per_sec` keys. The shared role defaults carry units
+  (`"2s"`, `"30m"`, `"10MiB"`, `"24MiB/s"`); the previous 3.11 vars
+  file stripped non-digits with `regex_replace`, so `"2s"` rendered as
+  `write_request_timeout_in_ms: 2` (= 2 ms), `"30m"` as
+  `roles_validity_in_ms: 30`, etc. This silently broke timeouts and
+  triggered `Back-pressure window size must be >= 10` at boot because
+  the back-pressure window derives from `write_request_timeout_in_ms`.
+  The 3.11 vars file now multiplies each value by the unit's base
+  count (`s=1000`, `m=60000`, `MiB=1`, `MiB/s -> *8` for the
+  megabits-per-sec stream throughput vars) so user overrides in
+  either form land on the correct integer 3.11 expects.
+
 - **cassandra 3.11 cassandra.yaml**: stop seeding
   `cassandra_native_transport_port_ssl` with `9142` in the 3.11 vars
   file. Cassandra 3.11 refuses to start when the key is set unless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ All notable changes to this collection are documented here. The format is based 
   starts with `3.11`. New molecule scenario `cassandra-3.11` and example
   playbook `examples/cassandra-3.11.yml`.
   ([#108](https://github.com/axonops/axonops-ansible-collection/issues/108))
-
-### Added
-
 - **preflight**: Amazon Linux added to the supported-OS allowlist
   (`Ubuntu, Debian, CentOS, RedHat, Rocky, Amazon`). All other roles
   already branch on `ansible_os_family`, which Amazon Linux reports
@@ -92,10 +89,10 @@ All notable changes to this collection are documented here. The format is based 
 
 - **cassandra**: `cassandra_use_password_files` no longer breaks Cassandra
   startup. The `keystore_password_file:` / `truststore_password_file:` keys it
-  emitted were added in Apache Cassandra 6.0 (CASSANDRA-13428) and do not exist
-  in 4.1.x / 5.0.x, the only versions this role supports — Cassandra rejected
-  them with `Invalid yaml. Please remove properties [...]` and refused to boot.
-  The feature now defaults to `false` and is force-disabled with a warning if
+  emitted were introduced in Apache Cassandra 6.0 (CASSANDRA-13428) and are
+  not recognised by 3.11.x, 4.1.x, or 5.0.x — Cassandra rejected them with
+  `Invalid yaml. Please remove properties [...]` and refused to boot. The
+  feature now defaults to `false` and is force-disabled with a warning if
   enabled, falling back to inline `keystore_password:` / `truststore_password:`.
   ([#102](https://github.com/axonops/axonops-ansible-collection/issues/102))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Fixed
 
+- **cassandra 3.11 cassandra.yaml**: `key_cache_save_period`,
+  `row_cache_save_period`, and `counter_cache_save_period` are now
+  rendered as integer seconds. The shared role defaults are duration
+  strings (`"4h"` / `"0s"` / `"2h"`) accepted by 4.1.x / 5.0.x but
+  rejected by 3.11 (`Cannot create property=key_cache_save_period …
+  For input string: "4h"`). The 3.11 vars file converts the friendly
+  defaults — and any user override in the same form — to seconds
+  before the template renders them.
+
 - **cassandra 3.11 jvm.options**: render `-XX:ParallelGCThreads` and
   `-XX:ConcGCThreads` only when set to a value `> 0`. Java 8's G1GC rejects
   `0` for these (`The flag -XX:+UseG1GC can not be combined with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Fixed
 
+- **cassandra 3.11 cassandra.yaml**: stop seeding
+  `cassandra_native_transport_port_ssl` with `9142` in the 3.11 vars
+  file. Cassandra 3.11 refuses to start when the key is set unless
+  `client_encryption_options.enabled: true` (`Encryption must be
+  enabled in client_encryption_options for native_transport_port_ssl`).
+  The variable is now undefined by default and must be opted into
+  alongside client encryption.
+
 - **cassandra 3.11 cassandra.yaml**: socket buffer + index summary keys no
   longer emit empty values that crash Cassandra at boot
   (`Can not set int field … to null value` /

--- a/docs/roles/cassandra.md
+++ b/docs/roles/cassandra.md
@@ -25,6 +25,34 @@ dynamic_snitch_reset_interval: 600000ms
 
 Before running this playbook for Cassandra 5.0, review the variables in [roles/cassandra/defaults/main.yml](../../roles/cassandra/defaults/main.yml) and compare them against the appropriate template.
 
+## Cassandra 3.11 support
+
+Cassandra 3.11.x is supported via the dedicated `templates/3.11.x/` set and the
+`vars/cassandra-3.11.yml` variable file. The role uses the **legacy**
+`cassandra.yaml` schema (`_in_ms`, `_in_mb`, `_in_kb` suffixed keys) and a
+single `jvm.options` file (4.x/5.x split into `jvm-server.options` plus
+client/version files). The 4.x/5.x-only keys (`auto_optimise_*`,
+`commitlog_sync_group_window`, `repaired_data_tracking_*`,
+`corrupted_tombstone_strategy`, `full_query_logging_options`,
+`client_encryption_options.optional` is preserved but unused on 3.11) are
+**not emitted** for 3.11.
+
+Cassandra 3.11 requires Java 8. The `axonops.axonops.java` role detects
+`cassandra_version.startswith('3.11')` and selects the Java 8 package
+automatically. Set `java_use_zulu: true` on RHEL 10+ / Debian 13+ where the
+base repositories no longer ship OpenJDK 8.
+
+```yaml
+cassandra_version: 3.11.17
+cassandra_cluster_name: legacy-cluster
+cassandra_dc: dc1
+cassandra_rack: rack1
+cassandra_max_heap_size: 4G
+```
+
+See [examples/cassandra-3.11.yml](../../examples/cassandra-3.11.yml) for a
+complete playbook including AxonOps agent.
+
 ## Role Variables
 
 ### Basic Configuration

--- a/examples/cassandra-3.11.yml
+++ b/examples/cassandra-3.11.yml
@@ -1,0 +1,46 @@
+- name: Deploy Cassandra 3.11 with AxonOps Agent
+  hosts: cassandra
+  become: true
+  vars:
+    install_cassandra: true
+    # Use the Cassandra 3.11-specific AxonOps agent JAR
+    axon_java_agent: "axon-cassandra3.11-agent"
+    axon_agent_version: "2.0.21"
+    axon_java_agent_version: "1.0.14"
+    # Cassandra 3.11 — legacy cassandra.yaml schema, requires Java 8.
+    cassandra_version: 3.11.17
+    cassandra_cluster_name: axonops
+    cassandra_dc: default
+    cassandra_rack: rack1
+    # This is the AxonOps Server host, it can be localhost or the IP of the AxonOps Server.
+    # Leave empty if you want to use the SaaS environment.
+    axon_agent_server_host: "{{ groups['axon-server'] | first }}"
+    axon_agent_tls_mode: "disabled"
+    axon_agent_customer_name: "mycompany"
+    cassandra_seeds: "{{ groups['cassandra'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | join(',') }}"
+
+  pre_tasks:
+    # This is only for this example to work, please review your firewall settings and requirements
+    - name: "Stop firewalld"
+      ansible.builtin.systemd:
+        name: firewalld
+        enabled: false
+        state: stopped
+      when: ansible_os_family == 'RedHat'
+      failed_when: false
+
+  roles:
+    - role: axonops.axonops.preflight
+      tags: preflight
+    - role: axonops.axonops.java
+      # cassandra_version starts with '3.11', so the java role automatically
+      # picks Java 8. Set java_use_zulu: true on EL10+/Debian13+ where the
+      # base repos no longer ship OpenJDK 8.
+      tags: java
+    - role: axonops.axonops.agent
+      tags: agent
+    - role: axonops.axonops.cassandra
+      tags: cassandra
+      when: install_cassandra is defined and install_cassandra
+
+# code: language=ansible

--- a/roles/cassandra/README.md
+++ b/roles/cassandra/README.md
@@ -2,6 +2,22 @@
 
 Installs and configures Apache Cassandra from the Apache tar distribution.
 
+## Supported versions
+
+| Cassandra | Java | `cassandra.yaml` schema | JVM options file(s) |
+|-----------|------|--------------------------|---------------------|
+| 3.11.x    | 8    | Legacy (`*_in_ms`, `*_in_mb`) | `jvm.options` |
+| 4.1.x     | 11   | Modern (duration/size strings) | `jvm-server.options`, `jvm11-server.options`, `jvm-clients.options`, `jvm11-clients.options` |
+| 5.0.x     | 17   | Modern (duration/size strings) | `jvm-server.options`, `jvm11-server.options`, `jvm-clients.options`, `jvm11-clients.options`, `jvm17-server.options`, `jvm17-clients.options` |
+
+Set `cassandra_version` to a value starting with `3.11`, `4.1`, or `5.` — anything
+else makes the role fail fast at the version assertion.
+
+The `axonops.axonops.java` role auto-selects the Java major version from
+`cassandra_version` (Java 8 for 3.11, Java 11 for 4.1, Java 17 for 5.x); use
+`java_use_zulu: true` on RHEL 10+ / Debian 13+ where the base repos no longer
+ship the relevant OpenJDK package.
+
 ## Requirements
 
 - Java must be installed before running this role (use `axonops.axonops.java`).
@@ -85,3 +101,28 @@ See `defaults/main.yml` for the full list of PEM variables (`cassandra_ssl_inter
         cassandra_cluster_name: my-cluster
         cassandra_dc: dc1
 ```
+
+## Example: Cassandra 3.11
+
+Cassandra 3.11 requires Java 8 and uses the legacy `cassandra.yaml` schema.
+The role picks the right template directory (`templates/3.11.x/`), variable
+set (`vars/cassandra-3.11.yml`) and config file list (single `jvm.options`)
+automatically when `cassandra_version` starts with `3.11`.
+
+```yaml
+- hosts: cassandra
+  become: true
+  vars:
+    cassandra_version: 3.11.17
+    cassandra_cluster_name: legacy-cluster
+    cassandra_dc: dc1
+    cassandra_rack: rack1
+    cassandra_max_heap_size: 4G
+    cassandra_seeds: "{{ groups['cassandra'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | join(',') }}"
+  roles:
+    - role: axonops.axonops.java
+      # No need to set java_zulu_version — the java role detects 3.11 → Java 8.
+    - role: axonops.axonops.cassandra
+```
+
+A full working example lives at [`examples/cassandra-3.11.yml`](../../examples/cassandra-3.11.yml).

--- a/roles/cassandra/defaults/main.yml
+++ b/roles/cassandra/defaults/main.yml
@@ -355,7 +355,7 @@ cassandra_transparent_data_encryption_options:
           key_password: "cassandra"
 
 # jemalloc
-cassandra_jemalloc_enabled: "{{ ansible_facts['os_family'] == 'Debian' }}"
+cassandra_jemalloc_enabled: true
 # cassandra_libjemalloc_path: ""  # auto-detected when cassandra_jemalloc_enabled is true
 
 # JVM

--- a/roles/cassandra/defaults/main.yml
+++ b/roles/cassandra/defaults/main.yml
@@ -10,9 +10,9 @@ cassandra_allocate_tokens_for_local_replication_factor: 3
 cassandra_binary_owner: root
 cassandra_binary_group: root
 
-cassandra_version: 5.0.7
+cassandra_version: 5.0.8
 
-cassandra_cqlai_version: 0.1.5
+cassandra_cqlai_version: 0.1.7
 cassandra_cqlai_binary: "{{ _cassandra_cqlai_binary }}"
 
 # It is recommended to leave this as false
@@ -355,7 +355,7 @@ cassandra_transparent_data_encryption_options:
           key_password: "cassandra"
 
 # jemalloc
-cassandra_jemalloc_enabled: true
+cassandra_jemalloc_enabled: "{{ ansible_facts['os_family'] == 'Debian' }}"
 # cassandra_libjemalloc_path: ""  # auto-detected when cassandra_jemalloc_enabled is true
 
 # JVM

--- a/roles/cassandra/molecule/cassandra-3.11/converge.yml
+++ b/roles/cassandra/molecule/cassandra-3.11/converge.yml
@@ -13,11 +13,10 @@
     # Cassandra 3.11 requires Java 8.
     cassandra_seeds: "127.0.0.1"
   pre_tasks:
-    - name: "Create /usr/share/man/man1/"
+    - name: Workaround missing man1 dir in test containers
       ansible.builtin.file:
-        path: /usr/share/man/man1/
+        path: /usr/share/man/man1
         state: directory
-        recurse: true
         mode: "0755"
   roles:
     - role: java

--- a/roles/cassandra/molecule/cassandra-3.11/converge.yml
+++ b/roles/cassandra/molecule/cassandra-3.11/converge.yml
@@ -1,0 +1,27 @@
+---
+- name: Converge — Cassandra 3.11 (legacy schema, Java 8, single jvm.options)
+  hosts: all
+  vars:
+    cassandra_cluster_name: cassandra-3-11
+    cassandra_dc: dc1
+    cassandra_rack: rack1
+    cassandra_max_heap_size: 512M
+    cassandra_version: 3.11.17
+    cassandra_start_on_boot: false
+    cassandra_start_on_install: false
+    cassandra_install_format: tar
+    # Cassandra 3.11 requires Java 8.
+    cassandra_seeds: "127.0.0.1"
+  pre_tasks:
+    - name: "Create /usr/share/man/man1/"
+      ansible.builtin.file:
+        path: /usr/share/man/man1/
+        state: directory
+        recurse: true
+        mode: "0755"
+  roles:
+    - role: java
+      vars:
+        # java role picks Java 8 automatically when cassandra_version starts with 3.11
+        java_use_zulu: true
+    - role: cassandra

--- a/roles/cassandra/molecule/cassandra-3.11/molecule.yml
+++ b/roles/cassandra/molecule/cassandra-3.11/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: docker
+platforms:
+  - name: ${MOLECULE_INSTANCE_NAME:-"cassandra"}
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml

--- a/roles/cassandra/molecule/cassandra-3.11/verify.yml
+++ b/roles/cassandra/molecule/cassandra-3.11/verify.yml
@@ -1,0 +1,67 @@
+---
+- name: Verify — Cassandra 3.11 install + config
+  hosts: all
+  gather_facts: false
+  vars:
+    cassandra_version: 3.11.17
+    cassandra_install_root: /opt
+    cassandra_conf_dir: "/opt/apache-cassandra-{{ cassandra_version }}/conf"
+  tasks:
+    - name: Tar extracted to versioned dir
+      ansible.builtin.stat:
+        path: "{{ cassandra_install_root }}/apache-cassandra-{{ cassandra_version }}"
+      register: install_dir
+      failed_when: not install_dir.stat.exists or not install_dir.stat.isdir
+
+    - name: Check cassandra.yaml exists
+      ansible.builtin.stat:
+        path: "{{ cassandra_conf_dir }}/cassandra.yaml"
+      register: yaml_stat
+      failed_when: not yaml_stat.stat.exists
+
+    - name: Check jvm.options exists (3.11 single-file layout)
+      ansible.builtin.stat:
+        path: "{{ cassandra_conf_dir }}/jvm.options"
+      register: jvm_opts_stat
+      failed_when: not jvm_opts_stat.stat.exists
+
+    - name: Check jvm-server.options absent (4.x/5.x only)
+      ansible.builtin.stat:
+        path: "{{ cassandra_conf_dir }}/jvm-server.options"
+      register: jvm_server_stat
+      failed_when: jvm_server_stat.stat.exists
+
+    - name: Slurp cassandra.yaml
+      ansible.builtin.slurp:
+        src: "{{ cassandra_conf_dir }}/cassandra.yaml"
+      register: yaml_slurp
+
+    - name: Parse cassandra.yaml
+      ansible.builtin.set_fact:
+        yaml_content: "{{ yaml_slurp.content | b64decode }}"
+        yaml_doc: "{{ yaml_slurp.content | b64decode | from_yaml }}"
+
+    - name: Check cluster_name set in cassandra.yaml
+      ansible.builtin.assert:
+        that:
+          - yaml_doc.cluster_name is defined
+          - yaml_doc.cluster_name == 'cassandra-3-11'
+
+    - name: 4.x/5.x-only keys MUST NOT appear in 3.11 cassandra.yaml
+      ansible.builtin.assert:
+        that:
+          - "'auto_optimise_full_repair_streams' not in yaml_content"
+          - "'auto_optimise_inc_repair_streams' not in yaml_content"
+          - "'auto_optimise_preview_repair_streams' not in yaml_content"
+          - "'commitlog_sync_group_window' not in yaml_content"
+          - "'repaired_data_tracking_for_range_reads_enabled' not in yaml_content"
+          - "'repaired_data_tracking_for_partition_reads_enabled' not in yaml_content"
+          - "'corrupted_tombstone_strategy' not in yaml_content"
+          - "'full_query_logging_options' not in yaml_content"
+
+    - name: Legacy 3.11 keys present
+      ansible.builtin.assert:
+        that:
+          - "'commitlog_sync_period_in_ms' in yaml_content"
+          - "'max_hint_window_in_ms' in yaml_content"
+          - "'native_transport_max_frame_size_in_mb' in yaml_content"

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -21,10 +21,10 @@
   ansible.builtin.assert:
     that:
       - cassandra_version is defined
-      - cassandra_version.startswith('4.1') or cassandra_version.startswith('5.')
+      - cassandra_version.startswith('3.11') or cassandra_version.startswith('4.1') or cassandra_version.startswith('5.')
     fail_msg: >-
       Unsupported cassandra_version '{{ cassandra_version }}'. This role supports versions
-      starting with '4.1' or '5.'. Please set cassandra_version to a supported value.
+      starting with '3.11', '4.1' or '5.'. Please set cassandra_version to a supported value.
   tags: always
 
 - name: Assert Cassandra version supports PEMBasedSslContextFactory
@@ -58,6 +58,11 @@
     - name: Force-disable cassandra_use_password_files on unsupported versions
       ansible.builtin.set_fact:
         cassandra_use_password_files: false
+
+- name: Import vars for 3.11
+  ansible.builtin.include_vars: cassandra-3.11.yml
+  when: cassandra_version.startswith('3.11')
+  tags: always
 
 - name: Import vars for 4.1
   ansible.builtin.include_vars: cassandra-4.1.yml
@@ -249,7 +254,29 @@
         tmpl_dir: 4.1.x
       when: cassandra_version.startswith('4.1')
 
-    - name: Ensure Cassandra node configured
+    - name: Template directory
+      ansible.builtin.set_fact:
+        tmpl_dir: 3.11.x
+      when: cassandra_version.startswith('3.11')
+
+    - name: Ensure Cassandra node configured (3.11 only — legacy schema, single jvm.options)
+      when: cassandra_version.startswith('3.11')
+      ansible.builtin.template:
+        src: "{{ tmpl_dir }}/{{ item }}.j2"
+        dest: "{{ cassandra_conf_dir | default('/etc/cassandra') }}/{{ item }}"
+        mode: "0640"
+        owner: cassandra
+        group: cassandra
+      loop:
+        - cassandra-env.sh
+        - cassandra-rackdc.properties
+        - cassandra.yaml
+        - logback.xml
+        - jvm.options
+      notify: Restart Cassandra
+
+    - name: Ensure Cassandra node configured (4.1.x / 5.x)
+      when: not cassandra_version.startswith('3.11')
       ansible.builtin.template:
         src: "{{ tmpl_dir }}/{{ item }}.j2"
         dest: "{{ cassandra_conf_dir | default('/etc/cassandra') }}/{{ item }}"

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -211,6 +211,14 @@
         name: libjemalloc2
         state: present
 
+    - name: Install epel-release for jemalloc on RedHat
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution != "Amazon"
+      ansible.builtin.yum:
+        name: epel-release
+        state: present
+
     - name: Install jemalloc package (RedHat)
       when: ansible_os_family == "RedHat"
       ansible.builtin.package:

--- a/roles/cassandra/templates/3.11.x/cassandra-env.sh.j2
+++ b/roles/cassandra/templates/3.11.x/cassandra-env.sh.j2
@@ -1,0 +1,340 @@
+# {{ ansible_managed }}
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+calculate_heap_sizes()
+{
+    case "`uname`" in
+        Linux)
+            system_memory_in_mb=`free -m | awk '/:/ {print $2;exit}'`
+            system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
+        ;;
+        FreeBSD)
+            system_memory_in_bytes=`sysctl hw.physmem | awk '{print $2}'`
+            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
+            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
+        ;;
+        SunOS)
+            system_memory_in_mb=`prtconf | awk '/Memory size:/ {print $3}'`
+            system_cpu_cores=`psrinfo | wc -l`
+        ;;
+        Darwin)
+            system_memory_in_bytes=`sysctl hw.memsize | awk '{print $2}'`
+            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
+            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
+        ;;
+        *)
+            # assume reasonable defaults for e.g. a modern desktop or
+            # cheap server
+            system_memory_in_mb="2048"
+            system_cpu_cores="2"
+        ;;
+    esac
+
+    # some systems like the raspberry pi don't report cores, use at least 1
+    if [ "$system_cpu_cores" -lt "1" ]
+    then
+        system_cpu_cores="1"
+    fi
+
+    # set max heap size based on the following
+    # max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+    # calculate 1/2 ram and cap to 1024MB
+    # calculate 1/4 ram and cap to 8192MB
+    # pick the max
+    half_system_memory_in_mb=`expr $system_memory_in_mb / 2`
+    quarter_system_memory_in_mb=`expr $half_system_memory_in_mb / 2`
+    if [ "$half_system_memory_in_mb" -gt "1024" ]
+    then
+        half_system_memory_in_mb="1024"
+    fi
+    if [ "$quarter_system_memory_in_mb" -gt "8192" ]
+    then
+        quarter_system_memory_in_mb="8192"
+    fi
+    if [ "$half_system_memory_in_mb" -gt "$quarter_system_memory_in_mb" ]
+    then
+        max_heap_size_in_mb="$half_system_memory_in_mb"
+    else
+        max_heap_size_in_mb="$quarter_system_memory_in_mb"
+    fi
+    MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
+
+    # Young gen: min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
+    max_sensible_yg_per_core_in_mb="100"
+    max_sensible_yg_in_mb=`expr $max_sensible_yg_per_core_in_mb "*" $system_cpu_cores`
+
+    desired_yg_in_mb=`expr $max_heap_size_in_mb / 4`
+
+    if [ "$desired_yg_in_mb" -gt "$max_sensible_yg_in_mb" ]
+    then
+        HEAP_NEWSIZE="${max_sensible_yg_in_mb}M"
+    else
+        HEAP_NEWSIZE="${desired_yg_in_mb}M"
+    fi
+}
+
+# Determine the sort of JVM we'll be running on.
+java_ver_output=`"${JAVA:-java}" -version 2>&1`
+jvmver=`echo "$java_ver_output" | grep '[openjdk|java] version' | awk -F'"' 'NR==1 {print $2}' | cut -d\- -f1`
+JVM_VERSION=${jvmver%_*}
+JVM_PATCH_VERSION=${jvmver#*_}
+
+if [ "$JVM_VERSION" \< "1.8" ] ; then
+    echo "Cassandra 3.0 and later require Java 8u40 or later."
+    exit 1;
+fi
+
+if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 40 ] ; then
+    echo "Cassandra 3.0 and later require Java 8u40 or later."
+    exit 1;
+fi
+
+jvm=`echo "$java_ver_output" | grep -A 1 'java version' | awk 'NR==2 {print $1}'`
+case "$jvm" in
+    OpenJDK)
+        JVM_VENDOR=OpenJDK
+        # this will be "64-Bit" or "32-Bit"
+        JVM_ARCH=`echo "$java_ver_output" | awk 'NR==3 {print $2}'`
+        ;;
+    "Java(TM)")
+        JVM_VENDOR=Oracle
+        # this will be "64-Bit" or "32-Bit"
+        JVM_ARCH=`echo "$java_ver_output" | awk 'NR==3 {print $3}'`
+        ;;
+    *)
+        # Help fill in other JVM values
+        JVM_VENDOR=other
+        JVM_ARCH=unknown
+        ;;
+esac
+
+#GC log path has to be defined here because it needs to access CASSANDRA_HOME
+JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+
+# Here we create the arguments that will get passed to the jvm when
+# starting cassandra.
+
+# Read user-defined JVM options from jvm.options file
+JVM_OPTS_FILE=$CASSANDRA_CONF/jvm.options
+for opt in `grep "^-" $JVM_OPTS_FILE`
+do
+  JVM_OPTS="$JVM_OPTS $opt"
+done
+
+# Check what parameters were defined on jvm.options file to avoid conflicts
+echo $JVM_OPTS | grep -q Xmn
+DEFINED_XMN=$?
+echo $JVM_OPTS | grep -q Xmx
+DEFINED_XMX=$?
+echo $JVM_OPTS | grep -q Xms
+DEFINED_XMS=$?
+echo $JVM_OPTS | grep -q UseConcMarkSweepGC
+USING_CMS=$?
+echo $JVM_OPTS | grep -q UseG1GC
+USING_G1=$?
+
+# Override these to set the amount of memory to allocate to the JVM at
+# start-up. For production use you may wish to adjust this for your
+# environment. MAX_HEAP_SIZE is the total amount of memory dedicated
+# to the Java heap. HEAP_NEWSIZE refers to the size of the young
+# generation. Both MAX_HEAP_SIZE and HEAP_NEWSIZE should be either set
+# or not (if you set one, set the other).
+#
+# The main trade-off for the young generation is that the larger it
+# is, the longer GC pause times will be. The shorter it is, the more
+# expensive GC will be (usually).
+#
+# The example HEAP_NEWSIZE assumes a modern 8-core+ machine for decent pause
+# times. If in doubt, and if you do not particularly want to tweak, go with
+# 100 MB per physical CPU core.
+
+#MAX_HEAP_SIZE="4G"
+#HEAP_NEWSIZE="800M"
+
+# Set this to control the amount of arenas per-thread in glibc
+#export MALLOC_ARENA_MAX=4
+
+# only calculate the size if it's not set manually
+if [ "x$MAX_HEAP_SIZE" = "x" ] && [ "x$HEAP_NEWSIZE" = "x" -o $USING_G1 -eq 0 ]; then
+    calculate_heap_sizes
+elif [ "x$MAX_HEAP_SIZE" = "x" ] ||  [ "x$HEAP_NEWSIZE" = "x" -a $USING_G1 -ne 0 ]; then
+    echo "please set or unset MAX_HEAP_SIZE and HEAP_NEWSIZE in pairs when using CMS GC (see cassandra-env.sh)"
+    exit 1
+fi
+
+if [ "x$MALLOC_ARENA_MAX" = "x" ] ; then
+    export MALLOC_ARENA_MAX=4
+fi
+
+# We only set -Xms and -Xmx if they were not defined on jvm.options file
+# If defined, both Xmx and Xms should be defined together.
+if [ $DEFINED_XMX -ne 0 ] && [ $DEFINED_XMS -ne 0 ]; then
+     JVM_OPTS="$JVM_OPTS -Xms${MAX_HEAP_SIZE}"
+     JVM_OPTS="$JVM_OPTS -Xmx${MAX_HEAP_SIZE}"
+elif [ $DEFINED_XMX -ne 0 ] || [ $DEFINED_XMS -ne 0 ]; then
+     echo "Please set or unset -Xmx and -Xms flags in pairs on jvm.options file."
+     exit 1
+fi
+
+# We only set -Xmn flag if it was not defined in jvm.options file
+# and if the CMS GC is being used
+# If defined, both Xmn and Xmx should be defined together.
+if [ $DEFINED_XMN -eq 0 ] && [ $DEFINED_XMX -ne 0 ]; then
+    echo "Please set or unset -Xmx and -Xmn flags in pairs on jvm.options file."
+    exit 1
+elif [ $DEFINED_XMN -ne 0 ] && [ $USING_CMS -eq 0 ]; then
+    JVM_OPTS="$JVM_OPTS -Xmn${HEAP_NEWSIZE}"
+fi
+
+if [ "$JVM_ARCH" = "64-Bit" ] && [ $USING_CMS -eq 0 ]; then
+    JVM_OPTS="$JVM_OPTS -XX:+UseCondCardMark"
+fi
+
+# provides hints to the JIT compiler
+JVM_OPTS="$JVM_OPTS -XX:CompileCommandFile=$CASSANDRA_CONF/hotspot_compiler"
+
+# add the jamm javaagent
+JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/jamm-0.3.0.jar"
+
+# set jvm HeapDumpPath with CASSANDRA_HEAPDUMP_DIR
+if [ "x$CASSANDRA_HEAPDUMP_DIR" != "x" ]; then
+    JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
+fi
+
+# stop the jvm on OutOfMemoryError as it can result in some data corruption
+# uncomment the preferred option
+# ExitOnOutOfMemoryError and CrashOnOutOfMemoryError require a JRE greater or equals to 1.7 update 101 or 1.8 update 92
+# For OnOutOfMemoryError we cannot use the JVM_OPTS variables because bash commands split words
+# on white spaces without taking quotes into account
+ JVM_OPTS="$JVM_OPTS -XX:+ExitOnOutOfMemoryError"
+# JVM_OPTS="$JVM_OPTS -XX:+CrashOnOutOfMemoryError"
+# JVM_ON_OUT_OF_MEMORY_ERROR_OPT="-XX:OnOutOfMemoryError=kill -9 %p"
+
+# print an heap histogram on OutOfMemoryError
+# JVM_OPTS="$JVM_OPTS -Dcassandra.printHeapHistogramOnOutOfMemoryError=true"
+
+# jmx: metrics and administration interface
+#
+# add this if you're having trouble connecting:
+# JVM_OPTS="$JVM_OPTS -Djava.rmi.server.hostname=<public name>"
+#
+# see
+# https://blogs.oracle.com/jmxetc/entry/troubleshooting_connection_problems_in_jconsole
+# for more on configuring JMX through firewalls, etc. (Short version:
+# get it working with no firewall first.)
+#
+# Cassandra ships with JMX accessible *only* from localhost.
+# To enable remote JMX connections, uncomment lines below
+# with authentication and/or ssl enabled. See https://wiki.apache.org/cassandra/JmxSecurity
+#
+if [ "x$LOCAL_JMX" = "x" ]; then
+    LOCAL_JMX=yes
+fi
+
+# Specifies the default port over which Cassandra will be available for
+# JMX connections.
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+JMX_PORT="{{ cassandra_jmx_port }}"
+
+if [ "$LOCAL_JMX" = "yes" ]; then
+  JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.local.port=$JMX_PORT"
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+else
+  JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.remote.port=$JMX_PORT"
+  # if ssl is enabled the same port cannot be used for both jmx and rmi so either
+  # pick another value for this property or comment out to use a random port (though see CASSANDRA-7087 for origins)
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT"
+
+  # turn on JMX authentication. See below for further options
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
+
+  # jmx ssl options
+  #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=true"
+  #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.need.client.auth=true"
+  #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.enabled.protocols=<enabled-protocols>"
+  #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.enabled.cipher.suites=<enabled-cipher-suites>"
+  #JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStore=/path/to/keystore"
+  #JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStorePassword=<keystore-password>"
+  #JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.trustStore=/path/to/truststore"
+  #JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.trustStorePassword=<truststore-password>"
+fi
+
+# jmx authentication and authorization options. By default, auth is only
+# activated for remote connections but they can also be enabled for local only JMX
+## Basic file based authn & authz
+{% if cassandra_jmx_password is defined and cassandra_jmx_password != "" %}
+JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.password.file={{ cassandra_jmx_password_file | default(cassandra_home_dir ~ '/conf/jmxremote.password') }}"
+{% if cassandra_jmx_access_file is defined and cassandra_jmx_access_file != '' %}
+JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.access.file={{ cassandra_jmx_access_file }}"
+{% endif %}
+{% endif %}
+## Custom auth settings which can be used as alternatives to JMX's out of the box auth utilities.
+## JAAS login modules can be used for authentication by uncommenting these two properties.
+## Cassandra ships with a LoginModule implementation - org.apache.cassandra.auth.CassandraLoginModule -
+## which delegates to the IAuthenticator configured in cassandra.yaml. See the sample JAAS configuration
+## file cassandra-jaas.config
+#JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.remote.login.config=CassandraLogin"
+#JVM_OPTS="$JVM_OPTS -Djava.security.auth.login.config=$CASSANDRA_HOME/conf/cassandra-jaas.config"
+
+## Cassandra also ships with a helper for delegating JMX authz calls to the configured IAuthorizer,
+## uncomment this to use it. Requires one of the two authentication options to be enabled
+#JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"
+
+# To use mx4j, an HTML interface for JMX, add mx4j-tools.jar to the lib/
+# directory.
+# See http://wiki.apache.org/cassandra/Operations#Monitoring_with_MX4J
+# By default mx4j listens on 0.0.0.0:8081. Uncomment the following lines
+# to control its listen address and port.
+#MX4J_ADDRESS="-Dmx4jaddress=127.0.0.1"
+#MX4J_PORT="-Dmx4jport=8081"
+
+#If /tmp has noexec flag set, update dirs to something else
+TMPDIR="{{ cassandra_java_tmp_dir }}"
+JVM_OPTS="$JVM_OPTS -Djna.tmpdir={{ cassandra_jna_tmp_dir }} -Djava.io.tmpdir={{ cassandra_java_tmp_dir }} -Dio.netty.native.workdir={{ cassandra_java_tmp_dir }}"
+
+
+# Cassandra uses SIGAR to capture OS metrics CASSANDRA-7838
+# for SIGAR we have to set the java.library.path
+# to the location of the native libraries.
+JVM_OPTS="$JVM_OPTS -Djava.library.path=$CASSANDRA_HOME/lib/sigar-bin"
+
+JVM_OPTS="$JVM_OPTS $MX4J_ADDRESS"
+JVM_OPTS="$JVM_OPTS $MX4J_PORT"
+JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"
+
+#JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address=x.x.x.x"
+#JVM_OPTS="$JVM_OPTS -Dcassandra.disable_stcs_in_l0=true"
+#JVM_OPTS="$JVM_OPTS -Dcassandra.config.loader=o.a.c.ConfigurationLoader"
+#JVM_OPTS="$JVM_OPTS -Dcassandra.custom_query_handler_class=o.a.c.cql3.QueryHandler"
+#JVM_OPTS="$JVM_OPTS -Dcassandra.metricsReporterConfifFile=some_file"
+#JVM_OPTS="$JVM_OPTS -Dcassandra.replayList=Foo.Bar"
+
+{% if cassandra_libjemalloc_path is defined %}
+CASSANDRA_LIBJEMALLOC="{{ cassandra_libjemalloc_path }}"
+{% endif %}
+
+{% if cassandra_replace_node_ip is defined %}
+JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address={{ cassandra_replace_node_ip }}"
+{% endif %}
+
+{% if axon_java_agent is defined and axon_java_agent != "" %}
+JVM_OPTS="$JVM_OPTS -javaagent:/usr/share/axonops/{{ axon_java_agent }}.jar=/etc/axonops/axon-agent.yml"
+{% endif %}
+
+{% for line in cassandra_env_extra %}
+{{ line }}
+{% endfor %}

--- a/roles/cassandra/templates/3.11.x/cassandra-rackdc.properties.j2
+++ b/roles/cassandra/templates/3.11.x/cassandra-rackdc.properties.j2
@@ -1,0 +1,28 @@
+# {{ ansible_managed }}
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These properties are used with GossipingPropertyFileSnitch and will
+# indicate the rack and dc for this node
+dc={{ cassandra_dc }}
+rack={{ cassandra_rack }}
+
+# Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch
+# to append a string to the EC2 region name.
+#dc_suffix=
+
+# Uncomment the following line to make this snitch prefer the internal ip when possible, as the Ec2MultiRegionSnitch does.
+# prefer_local=true

--- a/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
+++ b/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
@@ -1,0 +1,1414 @@
+# {{ ansible_managed }}
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: '{{ cassandra_cluster_name }}'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: {{ cassandra_num_tokens }}
+
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replication strategy used by the specified
+# keyspace.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+# allocate_tokens_for_keyspace: KEYSPACE
+{% if cassandra_allocate_tokens_for_keyspace is defined %}
+allocate_tokens_for_keyspace: {{ cassandra_allocate_tokens_for_keyspace }}
+{% endif %}
+
+# initial_token allows you to specify tokens manually.  While you can use it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes to legacy clusters
+# that do not have vnodes enabled.
+# initial_token:
+{% if cassandra_initial_token is defined %}
+initial_token: {{ cassandra_initial_token }}
+{% endif %}
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally
+hinted_handoff_enabled: {{ cassandra_hinted_handoff_enabled }}
+
+# When hinted_handoff_enabled is true, a black list of data centers that will not
+# perform hinted handoff
+# hinted_handoff_disabled_datacenters:
+#    - DC1
+#    - DC2
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: {{ cassandra_max_hint_window_in_ms }}
+
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+#hinted_handoff_throttle_in_kb: 1024
+hinted_handoff_throttle_in_kb: {{ cassandra_hinted_handoff_throttle_in_kb }}
+
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+#max_hints_delivery_threads: 2
+max_hints_delivery_threads: {{ cassandra_max_hints_delivery_threads }}
+
+# Directory where Cassandra should store hints.
+# If not set, the default directory is $CASSANDRA_HOME/data/hints.
+# hints_directory: /var/lib/cassandra/hints
+hints_directory: {{ cassandra_hints_directory }}
+
+# How often hints should be flushed from the internal buffers to disk.
+# Will *not* trigger fsync.
+#hints_flush_period_in_ms: 10000
+hints_flush_period_in_ms: {{ cassandra_hints_flush_period_in_ms }}
+
+# Maximum size for a single hints file, in megabytes.
+#max_hints_file_size_in_mb: 128
+max_hints_file_size_in_mb: {{ cassandra_max_hints_file_size_in_mb }}
+
+# Compression to apply to the hint files. If omitted, hints files
+# will be written uncompressed. LZ4, Snappy, and Deflate compressors
+# are supported.
+#hints_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: {{ cassandra_batchlog_replay_throttle_in_kb }}
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.roles table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
+authenticator: {{ cassandra_authenticator }}
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: {{ cassandra_authorizer }}
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+#role_manager: CassandraRoleManager
+role_manager: {{ cassandra_role_manager }}
+
+# Validity period for roles cache (fetching granted roles can be an expensive
+# operation depending on the role manager, CassandraRoleManager is one example)
+# Granted roles are cached for authenticated sessions in AuthenticatedUser and
+# after the period specified here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable caching entirely.
+# Will be disabled automatically for AllowAllAuthenticator.
+#roles_validity_in_ms: 2000
+roles_validity_in_ms: {{ cassandra_roles_validity_in_ms }}
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as roles_validity_in_ms.
+# roles_update_interval_in_ms: 2000
+roles_update_interval_in_ms: {{ cassandra_roles_update_interval_in_ms }}
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+#permissions_validity_in_ms: 2000
+permissions_validity_in_ms: {{ cassandra_permissions_validity_in_ms }}
+
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+permissions_update_interval_in_ms: {{ cassandra_permissions_update_interval_in_ms }}
+
+
+# Validity period for credentials cache. This cache is tightly coupled to
+# the provided PasswordAuthenticator implementation of IAuthenticator. If
+# another IAuthenticator implementation is configured, this cache will not
+# be automatically used and so the following settings will have no effect.
+# Please note, credentials are cached in their encrypted form, so while
+# activating this cache may reduce the number of queries made to the
+# underlying table, it may not  bring a significant reduction in the
+# latency of individual authentication attempts.
+# Defaults to 2000, set to 0 to disable credentials caching.
+# credentials_validity_in_ms: 2000
+credentials_validity_in_ms: {{ cassandra_credentials_validity_in_ms }}
+
+# Refresh interval for credentials cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If credentials_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as credentials_validity_in_ms.
+# credentials_update_interval_in_ms: 2000
+credentials_update_interval_in_ms: {{ cassandra_credentials_update_interval_in_ms }}
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+#partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+partitioner: {{ cassandra_partitioner }}
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+# data_file_directories:
+#     - /var/lib/cassandra/data
+data_file_directories:
+     - {{ cassandra_data_directory }}
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+# commitlog_directory: /var/lib/cassandra/commitlog
+commitlog_directory: {{ cassandra_commitlog_directory }}
+
+# Enable / disable CDC functionality on a per-node basis. This modifies the logic used
+# for write path allocation rejection (standard: never reject. cdc: reject Mutation
+# containing a CDC-enabled table if at space limit in cdc_raw_directory).
+cdc_enabled: {{ cassandra_cdc_enabled }}
+
+# CommitLogSegments are moved to this directory on flush if cdc_enabled: true and the
+# segment contains mutations for a CDC-enabled table. This should be placed on a
+# separate spindle than the data directories. If not set, the default directory is
+# $CASSANDRA_HOME/data/cdc_raw.
+# cdc_raw_directory: /var/lib/cassandra/cdc_raw
+
+# Policy for data disk failures:
+#
+# die
+#   shut down gossip and client transports and kill the JVM for any fs errors or
+#   single-sstable errors, so the node can be replaced.
+#
+# stop_paranoid
+#   shut down gossip and client transports even for single-sstable errors,
+#   kill the JVM for errors during startup.
+#
+# stop
+#   shut down gossip and client transports, leaving the node effectively dead, but
+#   can still be inspected via JMX, kill the JVM for errors during startup.
+#
+# best_effort
+#    stop using the failed disk and respond to requests based on
+#    remaining available sstables.  This means you WILL see obsolete
+#    data at CL.ONE!
+#
+# ignore
+#    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+#disk_failure_policy: stop
+disk_failure_policy: {{ cassandra_disk_failure_policy }}
+
+# Policy for commit disk failures:
+#
+# die
+#   shut down gossip and Thrift and kill the JVM, so the node can be replaced.
+#
+# stop
+#   shut down gossip and Thrift, leaving the node effectively dead, but
+#   can still be inspected via JMX.
+#
+# stop_commit
+#   shutdown the commit log, letting writes collect but
+#   continuing to service reads, as in pre-2.0.5 Cassandra
+#
+# ignore
+#   ignore fatal errors and let the batches fail
+#commit_failure_policy: stop
+commit_failure_policy: {{ cassandra_commit_failure_policy }}
+
+# Maximum size of the native protocol prepared statement cache
+#
+# Valid values are either "auto" (omitting the value) or a value greater 0.
+#
+# Note that specifying a too large value will result in long running GCs and possbily
+# out-of-memory errors. Keep the value at a small fraction of the heap.
+#
+# If you constantly see "prepared statements discarded in the last minute because
+# cache limit reached" messages, the first step is to investigate the root cause
+# of these messages and check whether prepared statements are used correctly -
+# i.e. use bind markers for variable parts.
+#
+# Do only change the default value, if you really have more prepared statements than
+# fit in the cache. In most cases it is not neccessary to change this value.
+# Constantly re-preparing statements is a performance penalty.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+prepared_statements_cache_size_mb: {{ cassandra_prepared_statements_cache_size_mb }}
+
+# Maximum size of the Thrift prepared statement cache
+#
+# If you do not use Thrift at all, it is safe to leave this value at "auto".
+#
+# See description of 'prepared_statements_cache_size_mb' above for more information.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+thrift_prepared_statements_cache_size_mb: {{ cassandra_thrift_prepared_statements_cache_size_mb }}
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+#key_cache_size_in_mb:
+key_cache_size_in_mb: {{ cassandra_key_cache_size_in_mb }}
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+#key_cache_save_period: 14400
+key_cache_save_period: {{ cassandra_key_cache_save_period }}
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+{% if cassandra_key_cache_keys_to_save is defined %}
+key_cache_keys_to_save: {{ cassandra_key_cache_keys_to_save }}
+{% endif %}
+
+# Row cache implementation class name. Available implementations:
+#
+# org.apache.cassandra.cache.OHCProvider
+#   Fully off-heap row cache implementation (default).
+#
+# org.apache.cassandra.cache.SerializingCacheProvider
+#   This is the row cache implementation availabile
+#   in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+row_cache_class_name: {{ cassandra_row_cache_class_name }}
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
+#row_cache_size_in_mb: 0
+row_cache_size_in_mb: {{ cassandra_row_cache_size_in_mb }}
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+#row_cache_save_period: 0
+row_cache_save_period: {{ cassandra_row_cache_save_period }}
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+{% if cassandra_row_cache_keys_to_save is defined %}
+row_cache_keys_to_save: {{ cassandra_row_cache_keys_to_save }}
+{% endif %}
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+#counter_cache_size_in_mb:
+counter_cache_size_in_mb: {{ cassandra_counter_cache_size_in_mb }}
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+#counter_cache_save_period: 7200
+counter_cache_save_period: {{ cassandra_counter_cache_save_period }}
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+{% if cassandra_counter_cache_keys_to_save is defined %}
+counter_cache_keys_to_save: {{ cassandra_counter_cache_keys_to_save }}
+{% endif %}
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+# saved_caches_directory: /var/lib/cassandra/saved_caches
+saved_caches_directory: {{ cassandra_saved_caches_directory }}
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+#commitlog_sync: periodic
+commitlog_sync: {{ cassandra_commitlog_sync }}
+#commitlog_sync_period_in_ms: 10000
+commitlog_sync_period_in_ms: {{ cassandra_commitlog_sync_period_in_ms }}
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+# Max mutation size is also configurable via max_mutation_size_in_kb setting in
+# cassandra.yaml. The default is half the size commitlog_segment_size_in_mb * 1024.
+# This should be positive and less than 2048.
+#
+# NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
+# be set to at least twice the size of max_mutation_size_in_kb / 1024
+#
+#commitlog_segment_size_in_mb: 32
+commitlog_segment_size_in_mb: {{ cassandra_commitlog_segment_size_in_mb }}
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+# commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points.
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+{% if cassandra_seeds is defined %}
+          - seeds: "{{ cassandra_seeds }}"
+{% else %}
+          - seeds: "127.0.0.1"
+{% endif %}
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+#concurrent_reads: 32
+#concurrent_writes: 32
+#concurrent_counter_writes: 32
+concurrent_reads: {{ cassandra_concurrent_reads }}
+concurrent_writes: {{ cassandra_concurrent_writes }}
+concurrent_counter_writes: {{ cassandra_concurrent_counter_writes }}
+
+# For materialized view writes, as there is a read involved, so this should
+# be limited by the less of concurrent reads or concurrent writes.
+concurrent_materialized_view_writes: {{ cassandra_concurrent_materialized_view_writes }}
+
+# Maximum memory to use for sstable chunk cache and buffer pooling.
+# 32MB of this are reserved for pooling buffers, the rest is used as an
+# cache that holds uncompressed sstable chunks.
+# Defaults to the smaller of 1/4 of heap or 512MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
+# file_cache_size_in_mb: 512
+{% if cassandra_file_cache_size_in_mb is defined %}
+file_cache_size_in_mb: {{ cassandra_file_cache_size_in_mb }}
+{% endif %}
+
+# Flag indicating whether to allocate on or off heap when the sstable buffer
+# pool is exhausted, that is when it has exceeded the maximum memory
+# file_cache_size_in_mb, beyond which it will not cache buffers but allocate on request.
+
+# buffer_pool_use_heap_if_exhausted: true
+{% if cassandra_buffer_pool_use_heap_if_exhausted is defined %}
+buffer_pool_use_heap_if_exhausted: {{ cassandra_buffer_pool_use_heap_if_exhausted }}
+{% endif %}
+# The strategy for optimizing disk read
+# Possible values are:
+# ssd (for solid state disks, the default)
+# spinning (for spinning disks)
+# disk_optimization_strategy: ssd
+disk_optimization_strategy: {{ cassandra_disk_optimization_strategy }}
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+{% if cassandra_memtable_heap_space_in_mb is defined %}
+memtable_heap_space_in_mb: {{ cassandra_memtable_heap_space_in_mb }}
+{% endif %}
+{% if cassandra_memtable_offheap_space_in_mb is defined %}
+memtable_offheap_space_in_mb: {{ cassandra_memtable_offheap_space_in_mb }}
+{% endif %}
+# memtable_cleanup_threshold is deprecated. The default calculation
+# is the only reasonable choice. See the comments on  memtable_flush_writers
+# for more information.
+#
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+{% if cassandra_memtable_cleanup_threshold is defined %}
+memtable_cleanup_threshold: {{ cassandra_memtable_cleanup_threshold }}
+{% endif %}
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#
+# heap_buffers
+#   on heap nio buffers
+#
+# offheap_buffers
+#   off heap (direct) nio buffers
+#
+# offheap_objects
+#    off heap objects
+#memtable_allocation_type: heap_buffers
+memtable_allocation_type: {{ cassandra_memtable_allocation_type }}
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space_in_mb: 8192
+commitlog_total_space_in_mb: {{ cassandra_commitlog_total_space_in_mb }}
+
+# This sets the number of memtable flush writer threads per disk
+# as well as the total number of memtables that can be flushed concurrently.
+# These are generally a combination of compute and IO bound.
+#
+# Memtable flushing is more CPU efficient than memtable ingest and a single thread
+# can keep up with the ingest rate of a whole server on a single fast disk
+# until it temporarily becomes IO bound under contention typically with compaction.
+# At that point you need multiple flush threads. At some point in the future
+# it may become CPU bound all the time.
+#
+# You can tell if flushing is falling behind using the MemtablePool.BlockedOnAllocation
+# metric which should be 0, but will be non-zero if threads are blocked waiting on flushing
+# to free memory.
+#
+# memtable_flush_writers defaults to two for a single data directory.
+# This means that two  memtables can be flushed concurrently to the single data directory.
+# If you have multiple data directories the default is one memtable flushing at a time
+# but the flush will use a thread per data directory so you will get two or more writers.
+#
+# Two is generally enough to flush on a fast disk [array] mounted as a single data directory.
+# Adding more flush writers will result in smaller more frequent flushes that introduce more
+# compaction overhead.
+#
+# There is a direct tradeoff between number of memtables that can be flushed concurrently
+# and flush size and frequency. More is not better you just need enough flush writers
+# to never stall waiting for flushing to free memory.
+#
+#memtable_flush_writers: 8
+{% if cassandra_memtable_flush_writers is defined %}
+memtable_flush_writers: {{ cassandra_memtable_flush_writers }}
+{% endif %}
+
+# Total space to use for change-data-capture logs on disk.
+#
+# If space gets above this value, Cassandra will throw WriteTimeoutException
+# on Mutations including tables with CDC enabled. A CDCCompactor is responsible
+# for parsing the raw CDC logs and deleting them when parsing is completed.
+#
+# The default value is the min of 4096 mb and 1/8th of the total space
+# of the drive where cdc_raw_directory resides.
+# cdc_total_space_in_mb: 4096
+
+# When we hit our cdc_raw limit and the CDCCompactor is either running behind
+# or experiencing backpressure, we check at the following interval to see if any
+# new space for cdc-tracked tables has been made available. Default to 250ms
+# cdc_free_space_check_interval_ms: 250
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+{% if cassandra_index_summary_capacity_in_mb is defined %}
+index_summary_capacity_in_mb: {{ cassandra_index_summary_capacity_in_mb }}
+{% else %}
+index_summary_capacity_in_mb:
+{% endif %}
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+#index_summary_resize_interval_in_minutes: 60
+index_summary_resize_interval_in_minutes: {{ cassandra_index_summary_resize_interval_in_minutes }}
+
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+#trickle_fsync: false
+#trickle_fsync_interval_in_kb: 10240
+trickle_fsync: {{ cassandra_trickle_fsync }}
+trickle_fsync_interval_in_kb: {{ cassandra_trickle_fsync_interval_in_kb }}
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+storage_port: {{ cassandra_storage_port }}
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+ssl_storage_port: {{ cassandra_ssl_storage_port }}
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+# listen_address: localhost
+
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# listen_interface: eth0
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# listen_interface_prefer_ipv6: false
+{% if cassandra_listen_address is defined %}
+listen_address: {{ cassandra_listen_address }}
+{% elif cassandra_listen_interface is defined %}
+listen_interface: {{cassandra_listen_interface}}
+{% else %}
+listen_address: localhost
+{% endif %}
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+{% if cassandra_memtable_broadcast_address is defined %}
+broadcast_address: {{ cassandra_broadcast_address }}
+{% endif %}
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+{% if cassandra_listen_on_broadcast_address is defined %}
+listen_on_broadcast_address: {{ cassandra_listen_on_broadcast_address }}
+{% endif %}
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+internode_authenticator: {{ cassandra_internode_authenticator }}
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: {{ cassandra_start_native_transport }}
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: {{ cassandra_native_transport_port }}
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+# native_transport_port_ssl: 9142
+{% if cassandra_native_transport_port_ssl is defined %}
+native_transport_port_ssl: {{ cassandra_native_transport_port_ssl }}
+{% endif %}
+
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+{% if cassandra_native_transport_max_threads is defined %}
+native_transport_max_threads: {{ cassandra_native_transport_max_threads }}
+{% endif %}
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB. If you're changing this parameter,
+# you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
+# native_transport_max_frame_size_in_mb: 256
+{% if cassandra_native_transport_max_frame_size_in_mb is defined %}
+native_transport_max_frame_size_in_mb: {{ cassandra_native_transport_max_frame_size_in_mb }}
+{% endif %}
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+{% if cassandra_native_transport_max_concurrent_connections is defined %}
+native_transport_max_concurrent_connections: {{ cassandra_native_transport_max_concurrent_connections }}
+{% endif %}
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+{% if cassandra_native_transport_max_concurrent_connections_per_ip is defined %}
+native_transport_max_concurrent_connections_per_ip: {{ cassandra_native_transport_max_concurrent_connections_per_ip }}
+{% endif %}
+
+# Whether to start the thrift rpc server.
+#start_rpc: false
+start_rpc: {{ cassandra_start_rpc }}
+
+# The address or interface to bind the Thrift RPC service and native transport
+# server to.
+#
+# Set rpc_address OR rpc_interface, not both.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#rpc_address: localhost
+
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# rpc_interface: eth1
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# rpc_interface_prefer_ipv6: false
+{% if cassandra_rpc_address is defined %}
+rpc_address: {{ cassandra_rpc_address }}
+{% elif cassandra_rpc_interface is defined %}
+rpc_interface: {{cassandra_rpc_interface}}
+{% else %}
+rpc_address: localhost
+{% endif %}
+
+# port for Thrift to listen for clients on
+rpc_port: {{ cassandra_rpc_port }}
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+{% if cassandra_broadcast_rpc_address is defined %}
+broadcast_rpc_address: {{ cassandra_broadcast_rpc_address }}
+{% endif %}
+
+# enable or disable keepalive on rpc/native connections
+#rpc_keepalive: true
+rpc_keepalive: {{ cassandra_rpc_keepalive }}
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync
+#   One thread per thrift connection. For a very large number of clients, memory
+#   will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#   per thread, and that will correspond to your use of virtual memory (but physical memory
+#   may be limited depending on use of stack space).
+#
+# hsha
+#   Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#   asynchronously using a small number of threads that does not vary with the amount
+#   of thrift clients (and thus scales well to many clients). The rpc requests are still
+#   synchronous (one thread per active request). If hsha is selected then it is essential
+#   that rpc_max_threads is changed from the default value of unlimited.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+#rpc_server_type: sync
+rpc_server_type: {{ cassandra_rpc_server_type }}
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+# rpc_min_threads: {{ cassandra_rpc_min_threads }}
+# rpc_max_threads: {{ cassandra_rpc_max_threads }}
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+{% if cassandra_rpc_send_buff_size_in_bytes is defined %}
+rpc_send_buff_size_in_bytes: {{ cassandra_rpc_send_buff_size_in_bytes }}
+{% endif %}
+{% if cassandra_rpc_recv_buff_size_in_bytes is defined %}
+rpc_recv_buff_size_in_bytes: {{ cassandra_rpc_recv_buff_size_in_bytes }}
+{% endif %}
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See also:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and 'man tcp'
+# internode_send_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# internode_recv_buff_size_in_bytes:
+{% if cassandra_internode_send_buff_size_in_bytes is defined %}
+internode_send_buff_size_in_bytes: {{ cassandra_internode_send_buff_size_in_bytes }}
+{% endif %}
+{% if cassandra_rpc_recv_buff_size_in_bytes is defined %}
+internode_recv_buff_size_in_bytes: {{ cassandra_internode_recv_buff_size_in_bytes }}
+{% endif %}
+
+# Frame size for thrift (maximum message length).
+#thrift_framed_transport_size_in_mb: 15
+thrift_framed_transport_size_in_mb: {{ cassandra_thrift_framed_transport_size_in_mb }}
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: {{ cassandra_incremental_backups }}
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: {{ cassandra_snapshot_before_compaction }}
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: {{ cassandra_auto_snapshot }}
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#
+# - a smaller granularity means more index entries are generated
+#   and looking up rows withing the partition by collation column
+#   is faster
+# - but, Cassandra will keep the collation index in memory for hot
+#   rows (as part of the key cache), so a larger granularity means
+#   you can cache more hot rows
+column_index_size_in_kb: {{ cassandra_column_index_size_in_kb }}
+
+# Per sstable indexed key cache entries (the collation index in memory
+# mentioned above) exceeding this size will not be held on heap.
+# This means that only partition information is held on heap and the
+# index entries are read from disk.
+#
+# Note that this size refers to the size of the
+# serialized index information and not the size of the partition.
+column_index_cache_size_in_kb: {{ cassandra_column_index_cache_size_in_kb }}
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+concurrent_compactors: {{ cassandra_concurrent_compactors }}
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+#compaction_throughput_mb_per_sec: 16
+compaction_throughput_mb_per_sec: {{ cassandra_compaction_throughput_mb_per_sec }}
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: {{ cassandra_sstable_preemptive_open_interval_in_mb }}
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+stream_throughput_outbound_megabits_per_sec: {{ cassandra_stream_throughput_outbound_megabits_per_sec }}
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 25 MB/s
+# inter_dc_stream_throughput_outbound_megabits_per_sec: 200
+inter_dc_stream_throughput_outbound_megabits_per_sec: {{ cassandra_inter_dc_stream_throughput_outbound_megabits_per_sec }}
+
+# How long the coordinator should wait for read operations to complete
+#read_request_timeout_in_ms: 5000
+read_request_timeout_in_ms: {{ cassandra_read_request_timeout_in_ms }}
+# How long the coordinator should wait for seq or index scans to complete
+#range_request_timeout_in_ms: 10000
+range_request_timeout_in_ms: {{ cassandra_range_request_timeout_in_ms }}
+# How long the coordinator should wait for writes to complete
+#write_request_timeout_in_ms: 2000
+write_request_timeout_in_ms: {{ cassandra_write_request_timeout_in_ms }}
+# How long the coordinator should wait for counter writes to complete
+#counter_write_request_timeout_in_ms: 5000
+counter_write_request_timeout_in_ms: {{ cassandra_counter_write_request_timeout_in_ms }}
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+#cas_contention_timeout_in_ms: 1000
+cas_contention_timeout_in_ms: {{ cassandra_cas_contention_timeout_in_ms }}
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+#truncate_request_timeout_in_ms: 60000
+truncate_request_timeout_in_ms: {{ cassandra_truncate_request_timeout_in_ms }}
+# The default timeout for other, miscellaneous operations
+#request_timeout_in_ms: 10000
+request_timeout_in_ms: {{ cassandra_request_timeout_in_ms }}
+
+# How long before a node logs slow queries. Select queries that take longer than
+# this timeout to execute, will generate an aggregated log message, so that slow queries
+# can be identified. Set this value to zero to disable slow query logging.
+slow_query_log_timeout_in_ms: {{ cassandra_slow_query_log_timeout_in_ms }}
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+#cross_node_timeout: false
+cross_node_timeout: {{ cassandra_cross_node_timeout }}
+
+# Set keep-alive period for streaming
+# This node will send a keep-alive message periodically with this period.
+# If the node does not receive a keep-alive message from the peer for
+# 2 keep-alive cycles the stream session times out and fail
+# Default value is 300s (5 minutes), which means stalled stream
+# times out in 10 minutes by default
+streaming_keep_alive_period_in_secs: {{ cassandra_streaming_keep_alive_period_in_secs }}
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+phi_convict_threshold: {{ cassandra_phi_convict_threshold }}
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+#
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# CASSANDRA WILL NOT ALLOW YOU TO SWITCH TO AN INCOMPATIBLE SNITCH
+# ONCE DATA IS INSERTED INTO THE CLUSTER.  This would cause data loss.
+# This means that if you start with the default SimpleSnitch, which
+# locates every node on "rack1" in "datacenter1", your only options
+# if you need to add another datacenter are GossipingPropertyFileSnitch
+# (and the older PFS).  From there, if you want to migrate to an
+# incompatible snitch like Ec2Snitch you can do it by adding new nodes
+# under Ec2Snitch (which will locate them in a new "datacenter") and
+# decommissioning the old ones.
+#
+# Out of the box, Cassandra provides:
+#
+# SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#
+# GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#
+# PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#
+# Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#
+# Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: {{ cassandra_endpoint_snitch }}
+
+# controls how often to perform the more expensive part of host score
+# calculation
+#dynamic_snitch_update_interval_in_ms: 100
+dynamic_snitch_update_interval_in_ms: {{ cassandra_dynamic_snitch_update_interval_in_ms }}
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+#dynamic_snitch_reset_interval_in_ms: 600000
+dynamic_snitch_reset_interval_in_ms: {{ cassandra_dynamic_snitch_reset_interval_in_ms }}
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+#dynamic_snitch_badness_threshold: 0.1
+dynamic_snitch_badness_threshold: {{ cassandra_dynamic_snitch_badness_threshold }}
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+#
+# NoScheduler
+#   Has no options
+#
+# RoundRobin
+#   throttle_limit
+#     The throttle_limit is the number of in-flight
+#     requests per client.  Requests beyond
+#     that limit are queued up until
+#     running requests can complete.
+#     The value of 80 here is twice the number of
+#     concurrent_reads + concurrent_writes.
+#   default_weight
+#     default_weight is optional and allows for
+#     overriding the default which is 1.
+#   weights
+#     Weights are optional and will default to 1 or the
+#     overridden default_weight. The weight translates into how
+#     many requests are handled during each turn of the
+#     RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# JVM defaults for supported SSL socket protocols and cipher suites can
+# be replaced using custom encryption options. This is not recommended
+# unless you have policies in place that dictate certain settings, or
+# need to disable vulnerable ciphers or protocols in case the JVM cannot
+# be updated.
+# FIPS compliant settings can be configured at JVM level and should not
+# involve changing encryption settings here:
+# https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/FIPS.html
+# *NOTE* No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    internode_encryption: {{ cassandra_ssl_internode_encryption }}
+    keystore: {{ cassandra_ssl_internode_keystore_file }}
+    keystore_password: {{ cassandra_ssl_internode_keystore_pass }}
+    truststore: {{ cassandra_ssl_truststore_file }}
+    truststore_password: {{ cassandra_ssl_truststore_pass }}
+    # More advanced defaults below:
+    protocol: {{ cassandra_ssl_internode_protocol }}
+    algorithm: SunX509
+    store_type: JKS
+{% if cassandra_cipher_suites_server_encryption is defined %}
+    cipher_suites:
+    {{ cassandra_cipher_suites_server_encryption | to_nice_yaml(indent=4) | trim | indent(4) }}
+{% endif %}
+    require_client_auth: {{ cassandra_ssl_internode_require_client_auth }}
+    require_endpoint_verification: {{ cassandra_require_endpoint_verification }}
+
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: {{ cassandra_ssl_client_encryption_enabled }}
+    # If enabled and optional is set to true encrypted and unencrypted connections are handled.
+    optional: {{ cassandra_ssl_client_encryption_optional }}
+    keystore: {{ cassandra_ssl_client_keystore_file }}
+    keystore_password: {{ cassandra_ssl_client_keystore_pass }}
+    require_client_auth: {{ cassandra_ssl_client_require_client_auth }}
+    # Set trustore and truststore_password if require_client_auth is true
+    truststore: {{ cassandra_ssl_truststore_file }}
+    truststore_password: {{ cassandra_ssl_truststore_pass }}
+    # More advanced defaults below:
+    protocol: {{ cassandra_ssl_client_encryption_protocol }}
+    algorithm: SunX509
+    store_type: JKS
+{% if cassandra_cipher_suites_client_encryption is defined %}
+    cipher_suites:
+    {{ cassandra_cipher_suites_client_encryption | to_nice_yaml(indent=4) | trim | indent(4) }}
+{% endif %}
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# Can be:
+#
+# all
+#   all traffic is compressed
+#
+# dc
+#   traffic between different datacenters is compressed
+#
+# none
+#   nothing is compressed.
+#internode_compression: all
+internode_compression: {{ cassandra_internode_compression }}
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+#inter_dc_tcp_nodelay: false
+inter_dc_tcp_nodelay: {{ cassandra_inter_dc_tcp_nodelay }}
+
+# TTL for different trace types used during logging of the repair process.
+#tracetype_query_ttl: 86400
+tracetype_query_ttl: {{ cassandra_tracetype_query_ttl }}
+#tracetype_repair_ttl: 604800
+tracetype_repair_ttl: {{ cassandra_tracetype_repair_ttl }}
+
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# gc_log_threshold_in_ms: 200
+gc_log_threshold_in_ms: {{ cassandra_gc_log_threshold_in_ms }}
+
+# If unset, all GC Pauses greater than gc_log_threshold_in_ms will log at
+# INFO level
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
+enable_user_defined_functions: {{ cassandra_enable_user_defined_functions }}
+
+# Enables scripted UDFs (JavaScript UDFs).
+# Java UDFs are always enabled, if enable_user_defined_functions is true.
+# Enable this option to be able to use UDFs with "language javascript" or any custom JSR-223 provider.
+# This option has no effect, if enable_user_defined_functions is false.
+enable_scripted_user_defined_functions: {{ cassandra_enable_scripted_user_defined_functions }}
+
+# Enables materialized view creation on this node.
+# Materialized views are considered experimental and are not recommended for production use.
+enable_materialized_views: {{ cassandra_enable_materialized_views }}
+
+# The default Windows kernel timer and scheduling resolution is 15.6ms for power conservation.
+# Lowering this value on Windows can provide much tighter latency and better throughput, however
+# some virtualized environments may see a negative performance impact from changing this setting
+# below their system default. The sysinternals 'clockres' tool can confirm your system's default
+# setting.
+windows_timer_interval: {{ cassandra_windows_timer_interval }}
+
+
+# Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
+# a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
+# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# can still (and should!) be in the keystore and will be used on decrypt operations
+# (to handle the case of key rotation).
+#
+# It is strongly recommended to download and install Java Cryptography Extension (JCE)
+# Unlimited Strength Jurisdiction Policy Files for your version of the JDK.
+# (current link: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+#
+# Currently, only the following file types are supported for transparent data encryption, although
+# more are coming in future cassandra releases: commitlog, hints
+transparent_data_encryption_options:
+    enabled: false
+    chunk_length_kb: 64
+    cipher: AES/CBC/PKCS5Padding
+    key_alias: testing:1
+    # CBC IV length for AES needs to be 16 bytes (which is also the default size)
+    # iv_length: 16
+    key_provider:
+      - class_name: org.apache.cassandra.security.JKSKeyProvider
+        parameters:
+          - keystore: conf/.keystore
+            keystore_password: cassandra
+            store_type: JCEKS
+            key_password: cassandra
+
+
+#####################
+# SAFETY THRESHOLDS #
+#####################
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+tombstone_warn_threshold: {{ cassandra_tombstone_warn_threshold }}
+# tombstone_failure_threshold: 100000
+tombstone_failure_threshold: {{ cassandra_tombstone_failure_threshold }}
+
+# Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+# batch_size_warn_threshold_in_kb: 5
+batch_size_warn_threshold_in_kb: {{ cassandra_batch_size_warn_threshold_in_kb }}
+
+
+# Fail any multiple-partition batch exceeding this value. 50kb (10x warn threshold) by default.
+# batch_size_fail_threshold_in_kb: 50
+batch_size_fail_threshold_in_kb: {{ cassandra_batch_size_fail_threshold_in_kb }}
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+# unlogged_batch_across_partitions_warn_threshold: 10
+unlogged_batch_across_partitions_warn_threshold: {{ cassandra_unlogged_batch_across_partitions_warn_threshold }}
+
+# Log a warning when compacting partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 100
+compaction_large_partition_warning_threshold_mb: {{ cassandra_compaction_large_partition_warning_threshold_mb }}
+
+# GC Pauses greater than gc_warn_threshold_in_ms will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+gc_warn_threshold_in_ms: {{ cassandra_gc_warn_threshold_in_ms }}
+
+# Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
+# early. Any value size larger than this threshold will result into marking an SSTable
+# as corrupted. This should be positive and less than 2048.
+# max_value_size_in_mb: 256
+{% if cassandra_max_value_size_in_mb is defined %}
+max_value_size_in_mb: {{ cassandra_max_value_size_in_mb }}
+{% endif %}
+
+# Back-pressure settings #
+# If enabled, the coordinator will apply the back-pressure strategy specified below to each mutation
+# sent to replicas, with the aim of reducing pressure on overloaded replicas.
+# back_pressure_enabled: false
+back_pressure_enabled: {{ cassandra_back_pressure_enabled }}
+# The back-pressure strategy applied.
+# The default implementation, RateBasedBackPressure, takes three arguments:
+# high ratio, factor, and flow type, and uses the ratio between incoming mutation responses and outgoing mutation requests.
+# If below high ratio, outgoing mutations are rate limited according to the incoming rate decreased by the given factor;
+# if above high ratio, the rate limiting is increased by the given factor;
+# such factor is usually best configured between 1 and 10, use larger values for a faster recovery
+# at the expense of potentially more dropped mutations;
+# the rate limiting is applied according to the flow type: if FAST, it's rate limited at the speed of the fastest replica,
+# if SLOW at the speed of the slowest one.
+# New strategies can be added. Implementors need to implement org.apache.cassandra.net.BackpressureStrategy and
+# provide a public constructor accepting a Map<String, Object>.
+back_pressure_strategy:
+    - class_name: org.apache.cassandra.net.RateBasedBackPressure
+      parameters:
+        - high_ratio: 0.90
+          factor: 5
+          flow: FAST
+
+# Coalescing Strategies #
+# Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
+# On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in
+# virtualized environments, the point at which an application can be bound by network packet processing can be
+# surprisingly low compared to the throughput of task processing that is possible inside a VM. It's not that bare metal
+# doesn't benefit from coalescing messages, it's that the number of packets a bare metal network interface can process
+# is sufficient for many applications such that no load starvation is experienced even without coalescing.
+# There are other benefits to coalescing network messages that are harder to isolate with a simple metric like messages
+# per second. By coalescing multiple tasks together, a network thread can process multiple messages for the cost of one
+# trip to read from a socket, and all the task submission work can be done at the same time reducing context switching
+# and increasing cache friendliness of network message processing.
+# See CASSANDRA-8692 for details.
+
+# Strategy to use for coalescing messages in OutboundTcpConnection.
+# Can be fixed, movingaverage, timehorizon, disabled (default).
+# You can also specify a subclass of CoalescingStrategies.CoalescingStrategy by name.
+# otc_coalescing_strategy: {{ cassandra_otc_coalescing_strategy }}
+
+# How many microseconds to wait for coalescing. For fixed strategy this is the amount of time after the first
+# message is received before it will be sent with any accompanying messages. For moving average this is the
+# maximum amount of time that will be waited as well as the interval at which messages must arrive on average
+# for coalescing to be enabled.
+# otc_coalescing_window_us: 200
+
+# Do not try to coalesce messages if we already got that many messages. This should be more than 2 and less than 128.
+# otc_coalescing_enough_coalesced_messages: 8
+
+# How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
+# Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
+# taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
+# will be appropriate. A smaller value could potentially expire messages slightly sooner at the expense of more CPU
+# time and queue contention while iterating the backlog of messages.
+# An interval of 0 disables any wait time, which is the behavior of former Cassandra versions.
+#
+# otc_backlog_expiration_interval_ms: 200

--- a/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
+++ b/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
@@ -733,7 +733,7 @@ native_transport_port: {{ cassandra_native_transport_port }}
 # from native_transport_port will use encryption for native_transport_port_ssl while
 # keeping native_transport_port unencrypted.
 # native_transport_port_ssl: 9142
-{% if cassandra_native_transport_port_ssl is defined %}
+{% if cassandra_native_transport_port_ssl is defined and cassandra_native_transport_port_ssl | string | length > 0 %}
 native_transport_port_ssl: {{ cassandra_native_transport_port_ssl }}
 {% endif %}
 

--- a/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
+++ b/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
@@ -632,10 +632,10 @@ memtable_flush_writers: {{ cassandra_memtable_flush_writers }}
 # shrink their index summaries in order to meet this limit.  However, this
 # is a best-effort process. In extreme conditions Cassandra may need to use
 # more than this amount of memory.
-{% if cassandra_index_summary_capacity_in_mb is defined %}
+{% if cassandra_index_summary_capacity_in_mb is defined and cassandra_index_summary_capacity_in_mb | string | length > 0 %}
 index_summary_capacity_in_mb: {{ cassandra_index_summary_capacity_in_mb }}
 {% else %}
-index_summary_capacity_in_mb:
+#index_summary_capacity_in_mb:
 {% endif %}
 
 # How frequently index summaries should be resampled.  This is done
@@ -698,7 +698,7 @@ listen_address: localhost
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
 # broadcast_address: 1.2.3.4
-{% if cassandra_memtable_broadcast_address is defined %}
+{% if cassandra_broadcast_address is defined and cassandra_broadcast_address | string | length > 0 %}
 broadcast_address: {{ cassandra_broadcast_address }}
 {% endif %}
 
@@ -860,10 +860,10 @@ rpc_server_type: {{ cassandra_rpc_server_type }}
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:
 # rpc_recv_buff_size_in_bytes:
-{% if cassandra_rpc_send_buff_size_in_bytes is defined %}
+{% if cassandra_rpc_send_buff_size_in_bytes is defined and cassandra_rpc_send_buff_size_in_bytes | string | length > 0 %}
 rpc_send_buff_size_in_bytes: {{ cassandra_rpc_send_buff_size_in_bytes }}
 {% endif %}
-{% if cassandra_rpc_recv_buff_size_in_bytes is defined %}
+{% if cassandra_rpc_recv_buff_size_in_bytes is defined and cassandra_rpc_recv_buff_size_in_bytes | string | length > 0 %}
 rpc_recv_buff_size_in_bytes: {{ cassandra_rpc_recv_buff_size_in_bytes }}
 {% endif %}
 
@@ -882,10 +882,10 @@ rpc_recv_buff_size_in_bytes: {{ cassandra_rpc_recv_buff_size_in_bytes }}
 # Note that when setting this, the buffer size is limited by net.core.wmem_max
 # and when not setting it it is defined by net.ipv4.tcp_wmem
 # internode_recv_buff_size_in_bytes:
-{% if cassandra_internode_send_buff_size_in_bytes is defined %}
+{% if cassandra_internode_send_buff_size_in_bytes is defined and cassandra_internode_send_buff_size_in_bytes | string | length > 0 %}
 internode_send_buff_size_in_bytes: {{ cassandra_internode_send_buff_size_in_bytes }}
 {% endif %}
-{% if cassandra_rpc_recv_buff_size_in_bytes is defined %}
+{% if cassandra_internode_recv_buff_size_in_bytes is defined and cassandra_internode_recv_buff_size_in_bytes | string | length > 0 %}
 internode_recv_buff_size_in_bytes: {{ cassandra_internode_recv_buff_size_in_bytes }}
 {% endif %}
 

--- a/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
+++ b/roles/cassandra/templates/3.11.x/cassandra.yaml.j2
@@ -327,7 +327,7 @@ key_cache_size_in_mb: {{ cassandra_key_cache_size_in_mb }}
 #
 # Default is 14400 or 4 hours.
 #key_cache_save_period: 14400
-key_cache_save_period: {{ cassandra_key_cache_save_period }}
+key_cache_save_period: {{ cassandra_key_cache_save_period_in_secs | int }}
 
 # Number of keys from the key cache to save
 # Disabled by default, meaning all keys are going to be saved
@@ -367,7 +367,7 @@ row_cache_size_in_mb: {{ cassandra_row_cache_size_in_mb }}
 #
 # Default is 0 to disable saving the row cache.
 #row_cache_save_period: 0
-row_cache_save_period: {{ cassandra_row_cache_save_period }}
+row_cache_save_period: {{ cassandra_row_cache_save_period_in_secs | int }}
 
 # Number of keys from the row cache to save.
 # Specify 0 (which is the default), meaning all keys are going to be saved
@@ -398,7 +398,7 @@ counter_cache_size_in_mb: {{ cassandra_counter_cache_size_in_mb }}
 #
 # Default is 7200 or 2 hours.
 #counter_cache_save_period: 7200
-counter_cache_save_period: {{ cassandra_counter_cache_save_period }}
+counter_cache_save_period: {{ cassandra_counter_cache_save_period_in_secs | int }}
 
 # Number of keys from the counter cache to save
 # Disabled by default, meaning all keys are going to be saved

--- a/roles/cassandra/templates/3.11.x/jvm.options.j2
+++ b/roles/cassandra/templates/3.11.x/jvm.options.j2
@@ -1,0 +1,274 @@
+# {{ ansible_managed }}
+###########################################################################
+#                             jvm.options                                 #
+#                                                                         #
+# - all flags defined here will be used by cassandra to startup the JVM   #
+# - one flag should be specified per line                                 #
+# - lines that do not start with '-' will be ignored                      #
+# - only static flags are accepted (no variables or parameters)           #
+# - dynamic flags will be appended to these on cassandra-env              #
+###########################################################################
+
+######################
+# STARTUP PARAMETERS #
+######################
+
+# Uncomment any of the following properties to enable specific startup parameters
+
+# In a multi-instance deployment, multiple Cassandra instances will independently assume that all
+# CPU processors are available to it. This setting allows you to specify a smaller set of processors
+# and perhaps have affinity.
+#-Dcassandra.available_processors=number_of_processors
+
+# The directory location of the cassandra.yaml file.
+#-Dcassandra.config=directory
+
+# Sets the initial partitioner token for a node the first time the node is started.
+#-Dcassandra.initial_token=token
+
+# Set to false to start Cassandra on a node but not have the node join the cluster.
+#-Dcassandra.join_ring=true|false
+
+# Set to false to clear all gossip state for the node on restart. Use when you have changed node
+# information in cassandra.yaml (such as listen_address).
+#-Dcassandra.load_ring_state=true|false
+
+# Enable pluggable metrics reporter. See Pluggable metrics reporting in Cassandra 2.0.2.
+#-Dcassandra.metricsReporterConfigFile=file
+
+# Set the port on which the CQL native transport listens for clients. (Default: 9042)
+#-Dcassandra.native_transport_port=port
+
+# Overrides the partitioner. (Default: org.apache.cassandra.dht.Murmur3Partitioner)
+#-Dcassandra.partitioner=partitioner
+
+# To replace a node that has died, restart a new node in its place specifying the address of the
+# dead node. The new node must not have any data in its data directory, that is, it must be in the
+# same state as before bootstrapping.
+#-Dcassandra.replace_address=listen_address or broadcast_address of dead node
+
+# Allow restoring specific tables from an archived commit log.
+#-Dcassandra.replayList=table
+
+# Allows overriding of the default RING_DELAY (30000ms), which is the amount of time a node waits
+# before joining the ring.
+#-Dcassandra.ring_delay_ms=ms
+
+# Set the port for the Thrift RPC service, which is used for client connections. (Default: 9160)
+#-Dcassandra.rpc_port=port
+
+# Set the SSL port for encrypted communication. (Default: 7001)
+#-Dcassandra.ssl_storage_port=port
+
+# Enable or disable the native transport server. See start_native_transport in cassandra.yaml.
+# cassandra.start_native_transport=true|false
+
+# Enable or disable the Thrift RPC server. (Default: true)
+#-Dcassandra.start_rpc=true/false
+
+# Set the port for inter-node communication. (Default: 7000)
+#-Dcassandra.storage_port=port
+
+# Set the default location for the trigger JARs. (Default: conf/triggers)
+#-Dcassandra.triggers_dir=directory
+
+# For testing new compaction and compression strategies. It allows you to experiment with different
+# strategies and benchmark write performance differences without affecting the production workload.
+#-Dcassandra.write_survey=true
+
+# To disable configuration via JMX of auth caches (such as those for credentials, permissions and
+# roles). This will mean those config options can only be set (persistently) in cassandra.yaml
+# and will require a restart for new values to take effect.
+#-Dcassandra.disable_auth_caches_remote_configuration=true
+
+# To disable dynamic calculation of the page size used when indexing an entire partition (during
+# initial index build/rebuild). If set to true, the page size will be fixed to the default of
+# 10000 rows per page.
+#-Dcassandra.force_default_indexing_page_size=true
+
+########################
+# GENERAL JVM SETTINGS #
+########################
+
+# enable assertions. highly suggested for correct application functionality.
+-ea
+
+# enable thread priorities, primarily so we can give periodic tasks
+# a lower priority to avoid interfering with client workload
+-XX:+UseThreadPriorities
+
+# allows lowering thread priority without being root on linux - probably
+# not necessary on Windows but doesn't harm anything.
+# see http://tech.stolsvik.com/2010/01/linux-java-thread-priorities-workar
+-XX:ThreadPriorityPolicy=42
+
+# Enable heap-dump if there's an OOM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# Per-thread stack size.
+-Xss256k
+
+# Larger interned string table, for gossip's benefit (CASSANDRA-6410)
+-XX:StringTableSize=1000003
+
+# Make sure all memory is faulted and zeroed on startup.
+# This helps prevent soft faults in containers and makes
+# transparent hugepage allocation more effective.
+-XX:+AlwaysPreTouch
+
+# Disable biased locking as it does not benefit Cassandra.
+-XX:-UseBiasedLocking
+
+# Enable thread-local allocation blocks and allow the JVM to automatically
+# resize them at runtime.
+-XX:+UseTLAB
+-XX:+ResizeTLAB
+-XX:+UseNUMA
+
+# http://www.evanjones.ca/jvm-mmap-pause.html
+-XX:+PerfDisableSharedMem
+
+# Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
+# http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:
+# comment out this entry to enable IPv6 support).
+-Djava.net.preferIPv4Stack=true
+
+### Debug options
+
+# uncomment to enable flight recorder
+#-XX:+UnlockCommercialFeatures
+#-XX:+FlightRecorder
+
+# uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
+#-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1414
+
+# uncomment to have Cassandra JVM log internal method compilation (developers only)
+#-XX:+UnlockDiagnosticVMOptions
+#-XX:+LogCompilation
+
+#################
+# HEAP SETTINGS #
+#################
+
+# Heap size is automatically calculated by cassandra-env based on this
+# formula: max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+# That is:
+# - calculate 1/2 ram and cap to 1024MB
+# - calculate 1/4 ram and cap to 8192MB
+# - pick the max
+#
+# For production use you may wish to adjust this for your environment.
+# If that's the case, uncomment the -Xmx and Xms options below to override the
+# automatic calculation of JVM heap memory.
+#
+# It is recommended to set min (-Xms) and max (-Xmx) heap sizes to
+# the same value to avoid stop-the-world GC pauses during resize, and
+# so that we can lock the heap in memory on startup to prevent any
+# of it from being swapped out.
+#-Xms4G
+#-Xmx4G
+-Xms{{ cassandra_max_heap_size }}
+-Xmx{{ cassandra_max_heap_size }}
+
+# Young generation size is automatically calculated by cassandra-env
+# based on this formula: min(100 * num_cores, 1/4 * heap size)
+#
+# The main trade-off for the young generation is that the larger it
+# is, the longer GC pause times will be. The shorter it is, the more
+# expensive GC will be (usually).
+#
+# It is not recommended to set the young generation size if using the
+# G1 GC, since that will override the target pause-time goal.
+# More info: http://www.oracle.com/technetwork/articles/java/g1gc-1984535.html
+#
+# The example below assumes a modern 8-core+ machine for decent
+# times. If in doubt, and if you do not particularly want to tweak, go
+# 100 MB per physical CPU core.
+#-Xmn800M
+
+###################################
+# EXPIRATION DATE OVERFLOW POLICY #
+###################################
+
+# Defines how to handle INSERT requests with TTL exceeding the maximum supported expiration date:
+# * REJECT: this is the default policy and will reject any requests with expiration date timestamp after 2038-01-19T03:14:06+00:00.
+# * CAP: any insert with TTL expiring after 2038-01-19T03:14:06+00:00 will expire on 2038-01-19T03:14:06+00:00 and the client will receive a warning.
+# * CAP_NOWARN: same as previous, except that the client warning will not be emitted.
+#
+#-Dcassandra.expiration_date_overflow_policy=REJECT
+
+#################
+#  GC SETTINGS  #
+#################
+
+### CMS Settings
+
+#-XX:+UseParNewGC
+#-XX:+UseConcMarkSweepGC
+#-XX:+CMSParallelRemarkEnabled
+#-XX:SurvivorRatio=8
+#-XX:MaxTenuringThreshold=1
+#-XX:CMSInitiatingOccupancyFraction=75
+#-XX:+UseCMSInitiatingOccupancyOnly
+#-XX:CMSWaitDuration=10000
+#-XX:+CMSParallelInitialMarkEnabled
+#-XX:+CMSEdenChunksRecordAlways
+# some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
+#-XX:+CMSClassUnloadingEnabled
+
+### G1 Settings (experimental, comment previous section and uncomment section below to enable)
+
+## Use the Hotspot garbage-first collector.
+-XX:+UseG1GC
+#
+## Have the JVM do less remembered set work during STW, instead
+## preferring concurrent GC. Reduces p99.9 latency.
+-XX:G1RSetUpdatingPauseTimePercent={{ cassandra_jvm_g1_rset_updating_pause_time_percent }}
+#
+## Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+## 200ms is the JVM default and lowest viable setting
+## 1000ms increases throughput. Keep it smaller than the timeouts in cassandra.yaml.
+-XX:MaxGCPauseMillis={{ cassandra_jvm_max_gc_pause_ms }}
+
+## Optional G1 Settings
+
+# Save CPU time on large (>= 16GB) heaps by delaying region scanning
+# until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+-XX:InitiatingHeapOccupancyPercent={{ cassandra_jvm_initiating_heap_occupancy_percentage }}
+
+# For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+# Otherwise equal to the number of cores when 8 or less.
+# Machines with > 10 cores should try setting these to <= full cores.
+-XX:ParallelGCThreads={{ cassandra_jvm_parallel_gc_threads }}
+# By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+# Setting both to the same value can reduce STW durations.
+-XX:ConcGCThreads={{ cassandra_jvm_conc_gc_threads }}
+
+# Do reference processing in parallel GC.
+-XX:+ParallelRefProcEnabled
+
+
+# For workloads that do large allocations, increasing the region
+# size may make things more efficient. Otherwise, let the JVM
+# set this automatically.
+{% if cassandra_jvm_g1_heap_region_size_mb is defined %}
+-XX:G1HeapRegionSize={{ cassandra_jvm_g1_heap_region_size_mb }}m
+{% endif %}
+
+### GC logging options -- uncomment to enable
+
+-XX:+PrintGCDetails
+-XX:+PrintGCDateStamps
+-XX:+PrintHeapAtGC
+-XX:+PrintTenuringDistribution
+-XX:+PrintGCApplicationStoppedTime
+-XX:+PrintPromotionFailure
+-XX:PrintFLSStatistics=1
+-Xloggc:{{ cassandra_gc_log_dir }}/gc.log
+-XX:+UseGCLogFileRotation
+-XX:NumberOfGCLogFiles={{ cassandra_jvm_gc_log_file_number }}
+-XX:GCLogFileSize={{ cassandra_jvm_gc_log_file_max_size_mb }}M
+
+-XX:+UnlockDiagnosticVMOptions
+-XX:+G1SummarizeRSetStats
+-XX:+PrintAdaptiveSizePolicy

--- a/roles/cassandra/templates/3.11.x/jvm.options.j2
+++ b/roles/cassandra/templates/3.11.x/jvm.options.j2
@@ -239,10 +239,18 @@
 # For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
 # Otherwise equal to the number of cores when 8 or less.
 # Machines with > 10 cores should try setting these to <= full cores.
+{% if cassandra_jvm_parallel_gc_threads | int > 0 %}
 -XX:ParallelGCThreads={{ cassandra_jvm_parallel_gc_threads }}
+{% else %}
+#-XX:ParallelGCThreads=16
+{% endif %}
 # By default, ConcGCThreads is 1/4 of ParallelGCThreads.
 # Setting both to the same value can reduce STW durations.
+{% if cassandra_jvm_conc_gc_threads | int > 0 %}
 -XX:ConcGCThreads={{ cassandra_jvm_conc_gc_threads }}
+{% else %}
+#-XX:ConcGCThreads=16
+{% endif %}
 
 # Do reference processing in parallel GC.
 -XX:+ParallelRefProcEnabled

--- a/roles/cassandra/templates/3.11.x/logback.xml.j2
+++ b/roles/cassandra/templates/3.11.x/logback.xml.j2
@@ -1,0 +1,119 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<!--
+In order to disable debug.log, comment-out the ASYNCDEBUGLOG
+appender reference in the root level section below.
+-->
+
+<configuration scan="true">
+  <jmxConfigurator />
+
+  <!-- No shutdown hook; we run it ourselves in StorageService after shutdown -->
+
+  <!-- SYSTEMLOG rolling file appender to system.log (INFO level) -->
+
+  <appender name="SYSTEMLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>{{ cassandra_system_log_level }}</level>
+    </filter>
+    <file>{{ cassandra_log_dir }}/system.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>{{ cassandra_log_dir }}/system.log.%i.gz</fileNamePattern>
+      <minIndex>{{ cassandra_log_rotation_min }}</minIndex>
+      <maxIndex>{{ cassandra_log_rotation_max }}</maxIndex>
+    </rollingPolicy>
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>20MB</maxFileSize>
+    </triggeringPolicy>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- DEBUGLOG rolling file appender to debug.log (all levels) -->
+
+  <appender name="DEBUGLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>{{ cassandra_log_dir }}/debug.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>{{ cassandra_log_dir }}/debug.log.%i.gz</fileNamePattern>
+      <minIndex>{{ cassandra_log_rotation_min }}</minIndex>
+      <maxIndex>{{ cassandra_log_rotation_max }}</maxIndex>
+    </rollingPolicy>
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>20MB</maxFileSize>
+    </triggeringPolicy>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- ASYNCLOG assynchronous appender to debug.log (all levels) -->
+
+  <appender name="ASYNCDEBUGLOG" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>1024</queueSize>
+    <discardingThreshold>0</discardingThreshold>
+    <includeCallerData>true</includeCallerData>
+    <appender-ref ref="DEBUGLOG" />
+  </appender>
+
+  <!-- STDOUT console appender to stdout (INFO level) -->
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>{{ cassandra_system_log_level }}</level>
+    </filter>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Uncomment bellow and corresponding appender-ref to activate logback metrics
+  <appender name="LogbackMetrics" class="com.codahale.metrics.logback.InstrumentedAppender" />
+   -->
+
+  <root level="INFO">
+    <appender-ref ref="SYSTEMLOG" />
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="ASYNCDEBUGLOG" /> <!-- Comment this line to disable debug.log -->
+    <!--
+    <appender-ref ref="LogbackMetrics" />
+    -->
+  </root>
+
+<!--
+  <logger name="org.apache.cassandra" level="DEBUG"/>
+  <logger name="com.thinkaurelius.thrift" level="ERROR"/>
+
+-->
+{% if cassandra_log_outbound_tcp_connection != 'disabled' %}
+  <logger name="org.apache.cassandra.net.OutboundTcpConnection" level="DEBUG"/>
+{% endif %}
+
+{% if cassandra_log_debug_repairs != 'disabled' %}
+  <logger name="org.apache.cassandra.net" level="DEBUG"/>
+  <logger name="org.apache.cassandra.repair" level="DEBUG"/>
+  <logger name="org.apache.cassandra.compaction" level="DEBUG"/>
+{% endif %}
+
+{% if cassandra_log_silence_status_logger == true %}
+  <logger name="org.apache.cassandra.utils.StatusLogger" level="OFF"/>
+{% endif %}
+
+</configuration>

--- a/roles/cassandra/vars/cassandra-3.11.yml
+++ b/roles/cassandra/vars/cassandra-3.11.yml
@@ -86,8 +86,10 @@ cassandra_counter_cache_keys_to_save: 100
 cassandra_buffer_pool_use_heap_if_exhausted: true
 cassandra_memtable_cleanup_threshold: 0.11
 
-# Index summary (3.11 only — unconditional in template)
-cassandra_index_summary_capacity_in_mb: ""
+# Index summary, RPC / internode buffer sizes: intentionally left undefined.
+# The 3.11 cassandra.yaml template guards each with `is defined and length > 0`
+# so the JVM picks its native defaults (or values from net.ipv4.tcp_{r,w}mem
+# for the socket buffers). Override in your playbook to force a value.
 
 # Listen / broadcast / RPC (3.11 only)
 cassandra_listen_on_broadcast_address: false
@@ -98,12 +100,8 @@ cassandra_native_transport_max_concurrent_connections_per_ip: -1
 cassandra_start_rpc: false
 cassandra_rpc_port: 9160
 cassandra_rpc_server_type: sync
-cassandra_rpc_send_buff_size_in_bytes: ""
-cassandra_rpc_recv_buff_size_in_bytes: ""
 cassandra_rpc_min_threads: 16
 cassandra_rpc_max_threads: 2048
-cassandra_internode_send_buff_size_in_bytes: ""
-cassandra_internode_recv_buff_size_in_bytes: ""
 
 # Misc 3.11-only unconditional keys
 cassandra_cross_node_timeout: false

--- a/roles/cassandra/vars/cassandra-3.11.yml
+++ b/roles/cassandra/vars/cassandra-3.11.yml
@@ -1,58 +1,120 @@
 ---
-# Legacy *_in_ms / *_in_kb / *_in_mb keys used by the Cassandra 3.11
-# cassandra.yaml template. Where the role default exposes a friendly value
-# (e.g. cassandra_max_hint_window=10800000 or "3h"), this var strips any
-# non-numeric suffix so the legacy 3.11 key receives a plain integer.
-cassandra_max_hint_window_in_ms: "{{ cassandra_max_hint_window | default(10800000) | regex_replace('[^0-9]', '') }}"
-cassandra_hinted_handoff_throttle_in_kb: "{{ cassandra_hinted_handoff_throttle | default(1024) | regex_replace('[^0-9]', '') }}"
-cassandra_hints_flush_period_in_ms: "{{ cassandra_hints_flush_period | default(10000) | regex_replace('[^0-9]', '') }}"
-cassandra_max_hints_file_size_in_mb: "{{ cassandra_max_hints_file_size | default(128) | regex_replace('[^0-9]', '') }}"
-cassandra_batchlog_replay_throttle_in_kb: "{{ cassandra_batchlog_replay_throttle | default(1024) | regex_replace('[^0-9]', '') }}"
-cassandra_roles_validity_in_ms: "{{ cassandra_roles_validity | default(120000) | regex_replace('[^0-9]', '') }}"
-cassandra_roles_update_interval_in_ms: "{{ cassandra_roles_update_interval | default(10000) | regex_replace('[^0-9]', '') }}"
-cassandra_permissions_validity_in_ms: "{{ cassandra_permissions_validity | default(60000) | regex_replace('[^0-9]', '') }}"
-cassandra_permissions_update_interval_in_ms: "{{ cassandra_permissions_update_interval | default(10000) | regex_replace('[^0-9]', '') }}"
-cassandra_credentials_validity_in_ms: "{{ cassandra_credentials_validity | default(120000) | regex_replace('[^0-9]', '') }}"
-cassandra_credentials_update_interval_in_ms: "{{ cassandra_credentials_update_interval | default(10000) | regex_replace('[^0-9]', '') }}"
-cassandra_key_cache_size_in_mb: "{{ cassandra_key_cache_size | default(512) | regex_replace('[^0-9]', '') }}"
-cassandra_row_cache_size_in_mb: "{{ cassandra_row_cache_size | default(0) | regex_replace('[^0-9]', '') }}"
-cassandra_counter_cache_size_in_mb: "{{ cassandra_counter_cache_size | default(50) | regex_replace('[^0-9]', '') }}"
-cassandra_commitlog_sync_period_in_ms: "{{ cassandra_commitlog_sync_period | default(1000) | regex_replace('[^0-9]', '') }}"
-cassandra_commitlog_segment_size_in_mb: "{{ cassandra_commitlog_segment_size | default(16) | regex_replace('[^0-9]', '') }}"
-cassandra_file_cache_size_in_mb: "{{ cassandra_file_cache_size | default(512) | regex_replace('[^0-9]', '') }}"
-cassandra_memtable_heap_space_in_mb: "{{ cassandra_memtable_heap_space | default(1024) | regex_replace('[^0-9]', '') }}"
-cassandra_memtable_offheap_space_in_mb: "{{ cassandra_memtable_offheap_space | default(4096) | regex_replace('[^0-9]', '') }}"
-cassandra_commitlog_total_space_in_mb: "{{ cassandra_commitlog_total_space | default(16384) | regex_replace('[^0-9]', '') }}"
-cassandra_index_summary_resize_interval_in_minutes: "{{ cassandra_index_summary_resize_interval | default(60) | regex_replace('[^0-9]', '') }}"
-cassandra_trickle_fsync_interval_in_kb: "{{ cassandra_trickle_fsync_interval | default(1024) | regex_replace('[^0-9]', '') }}"
-cassandra_native_transport_max_frame_size_in_mb: "{{ cassandra_native_transport_max_frame_size | default(256) | regex_replace('[^0-9]', '') }}"
-cassandra_thrift_framed_transport_size_in_mb: "{{ cassandra_thrift_framed_transport_size | default(16) | regex_replace('[^0-9]', '') }}"
-cassandra_column_index_size_in_kb: "{{ cassandra_column_index_size | default(64) | regex_replace('[^0-9]', '') }}"
-cassandra_batch_size_warn_threshold_in_kb: "{{ cassandra_batch_size_warn_threshold | default(64) | regex_replace('[^0-9]', '') }}"
-cassandra_batch_size_fail_threshold_in_kb: "{{ cassandra_batch_size_fail_threshold | default(640) | regex_replace('[^0-9]', '') }}"
-cassandra_sstable_preemptive_open_interval_in_mb: "{{ cassandra_sstable_preemptive_open_interval | default(50) | regex_replace('[^0-9]', '') }}"
-cassandra_read_request_timeout_in_ms: "{{ cassandra_read_request_timeout | default(5000) | regex_replace('[^0-9]', '') }}"
-cassandra_range_request_timeout_in_ms: "{{ cassandra_range_request_timeout | default(10000) | regex_replace('[^0-9]', '') }}"
-cassandra_write_request_timeout_in_ms: "{{ cassandra_write_request_timeout | default(2000) | regex_replace('[^0-9]', '') }}"
-cassandra_counter_write_request_timeout_in_ms: "{{ cassandra_counter_write_request_timeout | default(5000) | regex_replace('[^0-9]', '') }}"
-cassandra_cas_contention_timeout_in_ms: "{{ cassandra_cas_contention_timeout | default(1000) | regex_replace('[^0-9]', '') }}"
-cassandra_truncate_request_timeout_in_ms: "{{ cassandra_truncate_request_timeout | default(60000) | regex_replace('[^0-9]', '') }}"
-cassandra_request_timeout_in_ms: "{{ cassandra_request_timeout | default(10000) | regex_replace('[^0-9]', '') }}"
-cassandra_streaming_socket_timeout_in_ms: "{{ cassandra_streaming_socket_timeout | default(86400000) | regex_replace('[^0-9]', '') }}"
-cassandra_dynamic_snitch_update_interval_in_ms: "{{ cassandra_dynamic_snitch_update_interval | default(100) | regex_replace('[^0-9]', '') }}"
-cassandra_dynamic_snitch_reset_interval_in_ms: "{{ cassandra_dynamic_snitch_reset_interval | default(600000) | regex_replace('[^0-9]', '') }}"
-cassandra_gc_log_threshold_in_ms: "{{ cassandra_gc_log_threshold | default(200) | regex_replace('[^0-9]', '') }}"
-cassandra_gc_warn_threshold_in_ms: "{{ cassandra_gc_warn_threshold | default(1000) | regex_replace('[^0-9]', '') }}"
-cassandra_max_value_size_in_mb: "{{ cassandra_max_value_size | default(256) | regex_replace('[^0-9]', '') }}"
-cassandra_column_index_cache_size_in_kb: "{{ cassandra_column_index_cache_size | default(2) | regex_replace('[^0-9]', '') }}"
-cassandra_slow_query_log_timeout_in_ms: "{{ cassandra_slow_query_log_timeout | default(500) | regex_replace('[^0-9]', '') }}"
-cassandra_prepared_statements_cache_size_mb: "{{ cassandra_prepared_statements_cache_size | default(20) | regex_replace('[^0-9]', '') }}"
-cassandra_thrift_prepared_statements_cache_size_mb: "{{ cassandra_thrift_prepared_statements_cache_size | default(1) | regex_replace('[^0-9]', '') }}"
-cassandra_compaction_throughput_mb_per_sec: "{{ cassandra_compaction_throughput | default(16) | regex_replace('[^0-9]', '') }}"
-cassandra_stream_throughput_outbound_megabits_per_sec: "{{ cassandra_stream_throughput_outbound | default(200) | regex_replace('[^0-9]', '') }}"
-cassandra_inter_dc_stream_throughput_outbound_megabits_per_sec: "{{ cassandra_inter_dc_stream_throughput_outbound | default(200) | regex_replace('[^0-9]', '') }}"
-cassandra_compaction_large_partition_warning_threshold_mb: "{{ cassandra_compaction_large_partition_warning_threshold | default(100) | regex_replace('[^0-9]', '') }}"
-cassandra_jvm_gc_log_file_max_size_mb: "{{ cassandra_jvm_gc_log_file_max_size | default(10) | regex_replace('[^0-9]', '') }}"
+# Cassandra 3.11 uses legacy _in_ms / _in_kb / _in_mb keys in cassandra.yaml,
+# whereas the role's shared defaults (used by 4.1.x / 5.0.x) carry friendly
+# values with unit suffixes ("2s", "10MiB", "64MiB/s"). Strip the suffix and
+# multiply by the unit's base count so user overrides in either form land on
+# the correct integer 3.11 expects. A plain integer / numeric string (no
+# unit) is treated as already being in the target unit.
+#
+# The lookup tables below are private helpers (prefix `_`). The
+# `regex_replace('/s$', '')` step lets throughput vars like "64MiB/s" pass
+# through the same size table as "64MiB".
+
+_ms_units:
+  ms: 1
+  s: 1000
+  m: 60000
+  h: 3600000
+  d: 86400000
+  "": 1
+_secs_units:
+  s: 1
+  m: 60
+  h: 3600
+  d: 86400
+  "": 1
+_kb_units:
+  KiB: 1
+  MiB: 1024
+  GiB: 1048576
+  KB: 1
+  MB: 1024
+  GB: 1048576
+  K: 1
+  M: 1024
+  G: 1048576
+  "": 1
+_mb_units:
+  KiB: 0
+  MiB: 1
+  GiB: 1024
+  KB: 0
+  MB: 1
+  GB: 1024
+  K: 0
+  M: 1
+  G: 1024
+  "": 1
+# Stream throughput: 3.11 expresses these in megabits per second. The shared
+# defaults use MiB/s ("24MiB/s"); convert MiB/s to Mb/s (* 8). A plain int
+# (no unit) is treated as megabits already so the user can override directly
+# with the 3.11 unit.
+_megabit_factor:
+  KiB: 0.008
+  MiB: 8
+  GiB: 8192
+  KB: 0.008
+  MB: 8
+  GB: 8000
+  K: 0.008
+  M: 8
+  G: 8000
+  "": 1
+
+# ----- _in_ms conversions -----
+cassandra_max_hint_window_in_ms: "{{ (cassandra_max_hint_window | default(10800000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_max_hint_window | default(10800000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_hints_flush_period_in_ms: "{{ (cassandra_hints_flush_period | default(10000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_hints_flush_period | default(10000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_roles_validity_in_ms: "{{ (cassandra_roles_validity | default(120000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_roles_validity | default(120000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_roles_update_interval_in_ms: "{{ (cassandra_roles_update_interval | default(10000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_roles_update_interval | default(10000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_permissions_validity_in_ms: "{{ (cassandra_permissions_validity | default(60000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_permissions_validity | default(60000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_permissions_update_interval_in_ms: "{{ (cassandra_permissions_update_interval | default(10000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_permissions_update_interval | default(10000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_credentials_validity_in_ms: "{{ (cassandra_credentials_validity | default(120000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_credentials_validity | default(120000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_credentials_update_interval_in_ms: "{{ (cassandra_credentials_update_interval | default(10000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_credentials_update_interval | default(10000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_commitlog_sync_period_in_ms: "{{ (cassandra_commitlog_sync_period | default(10000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_commitlog_sync_period | default(10000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_read_request_timeout_in_ms: "{{ (cassandra_read_request_timeout | default(5000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_read_request_timeout | default(5000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_range_request_timeout_in_ms: "{{ (cassandra_range_request_timeout | default(10000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_range_request_timeout | default(10000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_write_request_timeout_in_ms: "{{ (cassandra_write_request_timeout | default(2000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_write_request_timeout | default(2000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_counter_write_request_timeout_in_ms: "{{ (cassandra_counter_write_request_timeout | default(5000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_counter_write_request_timeout | default(5000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_cas_contention_timeout_in_ms: "{{ (cassandra_cas_contention_timeout | default(1000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_cas_contention_timeout | default(1000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_truncate_request_timeout_in_ms: "{{ (cassandra_truncate_request_timeout | default(60000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_truncate_request_timeout | default(60000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_request_timeout_in_ms: "{{ (cassandra_request_timeout | default(10000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_request_timeout | default(10000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_streaming_socket_timeout_in_ms: "{{ (cassandra_streaming_socket_timeout | default(86400000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_streaming_socket_timeout | default(86400000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_dynamic_snitch_update_interval_in_ms: "{{ (cassandra_dynamic_snitch_update_interval | default(100) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_dynamic_snitch_update_interval | default(100) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_dynamic_snitch_reset_interval_in_ms: "{{ (cassandra_dynamic_snitch_reset_interval | default(600000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_dynamic_snitch_reset_interval | default(600000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_gc_log_threshold_in_ms: "{{ (cassandra_gc_log_threshold | default(200) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_gc_log_threshold | default(200) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_gc_warn_threshold_in_ms: "{{ (cassandra_gc_warn_threshold | default(1000) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_gc_warn_threshold | default(1000) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_slow_query_log_timeout_in_ms: "{{ (cassandra_slow_query_log_timeout | default(500) | string | regex_replace('[^0-9.]', '') | float * (_ms_units[cassandra_slow_query_log_timeout | default(500) | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+
+# ----- _in_kb / _in_mb conversions -----
+cassandra_hinted_handoff_throttle_in_kb: "{{ (cassandra_hinted_handoff_throttle | default(1024) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_kb_units[cassandra_hinted_handoff_throttle | default(1024) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_max_hints_file_size_in_mb: "{{ (cassandra_max_hints_file_size | default(128) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_max_hints_file_size | default(128) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_batchlog_replay_throttle_in_kb: "{{ (cassandra_batchlog_replay_throttle | default(1024) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_kb_units[cassandra_batchlog_replay_throttle | default(1024) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_key_cache_size_in_mb: "{{ (cassandra_key_cache_size | default(100) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_key_cache_size | default(100) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_row_cache_size_in_mb: "{{ (cassandra_row_cache_size | default(0) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_row_cache_size | default(0) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_counter_cache_size_in_mb: "{{ (cassandra_counter_cache_size | default(50) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_counter_cache_size | default(50) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_commitlog_segment_size_in_mb: "{{ (cassandra_commitlog_segment_size | default(32) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_commitlog_segment_size | default(32) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_file_cache_size_in_mb: "{{ (cassandra_file_cache_size | default(512) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_file_cache_size | default(512) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_memtable_heap_space_in_mb: "{{ (cassandra_memtable_heap_space | default(2048) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_memtable_heap_space | default(2048) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_memtable_offheap_space_in_mb: "{{ (cassandra_memtable_offheap_space | default(2048) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_memtable_offheap_space | default(2048) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_commitlog_total_space_in_mb: "{{ (cassandra_commitlog_total_space | default(8192) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_commitlog_total_space | default(8192) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_index_summary_resize_interval_in_minutes: "{{ cassandra_index_summary_resize_interval | default(60) | string | regex_replace('[^0-9]', '') | int }}"
+cassandra_trickle_fsync_interval_in_kb: "{{ (cassandra_trickle_fsync_interval | default(10240) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_kb_units[cassandra_trickle_fsync_interval | default(10240) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_native_transport_max_frame_size_in_mb: "{{ (cassandra_native_transport_max_frame_size | default(256) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_native_transport_max_frame_size | default(256) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_thrift_framed_transport_size_in_mb: "{{ (cassandra_thrift_framed_transport_size | default(15) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_thrift_framed_transport_size | default(15) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_column_index_size_in_kb: "{{ (cassandra_column_index_size | default(64) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_kb_units[cassandra_column_index_size | default(64) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_batch_size_warn_threshold_in_kb: "{{ (cassandra_batch_size_warn_threshold | default(5) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_kb_units[cassandra_batch_size_warn_threshold | default(5) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_batch_size_fail_threshold_in_kb: "{{ (cassandra_batch_size_fail_threshold | default(50) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_kb_units[cassandra_batch_size_fail_threshold | default(50) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_sstable_preemptive_open_interval_in_mb: "{{ (cassandra_sstable_preemptive_open_interval | default(50) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_sstable_preemptive_open_interval | default(50) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_max_value_size_in_mb: "{{ (cassandra_max_value_size | default(256) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_max_value_size | default(256) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_column_index_cache_size_in_kb: "{{ (cassandra_column_index_cache_size | default(2) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_kb_units[cassandra_column_index_cache_size | default(2) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_prepared_statements_cache_size_mb: "{{ (cassandra_prepared_statements_cache_size | default(20) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_prepared_statements_cache_size | default(20) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_thrift_prepared_statements_cache_size_mb: "{{ (cassandra_thrift_prepared_statements_cache_size | default(1) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_thrift_prepared_statements_cache_size | default(1) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_compaction_throughput_mb_per_sec: "{{ (cassandra_compaction_throughput | default(16) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_compaction_throughput | default(16) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_compaction_large_partition_warning_threshold_mb: "{{ (cassandra_compaction_large_partition_warning_threshold | default(100) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_compaction_large_partition_warning_threshold | default(100) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_jvm_gc_log_file_max_size_mb: "{{ (cassandra_jvm_gc_log_file_max_size | default(10) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_mb_units[cassandra_jvm_gc_log_file_max_size | default(10) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+
+cassandra_stream_throughput_outbound_megabits_per_sec: "{{ (cassandra_stream_throughput_outbound | default(200) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_megabit_factor[cassandra_stream_throughput_outbound | default(200) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
+cassandra_inter_dc_stream_throughput_outbound_megabits_per_sec: "{{ (cassandra_inter_dc_stream_throughput_outbound | default(200) | string | regex_replace('/s$', '') | regex_replace('[^0-9.]', '') | float * (_megabit_factor[cassandra_inter_dc_stream_throughput_outbound | default(200) | string | regex_replace('/s$', '') | regex_replace('[0-9. ]', '')] | default(1))) | int }}"
 
 # Tracing
 cassandra_tracetype_query_ttl: 86400
@@ -63,19 +125,12 @@ cassandra_enable_user_defined_functions: false
 cassandra_enable_scripted_user_defined_functions: false
 cassandra_enable_materialized_views: "{{ cassandra_materialized_views_enabled | default(false) | bool }}"
 
-# Cache save periods — Cassandra 3.11 expects integer seconds, not the
-# duration strings (e.g. "4h", "2h", "0s") used by 4.1.x / 5.0.x. Strip
-# any unit suffix and multiply by its second-count so user overrides in
-# either form keep working on 3.11.
-cassandra_key_cache_save_period_in_secs: >-
-  {{ (cassandra_key_cache_save_period | string | regex_replace('[^0-9]', '') | int)
-     * ({'s': 1, 'm': 60, 'h': 3600, 'd': 86400, '': 1}[cassandra_key_cache_save_period | string | regex_replace('[0-9]', '') | lower]) }}
-cassandra_row_cache_save_period_in_secs: >-
-  {{ (cassandra_row_cache_save_period | string | regex_replace('[^0-9]', '') | int)
-     * ({'s': 1, 'm': 60, 'h': 3600, 'd': 86400, '': 1}[cassandra_row_cache_save_period | string | regex_replace('[0-9]', '') | lower]) }}
-cassandra_counter_cache_save_period_in_secs: >-
-  {{ (cassandra_counter_cache_save_period | string | regex_replace('[^0-9]', '') | int)
-     * ({'s': 1, 'm': 60, 'h': 3600, 'd': 86400, '': 1}[cassandra_counter_cache_save_period | string | regex_replace('[0-9]', '') | lower]) }}
+# Cache save periods — 3.11 expects integer seconds. Shared defaults are
+# duration strings ("4h" / "0s" / "2h"). Convert with the same _secs_units
+# table.
+cassandra_key_cache_save_period_in_secs: "{{ (cassandra_key_cache_save_period | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_key_cache_save_period | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_row_cache_save_period_in_secs: "{{ (cassandra_row_cache_save_period | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_row_cache_save_period | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_counter_cache_save_period_in_secs: "{{ (cassandra_counter_cache_save_period | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_counter_cache_save_period | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
 
 # Cache save behaviour (3.11 unconditional keys)
 cassandra_key_cache_keys_to_save: 100

--- a/roles/cassandra/vars/cassandra-3.11.yml
+++ b/roles/cassandra/vars/cassandra-3.11.yml
@@ -93,7 +93,11 @@ cassandra_memtable_cleanup_threshold: 0.11
 
 # Listen / broadcast / RPC (3.11 only)
 cassandra_listen_on_broadcast_address: false
-cassandra_native_transport_port_ssl: 9142
+# native_transport_port_ssl is intentionally undefined. Cassandra 3.11 refuses
+# to start with it set unless client_encryption is enabled
+# ("Encryption must be enabled in client_encryption_options for
+# native_transport_port_ssl"). Override in your playbook (typically 9142)
+# when enabling TLS.
 cassandra_native_transport_max_threads: 128
 cassandra_native_transport_max_concurrent_connections: -1
 cassandra_native_transport_max_concurrent_connections_per_ip: -1

--- a/roles/cassandra/vars/cassandra-3.11.yml
+++ b/roles/cassandra/vars/cassandra-3.11.yml
@@ -1,0 +1,114 @@
+---
+# Legacy *_in_ms / *_in_kb / *_in_mb keys used by the Cassandra 3.11
+# cassandra.yaml template. Where the role default exposes a friendly value
+# (e.g. cassandra_max_hint_window=10800000 or "3h"), this var strips any
+# non-numeric suffix so the legacy 3.11 key receives a plain integer.
+cassandra_max_hint_window_in_ms: "{{ cassandra_max_hint_window | default(10800000) | regex_replace('[^0-9]', '') }}"
+cassandra_hinted_handoff_throttle_in_kb: "{{ cassandra_hinted_handoff_throttle | default(1024) | regex_replace('[^0-9]', '') }}"
+cassandra_hints_flush_period_in_ms: "{{ cassandra_hints_flush_period | default(10000) | regex_replace('[^0-9]', '') }}"
+cassandra_max_hints_file_size_in_mb: "{{ cassandra_max_hints_file_size | default(128) | regex_replace('[^0-9]', '') }}"
+cassandra_batchlog_replay_throttle_in_kb: "{{ cassandra_batchlog_replay_throttle | default(1024) | regex_replace('[^0-9]', '') }}"
+cassandra_roles_validity_in_ms: "{{ cassandra_roles_validity | default(120000) | regex_replace('[^0-9]', '') }}"
+cassandra_roles_update_interval_in_ms: "{{ cassandra_roles_update_interval | default(10000) | regex_replace('[^0-9]', '') }}"
+cassandra_permissions_validity_in_ms: "{{ cassandra_permissions_validity | default(60000) | regex_replace('[^0-9]', '') }}"
+cassandra_permissions_update_interval_in_ms: "{{ cassandra_permissions_update_interval | default(10000) | regex_replace('[^0-9]', '') }}"
+cassandra_credentials_validity_in_ms: "{{ cassandra_credentials_validity | default(120000) | regex_replace('[^0-9]', '') }}"
+cassandra_credentials_update_interval_in_ms: "{{ cassandra_credentials_update_interval | default(10000) | regex_replace('[^0-9]', '') }}"
+cassandra_key_cache_size_in_mb: "{{ cassandra_key_cache_size | default(512) | regex_replace('[^0-9]', '') }}"
+cassandra_row_cache_size_in_mb: "{{ cassandra_row_cache_size | default(0) | regex_replace('[^0-9]', '') }}"
+cassandra_counter_cache_size_in_mb: "{{ cassandra_counter_cache_size | default(50) | regex_replace('[^0-9]', '') }}"
+cassandra_commitlog_sync_period_in_ms: "{{ cassandra_commitlog_sync_period | default(1000) | regex_replace('[^0-9]', '') }}"
+cassandra_commitlog_segment_size_in_mb: "{{ cassandra_commitlog_segment_size | default(16) | regex_replace('[^0-9]', '') }}"
+cassandra_file_cache_size_in_mb: "{{ cassandra_file_cache_size | default(512) | regex_replace('[^0-9]', '') }}"
+cassandra_memtable_heap_space_in_mb: "{{ cassandra_memtable_heap_space | default(1024) | regex_replace('[^0-9]', '') }}"
+cassandra_memtable_offheap_space_in_mb: "{{ cassandra_memtable_offheap_space | default(4096) | regex_replace('[^0-9]', '') }}"
+cassandra_commitlog_total_space_in_mb: "{{ cassandra_commitlog_total_space | default(16384) | regex_replace('[^0-9]', '') }}"
+cassandra_index_summary_resize_interval_in_minutes: "{{ cassandra_index_summary_resize_interval | default(60) | regex_replace('[^0-9]', '') }}"
+cassandra_trickle_fsync_interval_in_kb: "{{ cassandra_trickle_fsync_interval | default(1024) | regex_replace('[^0-9]', '') }}"
+cassandra_native_transport_max_frame_size_in_mb: "{{ cassandra_native_transport_max_frame_size | default(256) | regex_replace('[^0-9]', '') }}"
+cassandra_thrift_framed_transport_size_in_mb: "{{ cassandra_thrift_framed_transport_size | default(16) | regex_replace('[^0-9]', '') }}"
+cassandra_column_index_size_in_kb: "{{ cassandra_column_index_size | default(64) | regex_replace('[^0-9]', '') }}"
+cassandra_batch_size_warn_threshold_in_kb: "{{ cassandra_batch_size_warn_threshold | default(64) | regex_replace('[^0-9]', '') }}"
+cassandra_batch_size_fail_threshold_in_kb: "{{ cassandra_batch_size_fail_threshold | default(640) | regex_replace('[^0-9]', '') }}"
+cassandra_sstable_preemptive_open_interval_in_mb: "{{ cassandra_sstable_preemptive_open_interval | default(50) | regex_replace('[^0-9]', '') }}"
+cassandra_read_request_timeout_in_ms: "{{ cassandra_read_request_timeout | default(5000) | regex_replace('[^0-9]', '') }}"
+cassandra_range_request_timeout_in_ms: "{{ cassandra_range_request_timeout | default(10000) | regex_replace('[^0-9]', '') }}"
+cassandra_write_request_timeout_in_ms: "{{ cassandra_write_request_timeout | default(2000) | regex_replace('[^0-9]', '') }}"
+cassandra_counter_write_request_timeout_in_ms: "{{ cassandra_counter_write_request_timeout | default(5000) | regex_replace('[^0-9]', '') }}"
+cassandra_cas_contention_timeout_in_ms: "{{ cassandra_cas_contention_timeout | default(1000) | regex_replace('[^0-9]', '') }}"
+cassandra_truncate_request_timeout_in_ms: "{{ cassandra_truncate_request_timeout | default(60000) | regex_replace('[^0-9]', '') }}"
+cassandra_request_timeout_in_ms: "{{ cassandra_request_timeout | default(10000) | regex_replace('[^0-9]', '') }}"
+cassandra_streaming_socket_timeout_in_ms: "{{ cassandra_streaming_socket_timeout | default(86400000) | regex_replace('[^0-9]', '') }}"
+cassandra_dynamic_snitch_update_interval_in_ms: "{{ cassandra_dynamic_snitch_update_interval | default(100) | regex_replace('[^0-9]', '') }}"
+cassandra_dynamic_snitch_reset_interval_in_ms: "{{ cassandra_dynamic_snitch_reset_interval | default(600000) | regex_replace('[^0-9]', '') }}"
+cassandra_gc_log_threshold_in_ms: "{{ cassandra_gc_log_threshold | default(200) | regex_replace('[^0-9]', '') }}"
+cassandra_gc_warn_threshold_in_ms: "{{ cassandra_gc_warn_threshold | default(1000) | regex_replace('[^0-9]', '') }}"
+cassandra_max_value_size_in_mb: "{{ cassandra_max_value_size | default(256) | regex_replace('[^0-9]', '') }}"
+cassandra_column_index_cache_size_in_kb: "{{ cassandra_column_index_cache_size | default(2) | regex_replace('[^0-9]', '') }}"
+cassandra_slow_query_log_timeout_in_ms: "{{ cassandra_slow_query_log_timeout | default(500) | regex_replace('[^0-9]', '') }}"
+cassandra_prepared_statements_cache_size_mb: "{{ cassandra_prepared_statements_cache_size | default(20) | regex_replace('[^0-9]', '') }}"
+cassandra_thrift_prepared_statements_cache_size_mb: "{{ cassandra_thrift_prepared_statements_cache_size | default(1) | regex_replace('[^0-9]', '') }}"
+cassandra_compaction_throughput_mb_per_sec: "{{ cassandra_compaction_throughput | default(16) | regex_replace('[^0-9]', '') }}"
+cassandra_stream_throughput_outbound_megabits_per_sec: "{{ cassandra_stream_throughput_outbound | default(200) | regex_replace('[^0-9]', '') }}"
+cassandra_inter_dc_stream_throughput_outbound_megabits_per_sec: "{{ cassandra_inter_dc_stream_throughput_outbound | default(200) | regex_replace('[^0-9]', '') }}"
+cassandra_compaction_large_partition_warning_threshold_mb: "{{ cassandra_compaction_large_partition_warning_threshold | default(100) | regex_replace('[^0-9]', '') }}"
+cassandra_jvm_gc_log_file_max_size_mb: "{{ cassandra_jvm_gc_log_file_max_size | default(10) | regex_replace('[^0-9]', '') }}"
+
+# Tracing
+cassandra_tracetype_query_ttl: 86400
+cassandra_tracetype_repair_ttl: 604800
+
+# UDF (3.11)
+cassandra_enable_user_defined_functions: false
+cassandra_enable_scripted_user_defined_functions: false
+cassandra_enable_materialized_views: "{{ cassandra_materialized_views_enabled | default(false) | bool }}"
+
+# Cache save behaviour (3.11 unconditional keys)
+cassandra_key_cache_keys_to_save: 100
+cassandra_row_cache_keys_to_save: 100
+cassandra_counter_cache_keys_to_save: 100
+
+# Memtable / buffer pool (3.11 only)
+cassandra_buffer_pool_use_heap_if_exhausted: true
+cassandra_memtable_cleanup_threshold: 0.11
+
+# Index summary (3.11 only — unconditional in template)
+cassandra_index_summary_capacity_in_mb: ""
+
+# Listen / broadcast / RPC (3.11 only)
+cassandra_listen_on_broadcast_address: false
+cassandra_native_transport_port_ssl: 9142
+cassandra_native_transport_max_threads: 128
+cassandra_native_transport_max_concurrent_connections: -1
+cassandra_native_transport_max_concurrent_connections_per_ip: -1
+cassandra_start_rpc: false
+cassandra_rpc_port: 9160
+cassandra_rpc_server_type: sync
+cassandra_rpc_send_buff_size_in_bytes: ""
+cassandra_rpc_recv_buff_size_in_bytes: ""
+cassandra_rpc_min_threads: 16
+cassandra_rpc_max_threads: 2048
+cassandra_internode_send_buff_size_in_bytes: ""
+cassandra_internode_recv_buff_size_in_bytes: ""
+
+# Misc 3.11-only unconditional keys
+cassandra_cross_node_timeout: false
+cassandra_streaming_keep_alive_period_in_secs: 300
+cassandra_windows_timer_interval: 1
+cassandra_back_pressure_enabled: false
+cassandra_otc_coalescing_strategy: DISABLED
+cassandra_cipher_suites_server_encryption:
+  - TLS_RSA_WITH_AES_128_CBC_SHA
+  - TLS_RSA_WITH_AES_256_CBC_SHA
+cassandra_cipher_suites_client_encryption:
+  - TLS_RSA_WITH_AES_128_CBC_SHA
+  - TLS_RSA_WITH_AES_256_CBC_SHA
+
+# Logback rotation (3.11 logback.xml.j2)
+cassandra_log_rotation_min: 1
+cassandra_log_rotation_max: 20
+
+# GC threads — 3.11 jvm.options.j2 references these unconditionally,
+# so provide neutral defaults (0 = let JVM decide).
+cassandra_jvm_parallel_gc_threads: 0
+cassandra_jvm_conc_gc_threads: 0

--- a/roles/cassandra/vars/cassandra-3.11.yml
+++ b/roles/cassandra/vars/cassandra-3.11.yml
@@ -128,9 +128,9 @@ cassandra_enable_materialized_views: "{{ cassandra_materialized_views_enabled | 
 # Cache save periods — 3.11 expects integer seconds. Shared defaults are
 # duration strings ("4h" / "0s" / "2h"). Convert with the same _secs_units
 # table.
-cassandra_key_cache_save_period_in_secs: "{{ (cassandra_key_cache_save_period | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_key_cache_save_period | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
-cassandra_row_cache_save_period_in_secs: "{{ (cassandra_row_cache_save_period | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_row_cache_save_period | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
-cassandra_counter_cache_save_period_in_secs: "{{ (cassandra_counter_cache_save_period | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_counter_cache_save_period | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_key_cache_save_period_in_secs: "{{ (cassandra_key_cache_save_period | default('4h') | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_key_cache_save_period | default('4h') | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_row_cache_save_period_in_secs: "{{ (cassandra_row_cache_save_period | default('0s') | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_row_cache_save_period | default('0s') | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
+cassandra_counter_cache_save_period_in_secs: "{{ (cassandra_counter_cache_save_period | default('2h') | string | regex_replace('[^0-9.]', '') | float * (_secs_units[cassandra_counter_cache_save_period | default('2h') | string | regex_replace('[0-9. ]', '') | lower] | default(1))) | int }}"
 
 # Cache save behaviour (3.11 unconditional keys)
 cassandra_key_cache_keys_to_save: 100

--- a/roles/cassandra/vars/cassandra-3.11.yml
+++ b/roles/cassandra/vars/cassandra-3.11.yml
@@ -63,6 +63,20 @@ cassandra_enable_user_defined_functions: false
 cassandra_enable_scripted_user_defined_functions: false
 cassandra_enable_materialized_views: "{{ cassandra_materialized_views_enabled | default(false) | bool }}"
 
+# Cache save periods — Cassandra 3.11 expects integer seconds, not the
+# duration strings (e.g. "4h", "2h", "0s") used by 4.1.x / 5.0.x. Strip
+# any unit suffix and multiply by its second-count so user overrides in
+# either form keep working on 3.11.
+cassandra_key_cache_save_period_in_secs: >-
+  {{ (cassandra_key_cache_save_period | string | regex_replace('[^0-9]', '') | int)
+     * ({'s': 1, 'm': 60, 'h': 3600, 'd': 86400, '': 1}[cassandra_key_cache_save_period | string | regex_replace('[0-9]', '') | lower]) }}
+cassandra_row_cache_save_period_in_secs: >-
+  {{ (cassandra_row_cache_save_period | string | regex_replace('[^0-9]', '') | int)
+     * ({'s': 1, 'm': 60, 'h': 3600, 'd': 86400, '': 1}[cassandra_row_cache_save_period | string | regex_replace('[0-9]', '') | lower]) }}
+cassandra_counter_cache_save_period_in_secs: >-
+  {{ (cassandra_counter_cache_save_period | string | regex_replace('[^0-9]', '') | int)
+     * ({'s': 1, 'm': 60, 'h': 3600, 'd': 86400, '': 1}[cassandra_counter_cache_save_period | string | regex_replace('[0-9]', '') | lower]) }}
+
 # Cache save behaviour (3.11 unconditional keys)
 cassandra_key_cache_keys_to_save: 100
 cassandra_row_cache_keys_to_save: 100

--- a/roles/java/vars/Debian.yml
+++ b/roles/java/vars/Debian.yml
@@ -1,9 +1,11 @@
-_java_pkg: "{% if cassandra_version is defined and cassandra_version.startswith('5') %}openjdk-17-jre-headless{% else %}openjdk-11-jre-headless{% endif %}"
+_java_pkg: "{% if cassandra_version is defined and cassandra_version.startswith('5') %}openjdk-17-jre-headless{% elif cassandra_version is defined and cassandra_version.startswith('3.11') %}openjdk-8-jre-headless{% else %}openjdk-11-jre-headless{% endif %}"
 _zulu_major_version: >-
   {%- if java_zulu_version is defined and java_zulu_version != '' -%}
     {{ java_zulu_version }}
   {%- elif cassandra_version is defined and cassandra_version.startswith('5') -%}
     17
+  {%- elif cassandra_version is defined and cassandra_version.startswith('3.11') -%}
+    8
   {%- else -%}
     11
   {%- endif -%}

--- a/roles/java/vars/RedHat.yml
+++ b/roles/java/vars/RedHat.yml
@@ -1,9 +1,11 @@
-_java_pkg: "{% if cassandra_version is defined and cassandra_version.startswith('5') %}java-17-openjdk-headless{% else %}java-11-openjdk-headless{% endif %}"
+_java_pkg: "{% if cassandra_version is defined and cassandra_version.startswith('5') %}java-17-openjdk-headless{% elif cassandra_version is defined and cassandra_version.startswith('3.11') %}java-1.8.0-openjdk-headless{% else %}java-11-openjdk-headless{% endif %}"
 _zulu_major_version: >-
   {%- if java_zulu_version is defined and java_zulu_version != '' -%}
     {{ java_zulu_version }}
   {%- elif cassandra_version is defined and cassandra_version.startswith('5') -%}
     17
+  {%- elif cassandra_version is defined and cassandra_version.startswith('3.11') -%}
+    8
   {%- else -%}
     11
   {%- endif -%}

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: Assert OS is supported
   when: preflight_check_os is defined and preflight_check_os | bool
   ansible.builtin.assert:
-    that: ansible_distribution in ['Ubuntu', 'Debian', 'CentOS', 'RedHat', 'Rocky']
+    that: ansible_distribution in ['Ubuntu', 'Debian', 'CentOS', 'RedHat', 'Rocky', 'Amazon']
     fail_msg: "Unsupported OS for Apache Cassandra."
 
 - name: Check memory


### PR DESCRIPTION
## Summary

Implements [#108](https://github.com/axonops/axonops-ansible-collection/issues/108): full install + configuration support for **Apache Cassandra 3.11.x** in the `cassandra` role.

- New `templates/3.11.x/` set with the **legacy** `cassandra.yaml` schema (`*_in_ms`/`*_in_kb`/`*_in_mb` suffixed keys).
- Single `jvm.options` file (4.x/5.x continue to use the split `jvm-server.options` + `jvm11-server.options` + `jvm-clients.options` + `jvm11-clients.options`, and 5.x additionally renders the `jvm17-*` files — all unchanged).
- New `vars/cassandra-3.11.yml` providing legacy keys plus 3.11-only defaults (`back_pressure_enabled`, `windows_timer_interval`, `otc_coalescing_strategy`, `rpc_*`, etc.).
- `tasks/main.yml`: version assert now allows `3.11`; vars / template-dir selection and config file list branch on the major version.
- `java` role auto-selects Java 8 (`openjdk-8-jre-headless` / `java-1.8.0-openjdk-headless` / Zulu 8) when `cassandra_version.startswith('3.11')`.
- 4.x/5.x-only keys (`auto_optimise_*`, `commitlog_sync_group_window`, `repaired_data_tracking_*`, `corrupted_tombstone_strategy`, `full_query_logging_options`) are **not** emitted in the 3.11 output.

## What does NOT change

- Default `cassandra_version` stays at `5.0.7`.
- 4.1.x and 5.0.x rendering, vars, templates, JVM file set, molecule scenarios — all untouched.

## Test plan

- [x] `ansible-lint roles/cassandra/ ...` clean for the new files (pre-existing `ignore_errors` violations on tasks/main.yml lines 1+11 remain unchanged and are out of scope).
- [ ] CI: `molecule -s default` passes on all distros (regression).
- [ ] CI: `molecule -s cassandra-3.11` (converge + verify + idempotence) passes on rockylinux9, rockylinux10, ubuntu2204, ubuntu2404, ubuntu2604, debian12, debian13.
- [ ] CI: `molecule -s shenandoah`, `g1`, `jks-inline-password`, `jks-tls-disabled`, `jks-empty-passwords` still pass (regression).

`verify.yml` for the new scenario asserts:
1. Tar extracted to `/opt/apache-cassandra-3.11.17`.
2. `cassandra.yaml` exists and parses as YAML with the expected `cluster_name`.
3. `jvm.options` exists; `jvm-server.options` does **not** exist.
4. None of the 4.x/5.x-only keys appear in `cassandra.yaml`.
5. Legacy keys (`commitlog_sync_period_in_ms`, `max_hint_window_in_ms`, `native_transport_max_frame_size_in_mb`) are present.

## Docs

- `roles/cassandra/README.md` — new **Supported versions** table + **Example: Cassandra 3.11** section.
- `docs/roles/cassandra.md` — new **Cassandra 3.11 support** section.
- `CHANGELOG.md` — entry under `[Unreleased] → Added`.
- `examples/cassandra-3.11.yml` — new working example playbook with the AxonOps agent.

Closes #108

Assisted-by: Claude Code