### PR TITLE
fix(cassandra): do not auto-start node on first install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Fixed
 
+- **cassandra**: the role no longer auto-starts the node on first install
+  when `cassandra_start_on_install: false`. The `Start cassandra` task's
+  `state` expression had an `{% else %}started` fall-through, so on a fresh
+  host — where `cassandra.service` is absent from `ansible_facts.services`
+  or `inactive` — it started the node regardless of the flag. The service
+  is now left untouched (`omit`) unless start is explicitly requested or the
+  node is already running.
+  ([#111](https://github.com/axonops/axonops-ansible-collection/issues/111))
+
 - **cassandra**: `cassandra_jemalloc_enabled` default used Jinja
   statement syntax (`{% true if ... %}`) instead of an expression,
   causing `Encountered unknown tag 'true'` whenever the variable was

--- a/roles/cassandra/README.md
+++ b/roles/cassandra/README.md
@@ -33,6 +33,13 @@ cassandra_rack: rack1
 cassandra_max_heap_size: 1G
 ```
 
+### Service control
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `cassandra_start_on_install` | `false` | When `false`, the role installs and (per `cassandra_start_on_boot`) enables the `cassandra` service but does **not** start it on first install — the node is left for an external operator to bootstrap. When `true`, the role starts the service. A node that is already running is always (re)started so a config change takes effect, regardless of this flag. |
+| `cassandra_start_on_boot` | `false` | Controls boot-time enablement only (`systemctl enable`). Independent of `cassandra_start_on_install` — enabling at boot does not start the node during the play. |
+
 ## TLS
 
 ### JKS (default)

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -375,7 +375,9 @@
     daemon_reload: true
     name: "cassandra"
     enabled: "{{ cassandra_start_on_boot | default(true) | bool }}"
-    state: >-
-      {% if cassandra_start_on_install %}started{% elif ansible_facts.services['cassandra.service'].state == 'running' %}started{% elif ansible_facts.services['cassandra.service'].state == 'stopped' %}stopped{% else %}started{% endif %}
+    # Start only when explicitly requested, or when the node is already running
+    # (so a config change can restart it). Otherwise leave systemd state untouched
+    # — never auto-start on first install when cassandra_start_on_install is false.
+    state: "{{ 'started' if (cassandra_start_on_install | bool or (ansible_facts.services['cassandra.service'] | default({})).state | default('') == 'running') else omit }}"
 
 # code: language=ansible


### PR DESCRIPTION
## Summary

Fixes the `cassandra` role auto-starting a node on first install even when
`cassandra_start_on_install: false`. Closes #111.

## Root cause

The `Start cassandra` task (`roles/cassandra/tasks/main.yml`) built `state`
with a multi-branch Jinja whose final branch was `{% else %}started`. On a
fresh host the `cassandra.service` unit was just written and never started, so
it is absent from `ansible_facts.services` (or `inactive`). With
`cassandra_start_on_install` false the `if` and both `elif` branches were
skipped and execution fell through to `{% else %}started` — starting the node
regardless of the flag.

## Fix

Single expression that starts only when start is explicitly requested **or**
the node is already running (preserving restart-on-config-change), otherwise
`omit` so systemd state is left untouched:

```yaml
state: "{{ 'started' if (cassandra_start_on_install | bool or (ansible_facts.services['cassandra.service'] | default({})).state | default('') == 'running') else omit }}"
```

`(... | default({})).state | default('')` guards the lookup so a missing
`cassandra.service` key cannot raise on first install.

## Verification

Evaluated the expression live via `ansible -m debug` across all four paths:

| install | service state | result |
|---------|---------------|--------|
| false | absent | `omit` (not started) |
| false | inactive | `omit` (not started) |
| false | running | `started` (restart path) |
| true | absent | `started` |

Gates run: `ansible-devops-reviewer`, `docs-quality-reviewer`, `pre-commit`
(trailing-whitespace, eof, check-yaml, yamllint) — all pass.

## Docs

- `CHANGELOG.md` — `[Unreleased]` → Fixed.
- `roles/cassandra/README.md` — new Service control table for
  `cassandra_start_on_install` / `cassandra_start_on_boot`.

## Follow-up

Molecule `no-start-on-install` scenario (asserting the `state` expression
resolves to `omit` without a live systemd) is listed in #111 testing
requirements; can land in this PR or a follow-up.

Assisted-by: Claude Code
