### PR TITLE
Release v0.6.3

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: axonops
 name: axonops
-version: 0.6.2
+version: 0.6.3
 readme: README.md
 authors:
   - AxonOps <support@axonops.com>


### PR DESCRIPTION
## Release v0.6.3

Version bump in `galaxy.yml` (`0.6.2` → `0.6.3`) and tag `v0.6.3`.

### Release notes (changes since v0.6.2)

#### Added

- **configurations role**: opt-in health / config check via the `info` tag (tagged `info` + `never`, so it only runs with `--tags info`). It queries the AxonOps API for the target `org` and `cluster`, validates the `use_saml` setting by retrying once with the opposite value (failing with a clear message if the opposite value is the one that works), and fails the play if any monitored component reports a non-zero `status`, returning a structured `unhealthy` list.
- **info module**: `use_saml` documentation, SAML flip-retry health check, and component status validation (`unhealthy` return field).

#### Changed

- **configurations role**: the preamble tasks (`org` / `cluster` / `cluster_type` resolution and the required-variable assertion) are now tagged `always`, so `--tags info` (and other tag selections) run the required setup standalone.

#### Fixed

- **cassandra role**: added a `[cassandra311]` yum repo stanza so `cassandra_install_format: pkg` works with `cassandra_version` 3.11.x on RedHat-family hosts (previously only 4.1.x / 5.0.x had a repo, causing `No package cassandra-3.11.17-1 available.`). Override via `cassandra_redhat_repository_url_311x`. ([#124](https://github.com/axonops/axonops-ansible-collection/issues/124))
- **cassandra role**: added the missing `gpgkey=` directive to all three RedHat yum repo stanzas (`cassandra311`, `cassandra41`, `cassandra50`). Without it, `repo_gpgcheck=1` failed signature verification on the repo metadata even though the GPG key was already imported into the RPM keyring, causing dnf to silently drop the repo. Pre-existing bug affecting all RedHat pkg installs. ([#124](https://github.com/axonops/axonops-ansible-collection/issues/124))
- **cassandra role**: fixed `ansible.builtin.rpm_key` crashing with `'utf-8' codec can't decode byte 0xe9 ... invalid continuation byte` on ansible-core >= 2.18 — Apache's `KEYS` file has one Latin-1 comment and `rpm_key` strict-decodes the whole file. Now imports via `rpm --import`. ([#124](https://github.com/axonops/axonops-ansible-collection/issues/124))
- **cassandra role**: fixed `rpm --import` failing with `key 1 not an armored public key` on rpm 4.19+ (Rocky/RHEL 10) and dnf's `Parsing armored OpenPGP packet(s) failed`. The role now extracts only the `BEGIN/END PGP PUBLIC KEY BLOCK` sections into `/etc/pki/rpm-gpg/RPM-GPG-KEY-apache-cassandra`, which all repo stanzas' `gpgkey=` point at; that file also serves as the import idempotency marker. ([#124](https://github.com/axonops/axonops-ansible-collection/issues/124))

The `[Unreleased]` section of `CHANGELOG.md` also carries the accumulated notes for the 0.6.x line (Cassandra 3.11 support, cqlsh venv wrapper, data-directory guard, chrony role, Amazon Linux support, TLS/keystore fixes) — that file has never been carved into per-version sections, so it is left untouched here.

### Verification

- `git tag -v v0.6.3` — signed tag verifies, tagger `Sergio Rua <sergio@axonops.com>`.
- Tag pushed to `origin`.

Assisted-by: Claude Code
