### PR TITLE
feat(cassandra): preflight guard for 0.6.0 data directory default change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,25 @@ All notable changes to this collection are documented here. The format is based 
 
 ## [Unreleased]
 
+### Changed
+
+- **cassandra (BREAKING)**: `cassandra_data_directory` now defaults to
+  `/var/lib/cassandra/data` (previously `/var/lib/cassandra`), matching the
+  upstream Apache Cassandra layout. New installs are unaffected. Existing
+  clusters that relied on the old default must either migrate keyspace data
+  into the new path (see "Upgrade Notes" in `roles/cassandra/README.md`) or
+  pin `cassandra_data_directory: /var/lib/cassandra`.
+  ([#96](https://github.com/axonops/axonops-ansible-collection/pull/96))
+
 ### Added
 
+- **cassandra**: preflight data-directory migration guard. The role now fails
+  fast when `cassandra_data_directory` contains no `system` keyspace directory
+  while its parent does — the signature of data still laid out with the
+  pre-0.6.0 default — instead of rewriting `cassandra.yaml` and restarting
+  Cassandra against an empty directory (which would bring the node up empty
+  with a new host ID). Controlled by `cassandra_data_directory_check`
+  (default `true`).
 - **cassandra**: Apache Cassandra 3.11 support. The role now installs and
   configures Cassandra 3.11.x via tar, using a dedicated `templates/3.11.x/`
   set (legacy `cassandra.yaml` schema with `*_in_ms` / `*_in_mb` keys, single

--- a/docs/roles/cassandra.md
+++ b/docs/roles/cassandra.md
@@ -89,6 +89,7 @@ complete playbook including AxonOps agent.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `cassandra_data_directory` | `/var/lib/cassandra/data` | Data (SSTable) directory |
+| `cassandra_data_directory_check` | `true` | Fail the play if `cassandra_data_directory` has no `system` keyspace but its parent does (unmigrated pre-0.6.0 layout) |
 | `cassandra_commitlog_directory` | `/var/lib/cassandra/commitlog` | Commit log directory |
 | `cassandra_saved_caches_directory` | `/var/lib/cassandra/saved_caches` | Saved caches directory |
 | `cassandra_hints_directory` | `/var/lib/cassandra/hints` | Hints directory |

--- a/roles/cassandra/README.md
+++ b/roles/cassandra/README.md
@@ -110,17 +110,39 @@ See `defaults/main.yml` for the full list of PEM variables (`cassandra_ssl_inter
 `/var/lib/cassandra`). New installs are unaffected.
 
 For an **existing** cluster that relied on the old default, the data path moves,
-so Cassandra would start against an empty directory. Migrate each node:
+so Cassandra would start against an empty directory. The role refuses to run in
+that situation: a preflight guard fails the play when `cassandra_data_directory`
+contains no `system` keyspace directory while its parent does (i.e. data is
+still laid out under the old default). The guard can be disabled with
+`cassandra_data_directory_check: false` once the data location is confirmed.
 
-1. Stop Cassandra on the node.
-2. Create `/var/lib/cassandra/data` and move the existing keyspace directories
+Migrate **one node at a time**, confirming the node is back to `UN` in
+`nodetool status` before moving to the next:
+
+1. Flush memtables and stop accepting writes: `nodetool drain`.
+2. Take a safety snapshot (cheap, hard links): `nodetool snapshot -t pre-datadir-move`.
+   The snapshot lives inside each keyspace directory and moves with it.
+3. Stop Cassandra on the node.
+4. Create `/var/lib/cassandra/data` and move the existing keyspace directories
    into it. The keyspace directories are the top-level subdirectories of
-   `/var/lib/cassandra` (for example `system/`, `system_schema/`, `system_auth/`,
-   and your application keyspaces). Do **not** move `commitlog/`, `hints/`,
-   `saved_caches/`, `cdc_raw/`, or filesystem metadata such as `lost+found/`.
-3. Fix ownership: `chown -R cassandra:cassandra /var/lib/cassandra/data`.
-4. Start Cassandra and verify the node rejoins the ring (`nodetool status`) and
-   that existing tables are readable.
+   `/var/lib/cassandra` (`system/`, `system_schema/`, `system_auth/`,
+   `system_distributed/`, `system_traces/`, and your application keyspaces).
+   For example:
+
+   ```bash
+   mkdir /var/lib/cassandra/data
+   cd /var/lib/cassandra
+   mv system system_schema system_auth system_distributed system_traces <your_keyspaces> data/
+   ```
+
+   Do **not** move `commitlog/`, `hints/`, `saved_caches/`, `cdc_raw/`, or
+   filesystem metadata such as `lost+found/`.
+5. Fix ownership: `chown -R cassandra:cassandra /var/lib/cassandra/data`.
+6. Start Cassandra and verify the node rejoins the ring (`nodetool status`
+   shows `UN`), schema agreement holds (`nodetool describecluster` shows a
+   single schema version), and existing tables are readable.
+7. Only then proceed to the next node. Once the whole cluster is migrated,
+   clear the snapshots: `nodetool clearsnapshot -t pre-datadir-move`.
 
 To keep the previous behavior instead, pin the variable:
 

--- a/roles/cassandra/defaults/main.yml
+++ b/roles/cassandra/defaults/main.yml
@@ -37,6 +37,11 @@ cassandra_gc_log_dir: /var/log/cassandra
 cassandra_log_dir: /var/log/cassandra
 cassandra_saved_caches_directory: /var/lib/cassandra/saved_caches
 cassandra_data_directory: /var/lib/cassandra/data
+# Refuse to run if cassandra_data_directory has no 'system' keyspace but its
+# parent directory does (data still laid out with the pre-0.6.0 default of
+# /var/lib/cassandra). See "Upgrade Notes" in the role README. Set to false
+# to bypass after migrating or for a deliberate fresh start.
+cassandra_data_directory_check: true
 cassandra_hints_directory: /var/lib/cassandra/hints
 cassandra_commitlog_directory: "/var/lib/cassandra/commitlog"
 cassandra_auto_bootstrap: true

--- a/roles/cassandra/molecule/default/verify.yml
+++ b/roles/cassandra/molecule/default/verify.yml
@@ -1,0 +1,65 @@
+---
+# BDD verification — data directory migration guard
+#
+# Behaviour under test: the role MUST refuse to run when the configured
+# cassandra_data_directory contains no 'system' keyspace directory while the
+# parent directory does (data laid out with the pre-0.6.0 default), MUST pass
+# on a fresh install, and MUST allow bypassing the guard with
+# cassandra_data_directory_check: false.
+
+- name: Verify data directory migration guard (BDD)
+  hosts: all
+  gather_facts: false
+  tasks:
+
+    - name: GIVEN — a fresh install converged with the 0.6 default layout
+      ansible.builtin.stat:
+        path: /var/lib/cassandra/data
+      register: verify_data_dir
+
+    - name: THEN — the configured data directory exists
+      ansible.builtin.assert:
+        that:
+          - verify_data_dir.stat.exists
+          - verify_data_dir.stat.isdir
+
+    - name: WHEN — the guard runs against the fresh install layout
+      ansible.builtin.include_tasks: ../../tasks/check-data-dir.yml
+      vars:
+        cassandra_data_directory: /var/lib/cassandra/data
+        cassandra_data_directory_check: true
+
+    - name: GIVEN — an unmigrated pre-0.6 layout under a scratch directory
+      ansible.builtin.file:
+        path: /tmp/guard-test/system
+        state: directory
+        mode: "0750"
+
+    - name: WHEN — the guard runs against the unmigrated layout
+      block:
+        - name: Include the data directory guard against the unmigrated layout
+          ansible.builtin.include_tasks: ../../tasks/check-data-dir.yml
+          vars:
+            cassandra_data_directory: /tmp/guard-test/data
+            cassandra_data_directory_check: true
+      rescue:
+        - name: Record that the guard failed
+          ansible.builtin.set_fact:
+            guard_failed: true
+
+    - name: THEN — the guard fails the play on the unmigrated layout
+      ansible.builtin.assert:
+        that:
+          - guard_failed | default(false) | bool
+        fail_msg: data directory guard did not fail on an unmigrated layout
+
+    - name: WHEN — the guard is disabled on the unmigrated layout
+      ansible.builtin.include_tasks: ../../tasks/check-data-dir.yml
+      vars:
+        cassandra_data_directory: /tmp/guard-test/data
+        cassandra_data_directory_check: false
+
+    - name: Clean up scratch directory
+      ansible.builtin.file:
+        path: /tmp/guard-test
+        state: absent

--- a/roles/cassandra/tasks/check-data-dir.yml
+++ b/roles/cassandra/tasks/check-data-dir.yml
@@ -1,0 +1,49 @@
+---
+# Safety guard for the 0.6.0 cassandra_data_directory default change
+# (/var/lib/cassandra -> /var/lib/cassandra/data).
+#
+# An initialized Cassandra data directory always contains a 'system' keyspace
+# directory. If the configured data directory has none but its parent does,
+# the node was deployed with the pre-0.6 default and the data has not been
+# migrated: templating the new path and restarting would boot Cassandra
+# against an empty directory (new host ID, empty node, possible cluster-wide
+# outage). Refuse to continue instead.
+#
+# Disable with cassandra_data_directory_check: false (after migrating, or for
+# a deliberate fresh start).
+
+- name: Cassandra data directory migration guard
+  when: cassandra_data_directory_check | bool
+  tags: always
+  block:
+    - name: Check for system keyspace in configured data directory
+      ansible.builtin.stat:
+        path: "{{ cassandra_data_directory }}/system"
+      register: cassandra_data_dir_system
+
+    - name: Check for system keyspace in parent of configured data directory
+      ansible.builtin.stat:
+        path: "{{ cassandra_data_directory | dirname }}/system"
+      register: cassandra_data_dir_parent_system
+
+    - name: Fail when Cassandra data has not been migrated to cassandra_data_directory
+      ansible.builtin.fail:
+        msg: >-
+          REFUSING TO PROCEED: cassandra_data_directory is set to
+          '{{ cassandra_data_directory }}', which contains no 'system' keyspace
+          directory, but '{{ cassandra_data_directory | dirname }}/system'
+          exists. This host appears to hold Cassandra data laid out with the
+          pre-0.6.0 default ('{{ cassandra_data_directory | dirname }}') that
+          has not been migrated. Continuing would rewrite cassandra.yaml to
+          point at an empty data directory and restart Cassandra, bringing the
+          node up empty with a new host ID. Either follow the migration steps
+          in the cassandra role README ("Upgrade Notes"), or pin
+          'cassandra_data_directory: {{ cassandra_data_directory | dirname }}'
+          to keep the old layout. Set 'cassandra_data_directory_check: false'
+          to bypass this guard once the data location has been confirmed.
+      when:
+        - not cassandra_data_dir_system.stat.exists
+        - cassandra_data_dir_parent_system.stat.exists
+        - cassandra_data_dir_parent_system.stat.isdir | default(false)
+
+# code: language=ansible

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -84,6 +84,9 @@
   when: ansible_os_family == "RedHat"
   tags: always
 
+- name: Data directory migration safety check
+  ansible.builtin.import_tasks: check-data-dir.yml
+
 - name: Install from pkg
   when: cassandra_install_format == "pkg"
   ansible.builtin.import_tasks: install-pkg.yml


### PR DESCRIPTION
## Summary

Follow-up to #96, which changed the `cassandra_data_directory` default from `/var/lib/cassandra` to `/var/lib/cassandra/data` (ships in 0.6.0). On an existing cluster deployed with the 0.5 default, re-running the playbook after upgrading the collection rewrites `cassandra.yaml` and the `Restart Cassandra` handler restarts the node against a freshly created **empty** data directory — the node comes up with no system keyspace, a new host ID, and serves empty data. The handler fires on any config change regardless of `cassandra_start_on_install`, so README guidance alone cannot prevent it.

This PR adds a preflight filesystem guard so the dangerous path fails loudly before any directory creation, config templating, or restart.

## Changes

- **New guard** `roles/cassandra/tasks/check-data-dir.yml`, imported early in `tasks/main.yml` with `tags: always`: fails the play when `{{ cassandra_data_directory }}/system` does not exist but `{{ cassandra_data_directory | dirname }}/system` does (an initialized Cassandra data directory always contains a `system` keyspace directory, so this is the signature of an unmigrated pre-0.6.0 layout). The failure message includes both paths, the migration steps location, the pin-old-default alternative, and the bypass variable.
- **New variable** `cassandra_data_directory_check` (default `true`) to bypass the guard after migration or for a deliberate fresh start.
- **Hardened README migration steps**: `nodetool drain` before stop, `nodetool snapshot` before the move, explicit `mv` example listing the system keyspaces, one-node-at-a-time rolling order with `nodetool status` UN verification, post-start schema agreement check, snapshot cleanup.
- **CHANGELOG**: adds the missing `[Unreleased]` entry for the #96 breaking change, plus an entry for the new guard.
- **Docs**: `docs/roles/cassandra.md` variable table row for the new variable.
- **Molecule**: new `roles/cassandra/molecule/default/verify.yml` (BDD style) asserting the guard passes on the converged fresh install, fails on a simulated unmigrated layout (scratch dir sentinel), and is skippable via the bypass variable.

## Behavior matrix (verified locally with ad-hoc playbook)

| Scenario | Result |
|---|---|
| Unmigrated upgrade (`<parent>/system` exists, data dir empty) | **fails with actionable message** |
| Fresh install (no `system` anywhere) | passes |
| Migrated (`<data_dir>/system` exists) | passes |
| Pinned old default (`cassandra_data_directory: /var/lib/cassandra`) | passes |
| `cassandra_data_directory_check: false` | guard skipped |

## Testing

- Guard logic exercised across all five matrix cases with a local ad-hoc playbook (include of `check-data-dir.yml` against scratch directories).
- `ansible-lint` clean on all new/changed files (two pre-existing `ignore-errors` violations in `tasks/main.yml` untouched, out of scope).
- New molecule verify playbook for the `default` scenario; existing scenarios cover the fresh-install pass path implicitly.

## Notes

- Should land before the 0.6.0 Galaxy release (galaxy.yml is already at 0.6.0).
- Trivial-skip CHANGELOG exemption not used — CHANGELOG updated.

Assisted-by: Claude Code
