### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: axonops
 name: axonops
-version: 0.6.1
+version: 0.6.2
 readme: README.md
 authors:
   - AxonOps <support@axonops.com>


### PR DESCRIPTION
## Summary
Version bump for the v0.6.2 release, which includes the new `chrony` role (#122).

Tag `v0.6.2` has already been created and pushed, pointing at this branch's version-bump commit, matching this collection's established release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)