### PR TITLE
feat(cassandra): provision cqlsh venv for Python 3.12+ hosts (#116)

### DIFF
--- a/.github/workflows/cassandra-molecule.yml
+++ b/.github/workflows/cassandra-molecule.yml
@@ -74,7 +74,7 @@ jobs:
           MOLECULE_INSTANCE_NAME: cassandra-${{ matrix.scenario }}-${{ matrix.distro }}
 
       - name: Run Molecule verify
-        if: contains(matrix.scenario, 'jks-') || matrix.scenario == 'cassandra-3.11'
+        if: contains(matrix.scenario, 'jks-') || matrix.scenario == 'cassandra-3.11' || matrix.scenario == 'default'
         run: molecule -v verify -s ${{ matrix.scenario }}
         env:
           PY_COLORS: '1'
@@ -84,7 +84,7 @@ jobs:
           MOLECULE_INSTANCE_NAME: cassandra-${{ matrix.scenario }}-${{ matrix.distro }}
 
       - name: Run Molecule idempotence
-        if: contains(matrix.scenario, 'jks-') || matrix.scenario == 'cassandra-3.11'
+        if: contains(matrix.scenario, 'jks-') || matrix.scenario == 'cassandra-3.11' || matrix.scenario == 'default'
         run: molecule -v idempotence -s ${{ matrix.scenario }}
         env:
           PY_COLORS: '1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Added
 
+- **cassandra role**: cqlsh now works on hosts whose system Python is >= 3.12
+  (Ubuntu 24.04, Debian 13), where the bundled cqlsh aborts on removed stdlib
+  modules. The role provisions an isolated Python virtual environment with the
+  maintained standalone `cqlsh` package and installs a wrapper at
+  `/usr/local/bin/cqlsh` that launches it, shadowing the broken distribution
+  `cqlsh` on `PATH` so the plain command works (configurable via
+  `cassandra_cqlsh_wrapper_path`). New variables:
+  `cassandra_cqlsh_venv_enabled`, `cassandra_cqlsh_venv_path`,
+  `cassandra_cqlsh_python`, `cassandra_cqlsh_venv_packages`,
+  `cassandra_cqlsh_wrapper_path` (see the cassandra role README for defaults).
+  ([#116](https://github.com/axonops/axonops-ansible-collection/issues/116))
+
 - **kafka role**: added `README.md` with full variable reference, quick start, and usage examples; fixes Galaxy publish failure caused by missing role readme.
 
 - **cassandra**: preflight data-directory migration guard. The role now fails

--- a/roles/cassandra/README.md
+++ b/roles/cassandra/README.md
@@ -40,6 +40,52 @@ cassandra_max_heap_size: 1G
 | `cassandra_start_on_install` | `false` | When `false`, the role installs and (per `cassandra_start_on_boot`) enables the `cassandra` service but does **not** start it on first install — the node is left for an external operator to bootstrap. When `true`, the role starts the service. A node that is already running is always (re)started so a config change takes effect, regardless of this flag. |
 | `cassandra_start_on_boot` | `false` | Controls boot-time enablement only (`systemctl enable`). Independent of `cassandra_start_on_install` — enabling at boot does not start the node during the play. |
 
+## cqlsh on modern Python (3.12+)
+
+The `cqlsh` shipped with Apache Cassandra relies on a Python driver that imports
+stdlib modules removed in Python 3.12 (e.g. `asyncore`, `imp`). On distributions
+whose **system Python is 3.12 or newer — notably Ubuntu 24.04 and Debian 13** —
+the bundled `cqlsh` aborts at startup with an import error. Older distros (Rocky
+Linux 9, Ubuntu 22.04, Debian 12) ship Python 3.9–3.11 and are unaffected.
+
+To make `cqlsh` work everywhere, the role provisions a dedicated Python virtual
+environment containing the maintained standalone [`cqlsh`](https://pypi.org/project/cqlsh/)
+package (which supports modern Python) and installs a wrapper that launches it.
+The system Python and the distribution's own `cqlsh` are left untouched.
+
+By default the wrapper is installed as `/usr/local/bin/cqlsh`, which **shadows**
+the broken distribution `cqlsh` on the `PATH` (`/usr/local/bin` precedes the
+tar install's `bin/` directory), so the plain command just works:
+
+```bash
+cqlsh <host> <port>
+```
+
+To install the wrapper side-by-side instead of shadowing, set
+`cassandra_cqlsh_wrapper_path: /usr/local/bin/cqlsh-venv` and invoke it
+explicitly:
+
+```bash
+cqlsh-venv <host> <port>
+```
+
+| Variable | Type | Default | Purpose |
+|----------|------|---------|---------|
+| `cassandra_cqlsh_venv_enabled` | bool | `true` | Provision the cqlsh venv and wrapper. Set `false` to skip entirely. |
+| `cassandra_cqlsh_venv_path` | string | `/opt/cassandra-cqlsh-venv` | Absolute path of the virtual environment. |
+| `cassandra_cqlsh_python` | string | `python3` | Target-host interpreter used to create the venv. The target's own `python3` is fine — the standalone `cqlsh` package supports Python 3.12+. |
+| `cassandra_cqlsh_venv_packages` | list | `[cqlsh]` | Packages installed into the venv. `cqlsh` pulls in a compatible driver. Pin a version (e.g. `[cqlsh==6.2.0]`) for reproducible installs. |
+| `cassandra_cqlsh_wrapper_path` | string | `/usr/local/bin/cqlsh` | Path of the wrapper script that execs cqlsh from the venv. Defaults to shadowing the distribution `cqlsh` on `PATH`. |
+
+Set `cassandra_cqlsh_venv_enabled: false` on distributions whose Python is 3.11
+or earlier (where the bundled cqlsh already works), or in air-gapped
+environments without a PyPI mirror.
+
+> **Note:** provisioning the venv installs `cqlsh` from PyPI, so the **target
+> host** needs network access (or an internal PyPI mirror) at provision time.
+> The venv is built with the target host's own `python3`; no additional Python
+> version is required.
+
 ## TLS
 
 ### JKS (default)

--- a/roles/cassandra/defaults/main.yml
+++ b/roles/cassandra/defaults/main.yml
@@ -15,6 +15,27 @@ cassandra_version: 5.0.8
 cassandra_cqlai_version: 0.1.7
 cassandra_cqlai_binary: "{{ _cassandra_cqlai_binary }}"
 
+# cqlsh virtual environment.
+# The cqlsh bundled with Cassandra fails on hosts whose system Python is >= 3.12
+# (Ubuntu 24.04, Debian 13) because its Python driver imports stdlib modules
+# removed in 3.12 (asyncore, imp). When enabled, the role provisions an isolated
+# venv with the maintained standalone `cqlsh` package and exposes it via a
+# wrapper, so cqlsh works regardless of the host Python version.
+cassandra_cqlsh_venv_enabled: true
+# Absolute path of the cqlsh virtual environment.
+cassandra_cqlsh_venv_path: /opt/cassandra-cqlsh-venv
+# Host interpreter used to create the venv (the host's own python3 is fine —
+# the standalone cqlsh package supports modern Python).
+cassandra_cqlsh_python: python3
+# Packages installed into the venv. `cqlsh` pulls in a compatible driver.
+cassandra_cqlsh_venv_packages:
+  - cqlsh
+# Path of the wrapper that execs cqlsh from the venv. Defaults to
+# /usr/local/bin/cqlsh, which shadows the broken distribution cqlsh on PATH
+# (/usr/local/bin precedes $CASSANDRA_HOME/bin) so plain `cqlsh` just works.
+# Set to e.g. /usr/local/bin/cqlsh-venv to install side-by-side instead.
+cassandra_cqlsh_wrapper_path: /usr/local/bin/cqlsh
+
 # It is recommended to leave this as false
 cassandra_start_on_boot: false
 

--- a/roles/cassandra/molecule/cassandra-3.11/converge.yml
+++ b/roles/cassandra/molecule/cassandra-3.11/converge.yml
@@ -12,6 +12,8 @@
     cassandra_install_format: tar
     # Cassandra 3.11 requires Java 8.
     cassandra_seeds: "127.0.0.1"
+    # cqlsh venv is exercised by the default scenario; keep this legacy scenario focused.
+    cassandra_cqlsh_venv_enabled: false
   pre_tasks:
     - name: Workaround missing man1 dir in test containers
       ansible.builtin.file:

--- a/roles/cassandra/molecule/default/converge.yml
+++ b/roles/cassandra/molecule/default/converge.yml
@@ -15,7 +15,6 @@
       ansible.builtin.file:
         path: /usr/share/man/man1/
         state: directory
-        recurse: true
         mode: "0755"
   roles:
     - role: java

--- a/roles/cassandra/molecule/default/verify.yml
+++ b/roles/cassandra/molecule/default/verify.yml
@@ -63,3 +63,55 @@
       ansible.builtin.file:
         path: /tmp/guard-test
         state: absent
+
+# BDD verification — cqlsh virtual environment
+#
+# Behaviour under test: with cassandra_cqlsh_venv_enabled (the default), the role
+# MUST provision an isolated venv containing a working cqlsh and a wrapper that
+# launches it, so cqlsh runs even where the system Python is >= 3.12 (Ubuntu
+# 24.04 / Debian 13).
+- name: Verify cqlsh virtual environment (BDD)
+  hosts: all
+  gather_facts: false
+  vars:
+    cassandra_cqlsh_venv_path: /opt/cassandra-cqlsh-venv
+    cassandra_cqlsh_wrapper_path: /usr/local/bin/cqlsh
+  tasks:
+
+    - name: GIVEN — the role converged with the cqlsh venv enabled
+      ansible.builtin.stat:
+        path: "{{ cassandra_cqlsh_venv_path }}/bin/cqlsh"
+      register: verify_venv_cqlsh
+
+    - name: THEN — the venv contains a cqlsh entry point
+      ansible.builtin.assert:
+        that:
+          - verify_venv_cqlsh.stat.exists
+        fail_msg: cqlsh was not installed into {{ cassandra_cqlsh_venv_path }}
+
+    - name: GIVEN — the wrapper was installed
+      ansible.builtin.stat:
+        path: "{{ cassandra_cqlsh_wrapper_path }}"
+      register: verify_wrapper
+
+    - name: THEN — the wrapper exists and is executable
+      ansible.builtin.assert:
+        that:
+          - verify_wrapper.stat.exists
+          - verify_wrapper.stat.mode == '0755'
+        fail_msg: cqlsh wrapper missing or not executable at {{ cassandra_cqlsh_wrapper_path }}
+
+    - name: WHEN — cqlsh is launched through the wrapper on a modern-Python host
+      ansible.builtin.command: "{{ cassandra_cqlsh_wrapper_path }} --version"
+      register: verify_cqlsh_version
+      changed_when: false
+
+    - name: THEN — cqlsh starts without a Python import error and reports its version
+      ansible.builtin.assert:
+        that:
+          - verify_cqlsh_version.rc == 0
+          - "'cqlsh' in (verify_cqlsh_version.stdout + verify_cqlsh_version.stderr)"
+        fail_msg: >-
+          cqlsh failed to launch from the venv
+          (stdout={{ verify_cqlsh_version.stdout }},
+           stderr={{ verify_cqlsh_version.stderr | default('') }})

--- a/roles/cassandra/tasks/cqlsh-venv.yml
+++ b/roles/cassandra/tasks/cqlsh-venv.yml
@@ -1,0 +1,43 @@
+---
+# Provision a dedicated Python virtual environment for cqlsh.
+#
+# The cqlsh shipped inside the Cassandra tarball (and the distro package) relies
+# on a Python driver that imports stdlib modules removed in Python 3.12+
+# (e.g. asyncore, imp). On Ubuntu 24.04 / Debian 13 the system Python is >= 3.12,
+# so the bundled cqlsh aborts at startup with an import error. We install the
+# maintained standalone `cqlsh` package — which supports modern Python — into an
+# isolated venv and expose it through a wrapper, leaving the system Python and
+# the bundled cqlsh untouched.
+
+- name: Ensure Python venv/pip build dependencies are present (Debian)
+  when: ansible_os_family == "Debian"
+  ansible.builtin.package:
+    name:
+      - python3-venv
+      - python3-pip
+    state: present
+
+- name: Ensure Python pip is present (RedHat)
+  when: ansible_os_family == "RedHat"
+  ansible.builtin.package:
+    name:
+      - python3
+      - python3-pip
+    state: present
+
+- name: Create the cqlsh virtual environment and install cqlsh
+  ansible.builtin.pip:
+    name: "{{ cassandra_cqlsh_venv_packages }}"
+    virtualenv: "{{ cassandra_cqlsh_venv_path }}"
+    virtualenv_command: "{{ cassandra_cqlsh_python }} -m venv"
+    state: present
+
+- name: Install the cqlsh wrapper
+  ansible.builtin.template:
+    src: cqlsh-wrapper.sh.j2
+    dest: "{{ cassandra_cqlsh_wrapper_path }}"
+    mode: "0755"
+    owner: root
+    group: root
+
+# code: language=ansible

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -358,6 +358,11 @@
     disable_gpg_check: true
   when: cassandra_cqlai_binary is defined and ansible_os_family == "RedHat"
 
+- name: Provision cqlsh virtual environment
+  ansible.builtin.import_tasks: cqlsh-venv.yml
+  when: cassandra_cqlsh_venv_enabled | bool
+  tags: cqlsh
+
 - name: Systemd service for cassandra
   ansible.builtin.template:
     dest: /etc/systemd/system/cassandra.service

--- a/roles/cassandra/templates/cqlsh-wrapper.sh.j2
+++ b/roles/cassandra/templates/cqlsh-wrapper.sh.j2
@@ -1,0 +1,8 @@
+#!/bin/sh
+# {{ ansible_managed }}
+#
+# Wrapper that runs cqlsh from the dedicated virtual environment provisioned by
+# the axonops.axonops cassandra role. This makes cqlsh work on hosts whose
+# system Python is too new (>= 3.12, e.g. Ubuntu 24.04 / Debian 13) for the
+# cqlsh shipped inside the Cassandra distribution.
+exec "{{ cassandra_cqlsh_venv_path }}/bin/cqlsh" "$@"


### PR DESCRIPTION
## Summary

- cqlsh shipped with Cassandra imports stdlib modules removed in Python 3.12 (`asyncore`, `imp`), so it aborts at startup on **Ubuntu 24.04 / Debian 13**. The `cassandra` role now provisions an isolated Python virtualenv with the maintained standalone `cqlsh` PyPI package and installs a wrapper at `/usr/local/bin/cqlsh` that **shadows** the broken distribution `cqlsh` on `PATH` — plain `cqlsh` just works. The Cassandra install is left untouched.
- Default-on via `cassandra_cqlsh_venv_enabled: true`; fully configurable (`cassandra_cqlsh_venv_path`, `cassandra_cqlsh_python`, `cassandra_cqlsh_venv_packages`, `cassandra_cqlsh_wrapper_path`).
- Adds BDD molecule verification in the `default` scenario (venv cqlsh exists, wrapper `0755`, `cqlsh --version` launches rc=0) and wires `verify` + `idempotence` into CI for that scenario, exercising the fix on the exact Python 3.12+ distros that motivated it.

Closes #116

## Test plan

- `pre-commit run --all-files` — pass
- `ansible-lint` (production profile) — pass on changed files
- Manually verified on a live box: `/opt/cassandra-cqlsh-venv/bin/cqlsh` connects (reaches network); bundled `cqlsh` fails with "No appropriate python interpreter found"
- Molecule `default` scenario (converge + verify + idempotence) across `rockylinux9`, `rockylinux10`, `ubuntu2204`, `ubuntu2404`, `ubuntu2604`, `debian12`, `debian13`
- Legacy `cassandra-3.11` scenario opts out via `cassandra_cqlsh_venv_enabled: false`

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] `ansible-lint` passes (production profile)
- [ ] Molecule tests pass on all six platforms (run in CI)
- [x] CHANGELOG.md updated
- [x] README updated
- [x] secrets-auditor: SAFE TO COMMIT

Assisted-by: Claude Code
