### PR TITLE
feat(exporter): add the configurations exporter tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@ venv/
 .claude/settings.local.json
 .ansible
 documents/
+
+# Everything the configurations exporter writes (exports/<org>/<cluster>/*.yaml,
+# .env.axonops and <org>.sh). It lands in whatever directory the tool is run from.
+exports/
+
+# Python bytecode and test caches
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Changed
 
+- **CLI**: `--help` now describes the tool as the "AxonOps CLI" rather than the
+  "AxonOps Adaptive Repair CLI", which no longer covered what it does.
+
 - **CLI**: the `info` command is now `health`. The connection and authentication
   summary it used to print is shown only with `-v`; the default output is the
   cluster health report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to this collection are documented here. The format is based 
 
 ### Added
 
+- **Configurations exporter**: new `configurations_exporter/` tool that exports the
+  AxonOps configuration of a cluster as YAML. `configurations_exporter.py` is a thin
+  front end over the new `src` package (`application.py`, `axonops.py`, `exporter.py`,
+  `urls.py`, `utils.py`). The `export` command reads alert rules, dashboards,
+  integrations, health checks, log collectors, silences, adaptive and scheduled
+  repairs, backups, commitlog archiving, and agent disconnection tolerance, and writes
+  one YAML file per section into `exports/<org>/<cluster>/<section>.yaml`;
+  `--section` restricts the export. Sections the API rejects — a cluster with no
+  commitlog archiving configured, say — are skipped and named in the summary;
+  `--fail-on-error` stops at the first one instead. A `sections` command lists what
+  can be exported. Every global option
+  (`--org`, `--cluster`, `--cluster-type`, `--token`, `--username`, `--password`,
+  `--url`) falls back to the matching `AXONOPS_*` environment variable. Only the org
+  is required: without `--cluster` the cluster list is read from `/api/v1/orgs` and
+  every cluster of the organisation is exported, each with the type the API reports
+  for it; credentials are optional too, so a self-hosted instance with authentication
+  disabled is exported without sending an `Authorization` header. Every export also
+  writes the matching CLI settings into `exports/<org>/`: a `.env.axonops` with the
+  connection variables (the token and the password are left as commented
+  placeholders — no credential is written to disk) and an `<org>.sh` replaying the
+  configuration through `axonopscli`. Sections the CLI cannot set yet are listed as a
+  TODO comment in the script.
+
 - **CLI `health` command**: reports the health of every cluster visible to the
   organisation. A new `Orgs` component queries `/api/v1/orgs` and flattens the
   returned org / type / cluster tree, mapping status `0`/`1`/`2` to

--- a/cli/axonopscli/application.py
+++ b/cli/axonopscli/application.py
@@ -35,7 +35,7 @@ class Application:
 
     def run(self, argv: Sequence):
 
-        parser = argparse.ArgumentParser(description='AxonOps Adaptive Repair CLI')
+        parser = argparse.ArgumentParser(description='AxonOps CLI')
 
         parser.add_argument('--org', type=str, required=False, default=os.getenv('AXONOPS_ORG'),
                             help='Name of your organisation')

--- a/configurations_exporter/CLAUDE.md
+++ b/configurations_exporter/CLAUDE.md
@@ -1,0 +1,66 @@
+# configurations_exporter — CLAUDE.md
+
+Python CLI that exports the configuration of AxonOps clusters (alert rules, dashboards,
+integrations, repairs, backups…) to YAML, plus the `.env.axonops` and `<org>.sh` files
+that let the [AxonOps CLI](../cli) replay that configuration elsewhere.
+
+It is a standalone tool inside an otherwise Ansible collection — the collection-wide
+role/molecule conventions in the root `CLAUDE.md` do not apply here.
+
+## Working directory
+
+Everything is run from `configurations_exporter/`: the entry point resolves `src` as a
+top-level package relative to itself, and the tests import `src.*` the same way.
+
+```shell
+python3 configurations_exporter.py --help
+python3 configurations_exporter.py --org acme --url http://127.0.0.1:3000 export
+python3 -m unittest discover -s tests -v
+```
+
+Dependencies are declared at the **repo root** (`requirements.txt`, `Pipfile`,
+`pyproject.toml`), so install from there. A working venv lives at `../.venv`.
+
+## Layout
+
+| Path | Responsibility |
+| --- | --- |
+| `configurations_exporter.py` | Front end only — builds `Application` and runs it. Keep it thin. |
+| `src/application.py` | Argument parsing, command dispatch, top-level error handling |
+| `src/axonops.py` | HTTP client: base URL resolution, auth, `do_request()` |
+| `src/clusters.py` | Discovers the clusters of an org from `/api/v1/orgs` |
+| `src/exporter.py` | Fetches the sections and writes the YAML |
+| `src/cli_script.py` | Renders `.env.axonops` and `<org>.sh` |
+| `src/urls.py` | Registry of API endpoints and exportable sections |
+| `src/utils.py` | Shared errors (`ExporterError`, `HTTPCodeError`, `APIConnectionError`) and helpers |
+
+## Conventions
+
+- **Adding a section**: one entry in `SECTIONS` in `src/urls.py` — the CLI help, the
+  `sections` command and the export all read from that registry. Do not special-case a
+  section in `exporter.py`.
+- **Never write a credential to disk.** `.env.axonops` gets org / cluster / url /
+  username as live exports; `AXONOPS_TOKEN` and `AXONOPS_PASSWORD` stay commented
+  placeholders. `test_the_token_is_never_written_to_disk` guards this — keep it passing.
+- **Errors** surface as `Error: …` on stderr with exit code 1; never let a `requests`
+  traceback reach the user.
+- **Leniency is the default**: a section the API rejects is skipped and named in the
+  summary. `--fail-on-error` opts into strict mode.
+- **Global options precede the subcommand** (`--org acme export`, not
+  `export --org acme`) — argparse subparsers, so tests must be written that way too.
+- Everything is written under `exports/<org>/<cluster>/`, relative to the cwd.
+  `exports/` is gitignored; tests must chdir into a temp dir (see `ApplicationTestCase`)
+  so they never write into the repo.
+
+## Tests
+
+`unittest` + `unittest.mock`, matching the sibling `cli/` tool rather than the
+pytest-bdd standard used elsewhere. `pytest tests/` collects them too. Cover the happy
+path and the invalid/edge input. Fixtures use `demo`/`demo-cluster`; user-facing docs
+use `acme`.
+
+## Docs
+
+`README.md` is user-facing: no internal API paths, no implementation detail, examples
+run from this directory. Internals belong in its Development section or here. Every
+behaviour change also updates the root `CHANGELOG.md` under `[Unreleased]`.

--- a/configurations_exporter/README.md
+++ b/configurations_exporter/README.md
@@ -1,0 +1,309 @@
+# AxonOps Configuration Exporter
+
+This python script allows you to export your AxonOps configuration, including alert rules, dashboards, and integrations, into a structured YAML format. 
+This can be useful for backup purposes or for migrating configurations between different AxonOps instances.
+
+## Requirements
+- Python 3.10 or higher
+- pip / pip3 / pipenv / uv
+- Access to the AxonOps API with appropriate permissions
+
+## Installation
+1. Clone the repository or download the script directly.
+2. Install the required Python dependencies using one of the methods described below.
+3. Configure your API credentials and organization/cluster information as environment variables or in a configuration file.
+4. Run the script to export your configuration.
+
+### Install Python dependencies
+
+This project provides multiple ways to install Python dependencies.  
+Choose the method that best fits your workflow.
+
+The dependencies are declared at the root of the project (where `requirements.txt`,
+`Pipfile` and `pyproject.toml` are located), so install them from there.
+
+---
+
+#### Option 1: Using pipenv (recommended)
+
+Pipenv is a popular tool for managing Python dependencies and virtual environments. 
+It provides an easy way to create isolated environments and manage dependencies.
+
+```shell
+pip install pipenv
+pipenv install
+```
+To run commands inside the environment:
+```shell
+pipenv shell
+cd configurations_exporter
+python3 configurations_exporter.py -h
+```
+Or:
+```shell
+cd configurations_exporter
+pipenv run python configurations_exporter.py -h
+```
+
+#### Option 2: Using `venv` and `pip`
+
+This is the most portable and widely supported method.
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+Run the application:
+```shell
+cd configurations_exporter
+python3 configurations_exporter.py -h
+````
+#### Option 3: Using uv
+
+uv is a fast alternative to pip.
+
+Install uv:
+
+```shell
+pip install uv
+```
+Then install dependencies:
+
+```shell
+uv pip install -r requirements.txt
+```
+To run the application:
+```shell
+cd configurations_exporter
+uv run python configurations_exporter.py -h
+```
+
+#### Optional: Install from pyproject.toml
+
+If you prefer modern Python packaging tools:
+
+```shell
+pip install .
+```
+With uv:
+```shell
+uv pip install .
+```
+
+**Note:** all the examples below are run from the `configurations_exporter` directory.
+To run from a different directory, use the relative path — e.g.
+`configurations_exporter/configurations_exporter.py` from the root of the project.
+
+## Usage
+
+To run the tool:
+
+```shell
+python3 configurations_exporter.py [GLOBAL OPTIONS] <command> [COMMAND OPTIONS]
+```
+
+Commands:
+
+| Command | Purpose |
+| --- | --- |
+| `export` | Export the configuration of your clusters as YAML |
+| `sections` | List the configuration sections the tool can export |
+
+### Global options
+
+Every global option falls back to an environment variable, so flags and the environment
+are interchangeable.
+
+| Option | Environment variable | Default | Example | Description |
+| --- | --- | --- | --- | --- |
+| `--org` | `AXONOPS_ORG` | — (required) | `acme` | Name of your organisation |
+| `--cluster` | `AXONOPS_CLUSTER` | every cluster of the org | `prod` | Name of your cluster, e.g. `prod`, `stage`, `dev` |
+| `--cluster-type` | `AXONOPS_CLUSTER_TYPE` | `cassandra` | `kafka` | Type of the cluster: `cassandra`, `dse` or `kafka` |
+| `--token` | `AXONOPS_TOKEN` | — | `axon_...` | API token used to authenticate with AxonOps Cloud (SaaS) |
+| `--username` | `AXONOPS_USERNAME` | — | `admin` | Username for AxonOps Self-Hosted when authentication is enabled |
+| `--password` | `AXONOPS_PASSWORD` | — | `s3cret` | Password for AxonOps Self-Hosted when authentication is enabled |
+| `--url` | `AXONOPS_URL` | AxonOps Cloud | `https://axonops.internal:3000` | AxonOps URL when not using AxonOps Cloud |
+| `-v`, `--verbose` | — | off | `-v` | Print the requests being made (repeatable) |
+| `--version` | — | — | `--version` | Print the version and exit |
+
+`--org` is the only required option. When `--url` is omitted the tool talks to AxonOps
+Cloud.
+
+### Choosing the clusters
+
+`--cluster` name one cluster. Optional. Without it,
+every cluster of the organisation is exported, each into its own directory.
+
+`--cluster-type` says what kind of cluster it is: `cassandra` (the default), `dse` or
+`kafka`. It describes the cluster named by `--cluster`; without `--cluster` each
+cluster is exported with its own type.
+
+Credentials are necessary when authentication is enabled:
+
+* `--token` for AxonOps Cloud.
+* `--username` and `--password` for a self-hosted instance with authentication
+  enabled. A `--token`, if given, wins.
+
+```shell
+python3 configurations_exporter.py \
+  --url http://127.0.0.1:3000 --org acme --cluster dev export
+```
+
+### `export` options
+
+| Option | Default | Example | Description |
+| --- | --- | --- | --- |
+| `--section` | all sections | `--section alert_rules` | Export only this section — repeat the flag for several |
+| `--fail-on-error` | off | `--fail-on-error` | Abort the export when a section cannot be exported, instead of skipping it |
+
+Exportable sections: `alert_rules`, `dashboards`, `integrations`, `healthchecks`,
+`logcollectors`, `silences`, `adaptive_repair`, `scheduled_repairs`, `backups`,
+`commitlog_archive`, `agent_disconnection_tolerance`.
+
+The export always writes one YAML file per section into
+`exports/<org>/<cluster>/<section>.yaml`, relative to the directory you run the tool
+from. Existing files are overwritten, so re-running the export refreshes the copy on
+disk.
+
+Not every section exists on every cluster — one with no commitlog archiving
+configured, for instance, has no `commitlog_archive`. Those sections are skipped and
+named in the summary, so the rest of the export still lands on disk:
+
+```text
+Exported 10 section(s) to exports/acme/prod-cassandra/, 1 skipped (commitlog_archive)
+```
+
+Pass `--fail-on-error` to stop at the first section that cannot be exported instead.
+
+### Examples
+
+Export everything from an AxonOps Cloud cluster:
+
+```shell
+export AXONOPS_ORG=acme
+export AXONOPS_CLUSTER=prod-cassandra
+export AXONOPS_TOKEN=axon_your_api_token
+
+python3 configurations_exporter.py export
+# -> exports/acme/prod-cassandra/alert_rules.yaml, dashboards.yaml, ...
+```
+
+Export only the alert rules and dashboards of a self-hosted cluster:
+
+```shell
+python3 configurations_exporter.py \
+  --url https://axonops.internal:3000 \
+  --org acme --cluster prod-cassandra \
+  --username admin --password "$AXONOPS_PASSWORD" \
+  export --section alert_rules --section dashboards
+```
+
+Export a single Kafka cluster, showing each request as it is made:
+
+```shell
+python3 configurations_exporter.py -v \
+  --org acme --cluster prod-kafka --cluster-type kafka --token "$AXONOPS_TOKEN" \
+  export
+# -> exports/acme/prod-kafka/alert_rules.yaml, ...
+```
+
+Export **every** cluster of an organisation from a local instance with authentication
+disabled — no `--cluster`, so they are all exported:
+
+```shell
+python3 configurations_exporter.py \
+  --url http://127.0.0.1:3000 --org acme export
+# -> exports/acme/prod-cassandra/..., exports/acme/prod-kafka/..., ...
+```
+
+### Output format
+
+Every file holds a single section and records the cluster it came from:
+
+`exports/acme/prod-cassandra/alert_rules.yaml`:
+
+```yaml
+org: acme
+cluster: prod-cassandra
+cluster_type: cassandra
+configuration:
+  alert_rules:
+  - alert: CPU high
+    operator: '>'
+    warning_value: 80
+```
+
+### CLI settings
+
+Alongside the YAML, every export writes two files into `exports/<org>/`:
+
+| File | What it is |
+| --- | --- |
+| `.env.axonops` | The connection settings for the [AxonOps CLI](../cli), ready to `source ./.env.axonops` |
+| `<org>.sh` | The CLI commands that reproduce the exported configuration on another environment |
+
+**No credential is ever written to disk.** `AXONOPS_ORG`, `AXONOPS_CLUSTER`,
+`AXONOPS_URL` and `AXONOPS_USERNAME` are filled in from the run; the token and the
+password are left as commented placeholders to complete by hand.
+
+```shell
+# exports/acme/.env.axonops
+export AXONOPS_ORG=acme
+export AXONOPS_URL=https://axonops.internal:3000
+# export AXONOPS_TOKEN='aaaabbbbccccddddeeee'
+# export AXONOPS_PASSWORD='I <3 AxonOps!'
+```
+
+One script covers every cluster of the org, each named explicitly:
+
+```shell
+# exports/acme/acme.sh
+AXONOPS_CLI="${AXONOPS_CLI:-python3 axonops.py}"
+
+### cluster prod-cassandra (cassandra)
+
+# adaptive_repair
+$AXONOPS_CLI --cluster prod-cassandra repair --disabled --gcgrace 86400 \
+  --tableparallelism 10 --segmentretries 3 --excludetwcstables true
+```
+
+Replay it against the target environment with:
+
+```shell
+source ./exports/acme/.env.axonops                       # edit in the credentials first
+AXONOPS_CLI='python3 /path/to/cli/axonops.py' bash ./exports/acme/acme.sh
+```
+
+Only the sections the CLI can set today become commands — `adaptive_repair`,
+`scheduled_repairs` and `silences`. The rest are listed as a `TODO` comment at the
+end of the script and remain available as YAML.
+
+## Development
+
+```shell
+# Run the tests (unittest based; pytest collects them too)
+python3 -m unittest discover -s tests -v
+pytest tests/
+```
+
+Layout:
+
+| Path | Responsibility |
+| --- | --- |
+| `configurations_exporter.py` | Front end — builds `Application` and runs it |
+| `src/application.py` | Argument parsing and command dispatch |
+| `src/axonops.py` | HTTP client: base URL resolution, auth, `do_request()` |
+| `src/clusters.py` | Discovery of the clusters of an org from `/api/v1/orgs` |
+| `src/cli_script.py` | Renders `.env.axonops` and `<org>.sh` from the exported configuration |
+| `src/exporter.py` | Fetches the configuration sections and renders the YAML |
+| `src/urls.py` | Registry of the API endpoints and the exportable sections |
+| `src/utils.py` | Shared errors and helpers |
+
+Adding a section means adding one entry to `SECTIONS` in `src/urls.py` — the CLI help,
+the `sections` command, and the export all read from that registry.
+
+## Support
+
+Maintained by [AxonOps](https://axonops.com). For support, contact us at
+[axonops.com/contact](https://axonops.com/contact).

--- a/configurations_exporter/configurations_exporter.py
+++ b/configurations_exporter/configurations_exporter.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Front end for the AxonOps Configurations Exporter.
+
+All the logic lives in the `src` package; this file only wires the command line
+into `src.application.Application`. Run it as a script:
+
+    python3 configurations_exporter.py --help
+"""
+
+import sys
+
+from src.application import Application
+
+
+def main() -> int:
+    return Application().run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configurations_exporter/src/__init__.py
+++ b/configurations_exporter/src/__init__.py
@@ -1,0 +1,3 @@
+"""AxonOps Configurations Exporter."""
+
+VERSION = "0.0.1"

--- a/configurations_exporter/src/application.py
+++ b/configurations_exporter/src/application.py
@@ -1,0 +1,173 @@
+"""Command line surface of the AxonOps Configurations Exporter."""
+
+import argparse
+import os
+import sys
+from typing import Any, Dict, List, Sequence, Tuple
+
+from . import VERSION
+from .axonops import DEFAULT_CLUSTER_TYPE, AxonOps
+from .cli_script import render_env_file, render_script
+from .clusters import Cluster, discover_clusters
+from .exporter import Exporter, org_directory
+from .urls import SECTION_NAMES
+from .utils import APIConnectionError, ExporterError, HTTPCodeError, safe_filename, write_file
+
+
+class Application:
+    """Parses the command line and dispatches to the matching handler."""
+
+    def __init__(self):
+        self.axonops = None
+
+    def get_axonops(self, args: argparse.Namespace) -> AxonOps:
+        """Build the API client once and reuse it for the whole run."""
+        if self.axonops is None:
+            self.axonops = AxonOps(args.org,
+                                   base_url=args.url,
+                                   username=args.username,
+                                   password=args.password,
+                                   cluster_type=args.cluster_type,
+                                   api_token=args.token,
+                                   verbose=args.v)
+        return self.axonops
+
+    def build_parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(
+            prog='configurations_exporter',
+            description="AxonOps Configurations Exporter - A tool to export configurations from AxonOps"
+        )
+
+        parser.add_argument('--version', action='version', version=f"%(prog)s {VERSION}")
+
+        parser.add_argument('--org', type=str, required=False, default=os.getenv('AXONOPS_ORG'),
+                            help='Name of your organisation')
+        parser.add_argument('--cluster', type=str, required=False, default=os.getenv('AXONOPS_CLUSTER'),
+                            help='Name of your cluster. If omitted, every cluster of the '
+                                 'organisation is exported')
+        parser.add_argument('--cluster-type', type=str, required=False,
+                            default=os.getenv('AXONOPS_CLUSTER_TYPE', DEFAULT_CLUSTER_TYPE),
+                            help=f"Type of the cluster, for example cassandra, dse or kafka "
+                                 f"(default: {DEFAULT_CLUSTER_TYPE}). Ignored without --cluster, "
+                                 f"where each cluster carries the type the API reports for it")
+        parser.add_argument('--token', type=str, required=False, default=os.getenv('AXONOPS_TOKEN'),
+                            help='AUTH_TOKEN used to authenticate with the API in SaaS')
+        parser.add_argument('--username', type=str, required=False, default=os.getenv('AXONOPS_USERNAME'),
+                            help='Username used for AxonOps Self-Hosted when authentication is enabled')
+        parser.add_argument('--password', type=str, required=False, default=os.getenv('AXONOPS_PASSWORD'),
+                            help='Password used for AxonOps Self-Hosted when authentication is enabled')
+        parser.add_argument('--url', type=str, default=os.getenv('AXONOPS_URL'),
+                            help='Specify the AxonOps URL if not using the AxonOps Cloud environment')
+
+        parser.add_argument('-v', '--verbose', dest='v', action='count', default=0, help='Verbosity')
+
+        commands_subparser = parser.add_subparsers(help='commands')
+
+        export_parser = commands_subparser.add_parser(
+            'export',
+            help="Export the configuration of a cluster")
+        export_parser.set_defaults(func=self.run_export)
+
+        export_parser.add_argument('--section', dest='sections', action='append', metavar='NAME',
+                                   help=f"Export only this section, repeatable. "
+                                        f"One of: {', '.join(SECTION_NAMES)}")
+        export_parser.add_argument('--fail-on-error', action='store_true',
+                                   help='Abort the export when the API rejects a section, '
+                                        'instead of skipping it')
+
+        sections_parser = commands_subparser.add_parser(
+            'sections',
+            help='List the configuration sections this tool can export')
+        sections_parser.set_defaults(func=self.run_sections)
+
+        return parser
+
+    def run(self, argv: Sequence[str]) -> int:
+        parser = self.build_parser()
+        args = parser.parse_args(args=argv)
+
+        if not hasattr(args, 'func'):
+            parser.print_help()
+            return 1
+
+        try:
+            return args.func(args)
+        except (ExporterError, HTTPCodeError, APIConnectionError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+    def run_mandatory_args_check(self, args: argparse.Namespace) -> None:
+        """Verify the options every API call depends on are present."""
+        if not args.org:
+            raise ExporterError("The org is mandatory")
+
+        # Credentials are optional: a self-hosted axon-server may have
+        # authentication disabled, which is the default for a local instance.
+        if args.v:
+            print(f"Org: {args.org}", file=sys.stderr)
+            print(f"Cluster: {args.cluster or 'every cluster of the organisation'}",
+                  file=sys.stderr)
+
+    def resolve_clusters(self, args: argparse.Namespace) -> List[Cluster]:
+        """The clusters to export: the named one, or every cluster of the org."""
+        if args.cluster:
+            return [Cluster(args.org, args.cluster_type, args.cluster)]
+
+        if args.v:
+            print("No --cluster given, asking the API for the clusters of the organisation",
+                  file=sys.stderr)
+
+        clusters = discover_clusters(self.get_axonops(args), org=args.org)
+        if not clusters:
+            raise ExporterError(f"No cluster found for the org '{args.org}'")
+
+        return clusters
+
+    def run_sections(self, _args: argparse.Namespace) -> int:
+        """List the exportable configuration sections."""
+        for name in SECTION_NAMES:
+            print(name)
+        return 0
+
+    def run_export(self, args: argparse.Namespace) -> int:
+        """Run the configuration export."""
+        self.run_mandatory_args_check(args)
+
+        axonops = self.get_axonops(args)
+        clusters = self.resolve_clusters(args)
+
+        by_org: Dict[str, List[Tuple[Cluster, Dict[str, Any]]]] = {}
+        for cluster in clusters:
+            exporter = Exporter(axonops,
+                                org=cluster.org,
+                                cluster=cluster.name,
+                                cluster_type=cluster.cluster_type,
+                                sections=args.sections,
+                                verbose=args.v,
+                                ignore_errors=not args.fail_on_error)
+
+            configuration = exporter.fetch()
+            exporter.write(configuration)
+            by_org.setdefault(cluster.org, []).append((cluster, configuration))
+
+        for org, exports in by_org.items():
+            self.write_cli_settings(args, org, exports)
+
+        if len(clusters) > 1:
+            print(f"Exported {len(clusters)} clusters", file=sys.stderr)
+
+        return 0
+
+    def write_cli_settings(self, args: argparse.Namespace, org: str,
+                           exports: List[Tuple[Cluster, Dict[str, Any]]]) -> None:
+        """Write the CLI environment file and the script that replays the export."""
+        directory = org_directory(org)
+
+        env_path = os.path.join(directory, '.env.axonops')
+        write_file(env_path, render_env_file(org, url=args.url, cluster=args.cluster,
+                                             username=args.username))
+
+        script_path = os.path.join(directory, f"{safe_filename(org)}.sh")
+        write_file(script_path, render_script(org, exports))
+
+        print(f"Wrote the CLI settings to {env_path} and {script_path}", file=sys.stderr)

--- a/configurations_exporter/src/axonops.py
+++ b/configurations_exporter/src/axonops.py
@@ -1,0 +1,141 @@
+"""HTTP client for the AxonOps API."""
+
+import json
+from typing import Any, List, Optional
+
+import requests
+
+from .urls import LOGIN_URL
+from .utils import APIConnectionError, HTTPCodeError
+
+# Cluster type assumed when neither the command line nor the orgs tree names one.
+DEFAULT_CLUSTER_TYPE = 'cassandra'
+
+
+class AxonOps:
+    """Minimal read-oriented client for the AxonOps API.
+
+    Base URL resolution follows the same rules as the AxonOps Ansible modules:
+      * no ``base_url`` -> AxonOps Cloud, ``https://dash.axonops.cloud/{org}``
+        (the org is part of the path)
+      * explicit ``base_url`` -> self-hosted axon-server, the org is *not*
+        appended and instead travels in the request path of each endpoint.
+    """
+
+    def __init__(self, org_name: str, base_url: str = '', username: str = '', password: str = '',
+                 cluster_type: str = DEFAULT_CLUSTER_TYPE, api_token: str = '', verbose: int = 0,
+                 timeout: int = 30):
+        self.org_name = org_name
+        self.api_token = api_token
+        self.username = username
+        self.password = password
+        self.cluster_type = cluster_type
+        self.verbose = verbose
+        self.timeout = timeout
+        self.jwt = ''
+
+        if not base_url:
+            self.base_url = f'https://dash.axonops.cloud/{org_name}'
+        else:
+            self.base_url = base_url.rstrip('/')
+
+    def get_cluster_type(self) -> str:
+        """Getter for cluster_type."""
+        return self.cluster_type
+
+    def dash_url(self) -> str:
+        """Base URL every relative endpoint is appended to."""
+        return self.base_url
+
+    def get_jwt(self) -> str:
+        """Log in with username/password and cache the returned JWT."""
+        if self.jwt:
+            return self.jwt
+
+        json_data = {
+            "username": self.username,
+            "password": self.password,
+        }
+        result = self.do_request(LOGIN_URL, json_data=json_data, method='POST')
+
+        token = result.get('token') if isinstance(result, dict) else None
+        if not token:
+            raise HTTPCodeError(f"Login to {self.dash_url()}{LOGIN_URL} did not return a token")
+
+        self.jwt = token
+        return self.jwt
+
+    def bearer(self, url: str) -> str:
+        """Resolve the bearer token to use for a request.
+
+        An API token always wins; otherwise username/password are exchanged for
+        a JWT. The login request itself is never authenticated.
+        """
+        if self.api_token:
+            return self.api_token
+        if url != LOGIN_URL and self.username and self.password:
+            return self.get_jwt()
+        return ''
+
+    def do_request(self, url: str,
+                   method: str = "GET",
+                   json_data: Any = None,
+                   data: Any = None,
+                   ok_codes: Optional[List[int]] = None) -> Any:
+        """Perform an HTTP(S) request against the AxonOps API.
+
+        Parameters:
+            url: relative URL, starting with a leading slash.
+            method: HTTP method to use.
+            json_data: payload to serialise as a JSON body.
+            data: raw body, takes precedence over ``json_data``.
+            ok_codes: status codes treated as success.
+
+        Returns the decoded JSON body, or ``{}`` for an empty response.
+        Raises ``HTTPCodeError`` on any other status code.
+        """
+        if ok_codes is None:
+            ok_codes = [200, 201, 204]
+
+        full_url = f'{self.dash_url()}{url}'
+
+        if data is None and json_data is not None:
+            data = json.dumps(json_data).encode('utf-8')
+
+        headers = {
+            'Accept': 'application/json',
+            'User-agent': 'AxonOps Configurations Exporter',
+        }
+
+        # Nothing to send when the server has authentication disabled.
+        bearer = self.bearer(url)
+        if bearer:
+            headers['Authorization'] = f'Bearer {bearer}'
+
+        if data is not None:
+            headers['Content-type'] = 'application/json'
+
+        method = method.upper()
+        if self.verbose:
+            print(f"{method} {full_url}")
+
+        try:
+            response = requests.request(method, full_url, headers=headers, data=data,
+                                        timeout=self.timeout)
+        except requests.exceptions.RequestException as exc:
+            raise APIConnectionError(f"Could not reach {full_url}: {exc}") from exc
+
+        if response.status_code not in ok_codes:
+            raise HTTPCodeError(f"Call to {full_url} returned {response.status_code}: {response.text[:200]}")
+
+        if response.status_code == 204 or not response.text.strip():
+            return {}
+
+        try:
+            return response.json()
+        except json.decoder.JSONDecodeError as exc:
+            raise HTTPCodeError(f"Call to {full_url} returned a non-JSON body: {response.text[:200]}") from exc
+
+
+if __name__ == "__main__":
+    print("This file is not meant to be run directly. It only contains objects other scripts use.")

--- a/configurations_exporter/src/cli_script.py
+++ b/configurations_exporter/src/cli_script.py
@@ -1,0 +1,267 @@
+"""Render the exported configuration as AxonOps CLI settings.
+
+Two files are produced next to the exported YAML, in `exports/<org>/`:
+
+* `.env.axonops` — the connection settings, in the shape the CLI expects
+  (`source ./.env.axonops`). Secrets are never written: the token and the
+  password are left as commented placeholders to fill in by hand.
+* `<org>.sh` — the `axonopscli` commands that reproduce the exported
+  configuration on another environment.
+
+Only the configuration areas the CLI can set today are turned into commands;
+the rest are listed as a TODO comment at the end of the script.
+"""
+
+import json
+import shlex
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from . import VERSION
+from .clusters import Cluster
+
+# Alert types a silence can cover: payload key -> CLI flag.
+SILENCE_ALERT_FLAGS = {
+    'MetricsAlerts': '--silencemetricsalerts',
+    'ServiceChecksAlerts': '--silenceservicechecksalerts',
+    'EventAlerts': '--silenceeventalerts',
+    'BackupAlerts': '--silencebackupalerts',
+    'BackupRestoreAlerts': '--silencebackuprestorealerts',
+    'AuditAlerts': '--silenceauditalerts',
+    'AdaptiveRepairAlerts': '--silenceadaptiverepairalerts',
+    'GenericAlerts': '--silencegenericalerts',
+    'GenericTaskAlerts': '--silencegenerictaskalerts',
+    'LogAlerts': '--silencelogalerts',
+    'NodeAlerts': '--silencenodealerts',
+    'RepairAlerts': '--silencerepairalerts',
+    'RollingRestartAlerts': '--silencerollingrestartalerts',
+    'ScheduledReportsAlerts': '--silencescheduledreportsalerts',
+}
+
+# Sections the CLI can reproduce, in the order they are written to the script.
+SUPPORTED_SECTIONS = ('adaptive_repair', 'scheduled_repairs', 'silences')
+
+
+def render_env_file(org: str, url: Optional[str] = None, cluster: Optional[str] = None,
+                    username: Optional[str] = None) -> str:
+    """Render the `.env.axonops` for this environment.
+
+    The token and the password are deliberately left commented out — an export
+    never writes a credential to disk.
+    """
+    lines = [
+        "# Connection settings for the AxonOps CLI, written by the AxonOps",
+        f"# Configurations Exporter {VERSION}.",
+        "#",
+        "# Once filled with your details, export the variables with:",
+        "# $ source ./.env.axonops",
+        "",
+        "# export your org",
+        "# This is the only mandatory variable value",
+        f"export AXONOPS_ORG={shlex.quote(org)}",
+        "",
+    ]
+
+    if cluster:
+        lines += [
+            "# export your cluster",
+            "# Leave it unset to work on every cluster of the org",
+            f"export AXONOPS_CLUSTER={shlex.quote(cluster)}",
+            "",
+        ]
+
+    lines += [
+        "# export your token",
+        "# token is used to authenticate in AxonOps Cloud.",
+        "# export AXONOPS_TOKEN='aaaabbbbccccddddeeee'",
+        "",
+        "# export the AxonOps url",
+        "# this needs to be specified if you are using AxonOps Self-Hosted.",
+    ]
+    if url:
+        lines.append(f"export AXONOPS_URL={shlex.quote(url)}")
+    else:
+        lines.append("# export AXONOPS_URL=http://127.0.0.1:3000")
+    lines.append("")
+
+    lines += [
+        "# export user and password",
+        "# this needs to be specified if your authentication method is user and password",
+    ]
+    if username:
+        lines.append(f"export AXONOPS_USERNAME={shlex.quote(username)}")
+    else:
+        lines.append("# export AXONOPS_USERNAME='my_user'")
+    lines += [
+        "# export AXONOPS_PASSWORD='I <3 AxonOps!'",
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+def render_script(org: str, exports: Sequence[Tuple[Cluster, Dict[str, Any]]]) -> str:
+    """Render the `<org>.sh` reproducing the exported configuration."""
+    lines = [
+        "#!/usr/bin/env bash",
+        f"# AxonOps CLI settings for the org '{org}', written by the AxonOps",
+        f"# Configurations Exporter {VERSION}.",
+        "#",
+        "# The org comes from AXONOPS_ORG, so point the environment at the target",
+        "# instance and run the script:",
+        "#   source ./.env.axonops",
+        f"#   bash {org}.sh",
+        "",
+        "set -euo pipefail",
+        "",
+        "# The CLI to drive. Override it to match your checkout, for example:",
+        "#   AXONOPS_CLI='python3 /path/to/cli/axonops.py' bash " + f"{org}.sh",
+        'AXONOPS_CLI="${AXONOPS_CLI:-python3 axonops.py}"',
+        "",
+    ]
+
+    missing = set()
+    for cluster, configuration in exports:
+        lines += [
+            f"### cluster {cluster.name} ({cluster.cluster_type})",
+            "",
+        ]
+
+        for section in SUPPORTED_SECTIONS:
+            if section not in configuration:
+                continue
+
+            commands = render_section(section, cluster, configuration[section])
+            lines.append(f"# {section}")
+            lines += commands or [f"# nothing to set for {section}"]
+            lines.append("")
+
+        missing.update(name for name in configuration if name not in SUPPORTED_SECTIONS)
+
+    if missing:
+        lines += [
+            "# TODO: the CLI has no command for these sections yet, so they are only",
+            "# available as YAML next to this script:",
+        ]
+        lines += [f"#   - {name}" for name in sorted(missing)]
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def render_section(section: str, cluster: Cluster, payload: Any) -> List[str]:
+    """Render one exported section as CLI commands."""
+    if section == 'adaptive_repair':
+        return render_adaptive_repair(cluster, payload)
+    if section == 'scheduled_repairs':
+        return render_scheduled_repairs(cluster, payload)
+    if section == 'silences':
+        return render_silences(cluster, payload)
+    return []
+
+
+def render_adaptive_repair(cluster: Cluster, payload: Any) -> List[str]:
+    """`repair` command mirroring the adaptive repair settings."""
+    if not isinstance(payload, dict):
+        return []
+
+    options = ['--enabled' if payload.get('Active') else '--disabled']
+
+    for key, flag in (('GcGraceThreshold', '--gcgrace'),
+                      ('TableParallelism', '--tableparallelism'),
+                      ('MaxSegmentsPerTable', '--maxsegmentspertable'),
+                      ('SegmentRetries', '--segmentretries'),
+                      ('SegmentTargetSizeMB', '--segmenttargetsizemb')):
+        if payload.get(key) is not None:
+            options += [flag, str(payload[key])]
+
+    if payload.get('BlacklistedTables'):
+        options += ['--excludedtables', ','.join(payload['BlacklistedTables'])]
+
+    if payload.get('FilterTWCSTables') is not None:
+        options += ['--excludetwcstables', str(payload['FilterTWCSTables']).lower()]
+
+    timeout = payload.get('SegmentTimeout')
+    if timeout and timeout != '0s':
+        options += ['--segmenttimeout', timeout]
+
+    return [command(cluster, 'repair', options)]
+
+
+def render_scheduled_repairs(cluster: Cluster, payload: Any) -> List[str]:
+    """One `scheduledrepair` command per scheduled repair."""
+    if not isinstance(payload, dict):
+        return []
+
+    commands = []
+    for repair in payload.get('ScheduledRepairs') or []:
+        params = repair.get('Params') if isinstance(repair, dict) else None
+        if isinstance(params, list):
+            params = params[0] if params else None
+        if not isinstance(params, dict):
+            continue
+
+        options: List[str] = []
+        for key, flag in (('keyspace', '--keyspace'),
+                          ('scheduleExpr', '--scheduleexpr'),
+                          ('parallelism', '--parallelism'),
+                          ('tag', '--tags')):
+            if params.get(key):
+                options += [flag, str(params[key])]
+
+        for key, flag in (('tables', '--tables'),
+                          ('blacklistedTables', '--excludedtables'),
+                          ('nodes', '--nodes'),
+                          ('specificDataCenters', '--datacenters')):
+            if params.get(key):
+                options += [flag, ','.join(str(item) for item in params[key])]
+
+        for key, flag in (('segmentsPerNode', '--segmentspernode'),
+                          ('jobThreads', '--jobthreads')):
+            if params.get(key) is not None:
+                options += [flag, str(params[key])]
+
+        for key, flag in (('segmented', '--segmented'),
+                          ('incremental', '--incremental'),
+                          ('primaryRange', '--partitionerrange'),
+                          ('optimiseStreams', '--optimisestreams'),
+                          ('skipPaxos', '--skippaxos'),
+                          ('paxosOnly', '--paxosonly')):
+            if params.get(key):
+                options.append(flag)
+
+        commands.append(command(cluster, 'scheduledrepair', options))
+
+    return commands
+
+
+def render_silences(cluster: Cluster, payload: Any) -> List[str]:
+    """One `silence --create` command per silence window."""
+    if not isinstance(payload, list):
+        return []
+
+    commands = []
+    for silence in payload:
+        if not isinstance(silence, dict):
+            continue
+
+        options = ['--create']
+        if silence.get('Duration'):
+            options += ['--duration', str(silence['Duration'])]
+        if silence.get('IsRecurring') and silence.get('CronExpr'):
+            options += ['--cronexpr', str(silence['CronExpr'])]
+        if silence.get('DCs'):
+            options += ['--dcs', json.dumps(silence['DCs'])]
+
+        # SilenceAll is what the CLI assumes when no alert type is named.
+        if not silence.get('SilenceAll'):
+            options += [flag for key, flag in SILENCE_ALERT_FLAGS.items() if silence.get(key)]
+
+        commands.append(command(cluster, 'silence', options))
+
+    return commands
+
+
+def command(cluster: Cluster, subcommand: str, options: Sequence[str]) -> str:
+    """Build one CLI invocation for a cluster, quoted for the shell."""
+    argv = ['--cluster', cluster.name, subcommand, *options]
+    return '$AXONOPS_CLI ' + ' '.join(shlex.quote(argument) for argument in argv)

--- a/configurations_exporter/src/clusters.py
+++ b/configurations_exporter/src/clusters.py
@@ -1,0 +1,37 @@
+"""Discovery of the clusters an AxonOps environment knows about."""
+
+from typing import List, NamedTuple, Optional
+
+from .axonops import AxonOps
+from .urls import ORGS_URL
+
+
+class Cluster(NamedTuple):
+    """One cluster to export, as named by the orgs tree."""
+
+    org: str
+    cluster_type: str
+    name: str
+
+
+def discover_clusters(axonops: AxonOps, org: Optional[str] = None) -> List[Cluster]:
+    """Flatten the orgs tree (org -> type -> cluster) into a list of clusters.
+
+    Every cluster carries the type the API reports for it, so an org holding both
+    Cassandra and Kafka clusters is exported with the right type for each.
+    `org` narrows the result down to a single organisation.
+    """
+    tree = axonops.do_request(ORGS_URL) or {}
+
+    clusters = []
+    for org_node in tree.get('children') or []:
+        org_name = org_node.get('name')
+        if org and org_name != org:
+            continue
+
+        for type_node in org_node.get('children') or []:
+            for cluster_node in type_node.get('children') or []:
+                node_type = cluster_node.get('type') or type_node.get('name')
+                clusters.append(Cluster(org_name, node_type, cluster_node.get('name')))
+
+    return clusters

--- a/configurations_exporter/src/exporter.py
+++ b/configurations_exporter/src/exporter.py
@@ -1,0 +1,101 @@
+"""Fetch AxonOps configuration and render it as YAML."""
+
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from .axonops import AxonOps
+from .urls import SECTIONS, cluster_url
+from .utils import ExporterError, HTTPCodeError, safe_filename, write_file
+
+# Every export is written under this directory, one file per section, in
+# `<EXPORT_ROOT>/<org>/<cluster>/<section>.yaml`.
+EXPORT_ROOT = "exports"
+
+
+def org_directory(org: str) -> str:
+    """Directory holding everything exported for one organisation."""
+    return os.path.join(EXPORT_ROOT, safe_filename(org))
+
+
+class Exporter:
+    """Reads the configuration of one cluster and writes it out as YAML."""
+
+    def __init__(self, axonops: AxonOps, org: str, cluster: str,
+                 cluster_type: Optional[str] = None,
+                 sections: Optional[List[str]] = None, verbose: int = 0,
+                 ignore_errors: bool = True):
+        self.axonops = axonops
+        self.org = org
+        self.cluster = cluster
+        self.cluster_type = cluster_type or axonops.get_cluster_type()
+        self.sections = sections or list(SECTIONS)
+        self.verbose = verbose
+        self.ignore_errors = ignore_errors
+        self.skipped: List[str] = []
+
+        unknown = [name for name in self.sections if name not in SECTIONS]
+        if unknown:
+            raise ExporterError(f"Unknown section(s): {', '.join(unknown)}. "
+                                f"Known sections: {', '.join(SECTIONS)}")
+
+    def fetch(self) -> Dict[str, Any]:
+        """Fetch every requested section and return them keyed by section name.
+
+        A section the API rejects is skipped and recorded in `self.skipped`, unless
+        the caller asked for `ignore_errors=False`.
+        """
+        exported: Dict[str, Any] = {}
+        self.skipped = []
+
+        for name in self.sections:
+            endpoint, query = SECTIONS[name]
+            url = cluster_url(endpoint, self.org, self.cluster_type, self.cluster, query)
+
+            if self.verbose:
+                print(f"Exporting {name} of {self.cluster}", file=sys.stderr)
+
+            try:
+                exported[name] = self.axonops.do_request(url)
+            except HTTPCodeError as exc:
+                if not self.ignore_errors:
+                    raise ExporterError(
+                        f"{exc}\nThe '{name}' section may not be available on this AxonOps "
+                        f"version or cluster.") from exc
+                self.skipped.append(name)
+                print(f"Skipping {name} of {self.cluster}: {exc}", file=sys.stderr)
+
+        return exported
+
+    def document(self, exported: Dict[str, Any]) -> Dict[str, Any]:
+        """Wrap the exported sections with the context they were read from."""
+        return {
+            'org': self.org,
+            'cluster': self.cluster,
+            'cluster_type': self.cluster_type,
+            'configuration': exported,
+        }
+
+    def output_directory(self) -> str:
+        """Directory this export is written to."""
+        return os.path.join(org_directory(self.org), safe_filename(self.cluster))
+
+    def write(self, exported: Dict[str, Any]) -> None:
+        """Write one YAML file per section into the export directory."""
+        directory = self.output_directory()
+        os.makedirs(directory, exist_ok=True)
+
+        for name, payload in exported.items():
+            path = os.path.join(directory, f"{safe_filename(name)}.yaml")
+            write_file(path, self._dump(self.document({name: payload})))
+            if self.verbose:
+                print(f"Wrote {path}", file=sys.stderr)
+
+        skipped = f", {len(self.skipped)} skipped ({', '.join(self.skipped)})" if self.skipped else ""
+        print(f"Exported {len(exported)} section(s) to {directory}/{skipped}", file=sys.stderr)
+
+    @staticmethod
+    def _dump(document: Dict[str, Any]) -> str:
+        return yaml.safe_dump(document, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/configurations_exporter/src/urls.py
+++ b/configurations_exporter/src/urls.py
@@ -1,0 +1,52 @@
+"""
+Central registry of the AxonOps API endpoints the exporter reads from.
+
+All paths are relative to the base URL resolved by `AxonOps.dash_url()` and must
+start with a leading slash. Cluster-scoped endpoints are completed at request
+time with `/{org}/{cluster_type}/{cluster}`.
+"""
+
+# Authentication
+LOGIN_URL = "/api/login"
+
+# Org and cluster inventory
+ORGS_URL = "/api/v1/orgs"
+NODES_URL = "/api/v1/nodes"
+
+# Cluster-scoped configuration endpoints
+ALERT_RULES_URL = "/api/v1/alert-rules"
+DASHBOARD_TEMPLATE_URL = "/api/v1/dashboardtemplate"
+INTEGRATIONS_URL = "/api/v1/integrations"
+HEALTHCHECKS_URL = "/api/v1/healthchecks"
+LOGCOLLECTORS_URL = "/api/v1/logcollectors"
+SILENCE_WINDOW_URL = "/api/v1/silenceWindow"
+ADAPTIVE_REPAIR_URL = "/api/v1/adaptiveRepair"
+# GET returns the running, scheduled and adaptive repairs of the cluster.
+# (`/api/v1/cassandrascheduledrepair` only answers POST, to create one.)
+REPAIR_URL = "/api/v1/repair"
+BACKUP_SCHEDULE_URL = "/api/v1/cassandraScheduleSnapshot"
+COMMITLOG_SETTINGS_URL = "/api/v1/cassandraCommitLogsSettings"
+AGENT_DISCONNECTION_TOLERANCE_URL = "/api/v1/configs/agentDisconnectionTolerance"
+
+# The configuration areas the exporter knows how to read, in export order.
+# name -> (endpoint, query string appended to the cluster-scoped URL)
+SECTIONS = {
+    "alert_rules": (ALERT_RULES_URL, ""),
+    "dashboards": (DASHBOARD_TEMPLATE_URL, "?dashver=2.0"),
+    "integrations": (INTEGRATIONS_URL, ""),
+    "healthchecks": (HEALTHCHECKS_URL, ""),
+    "logcollectors": (LOGCOLLECTORS_URL, ""),
+    "silences": (SILENCE_WINDOW_URL, ""),
+    "adaptive_repair": (ADAPTIVE_REPAIR_URL, ""),
+    "scheduled_repairs": (REPAIR_URL, ""),
+    "backups": (BACKUP_SCHEDULE_URL, ""),
+    "commitlog_archive": (COMMITLOG_SETTINGS_URL, ""),
+    "agent_disconnection_tolerance": (AGENT_DISCONNECTION_TOLERANCE_URL, ""),
+}
+
+SECTION_NAMES = list(SECTIONS)
+
+
+def cluster_url(endpoint: str, org: str, cluster_type: str, cluster: str, query: str = "") -> str:
+    """Build a cluster-scoped relative URL for the given endpoint."""
+    return f"{endpoint}/{org}/{cluster_type}/{cluster}{query}"

--- a/configurations_exporter/src/utils.py
+++ b/configurations_exporter/src/utils.py
@@ -1,0 +1,33 @@
+"""Small helpers shared across the exporter."""
+
+import os
+import re
+
+
+class HTTPCodeError(Exception):
+    """Raised when the AxonOps API answers with an unexpected status code."""
+
+
+class APIConnectionError(Exception):
+    """Raised when the AxonOps API cannot be reached at all."""
+
+
+class ExporterError(Exception):
+    """Raised for user-facing errors that should abort the export."""
+
+
+def safe_filename(name: str) -> str:
+    """Turn an arbitrary name into something safe to use as a path segment.
+
+    Path separators and any other unexpected character become an underscore, and
+    leading dots are dropped so a name like `..` cannot escape its directory.
+    """
+    cleaned = re.sub(r'[^A-Za-z0-9._-]+', '_', name).strip('._-')
+    return cleaned or 'unnamed'
+
+
+def write_file(path: str, content: str) -> None:
+    """Write `content` to `path`, creating the directories it needs."""
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write(content)

--- a/configurations_exporter/tests/test_application_unittest.py
+++ b/configurations_exporter/tests/test_application_unittest.py
@@ -1,0 +1,227 @@
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from src.application import Application
+from src.clusters import Cluster
+from src.urls import SECTION_NAMES
+
+
+def run(argv, env=None):
+    """Run the CLI with a controlled environment and return its exit code."""
+    with mock.patch.dict("os.environ", env or {}, clear=True):
+        return Application().run(argv)
+
+
+class ApplicationTestCase(unittest.TestCase):
+    """Runs each test in a temporary directory — an export writes to the cwd."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = tmp.name
+
+        cwd = os.getcwd()
+        os.chdir(self.tmp)
+        self.addCleanup(os.chdir, cwd)
+
+
+class TestArgumentHandling(ApplicationTestCase):
+    def test_no_command_prints_the_help_and_fails(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = run([])
+        self.assertEqual(exit_code, 1)
+        self.assertIn("usage:", buffer.getvalue())
+
+    def test_sections_lists_every_exportable_section(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = run(["sections"])
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(buffer.getvalue().split(), SECTION_NAMES)
+
+    def test_the_org_is_mandatory(self):
+        self.assertEqual(run(["--token", "tok", "export"]), 1)
+
+    def test_credentials_are_optional(self):
+        """A self-hosted server may have authentication disabled."""
+        with mock.patch("src.application.Exporter"):
+            self.assertEqual(
+                run(["--org", "acme", "--cluster", "prod",
+                     "--url", "http://127.0.0.1:3000", "export"]), 0)
+
+    def test_options_default_to_the_axonops_environment_variables(self):
+        env = {
+            "AXONOPS_ORG": "acme",
+            "AXONOPS_CLUSTER": "prod",
+            "AXONOPS_CLUSTER_TYPE": "kafka",
+            "AXONOPS_TOKEN": "tok",
+            "AXONOPS_URL": "https://axonops.internal/",
+        }
+        with mock.patch.dict("os.environ", env, clear=True):
+            application = Application()
+            with mock.patch("src.application.Exporter") as exporter:
+                exit_code = application.run(["export"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(application.axonops.dash_url(), "https://axonops.internal")
+        self.assertEqual(application.axonops.get_cluster_type(), "kafka")
+        self.assertEqual(application.axonops.api_token, "tok")
+        self.assertEqual(exporter.call_args.kwargs["org"], "acme")
+        self.assertEqual(exporter.call_args.kwargs["cluster"], "prod")
+
+    def test_flags_win_over_the_environment(self):
+        env = {"AXONOPS_ORG": "from-env", "AXONOPS_CLUSTER": "from-env", "AXONOPS_TOKEN": "tok"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            application = Application()
+            with mock.patch("src.application.Exporter") as exporter:
+                application.run(["--org", "acme", "--cluster", "prod", "export"])
+
+        self.assertEqual(exporter.call_args.kwargs["org"], "acme")
+        self.assertEqual(exporter.call_args.kwargs["cluster"], "prod")
+
+
+class TestClusterSelection(ApplicationTestCase):
+    """Without --cluster the export covers every cluster of the org."""
+
+    base_argv = ["--org", "demo", "--url", "http://127.0.0.1:3000"]
+
+    def test_a_named_cluster_is_exported_on_its_own(self):
+        with mock.patch("src.application.discover_clusters") as discover, \
+                mock.patch("src.application.Exporter") as exporter:
+            exit_code = run(self.base_argv + ["--cluster", "prod", "export"])
+
+        self.assertEqual(exit_code, 0)
+        discover.assert_not_called()
+        self.assertEqual(exporter.call_count, 1)
+        self.assertEqual(exporter.call_args.kwargs["cluster"], "prod")
+        self.assertEqual(exporter.call_args.kwargs["cluster_type"], "cassandra")
+
+    def test_a_named_cluster_keeps_the_given_cluster_type(self):
+        with mock.patch("src.application.Exporter") as exporter:
+            run(self.base_argv + ["--cluster", "prod", "--cluster-type", "dse", "export"])
+        self.assertEqual(exporter.call_args.kwargs["cluster_type"], "dse")
+
+    def test_without_a_cluster_every_discovered_cluster_is_exported(self):
+        discovered = [Cluster("demo", "cassandra", "demo-cluster"),
+                      Cluster("demo", "kafka", "demo-kafka")]
+
+        with mock.patch("src.application.discover_clusters", return_value=discovered) as discover, \
+                mock.patch("src.application.Exporter") as exporter:
+            exit_code = run(self.base_argv + ["export"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(discover.call_args.kwargs, {"org": "demo"})
+        self.assertEqual(
+            [(call.kwargs["cluster"], call.kwargs["cluster_type"])
+             for call in exporter.call_args_list],
+            [("demo-cluster", "cassandra"), ("demo-kafka", "kafka")])
+        self.assertEqual(exporter.return_value.write.call_count, 2)
+
+    def test_a_discovered_cluster_keeps_its_own_type_over_the_default(self):
+        """--cluster-type describes --cluster; discovery uses what the API reports."""
+        with mock.patch("src.application.discover_clusters",
+                        return_value=[Cluster("demo", "kafka", "demo-kafka")]), \
+                mock.patch("src.application.Exporter") as exporter:
+            run(self.base_argv + ["export"])
+
+        self.assertEqual(exporter.call_args.kwargs["cluster_type"], "kafka")
+
+    def test_an_org_without_clusters_is_an_error(self):
+        with mock.patch("src.application.discover_clusters", return_value=[]):
+            self.assertEqual(run(self.base_argv + ["export"]), 1)
+
+
+class TestExportCommand(ApplicationTestCase):
+    base_argv = ["--org", "acme", "--cluster", "prod", "--token", "tok", "export"]
+
+    def test_export_options_reach_the_exporter(self):
+        with mock.patch("src.application.Exporter") as exporter:
+            exit_code = run(self.base_argv + ["--section", "alert_rules", "--section", "dashboards"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(exporter.call_args.kwargs["sections"], ["alert_rules", "dashboards"])
+        exporter.return_value.write.assert_called_once_with(exporter.return_value.fetch.return_value)
+
+    def test_failing_sections_are_skipped_by_default(self):
+        with mock.patch("src.application.Exporter") as exporter:
+            run(self.base_argv)
+        self.assertTrue(exporter.call_args.kwargs["ignore_errors"])
+
+    def test_fail_on_error_makes_the_export_strict(self):
+        with mock.patch("src.application.Exporter") as exporter:
+            run(self.base_argv + ["--fail-on-error"])
+        self.assertFalse(exporter.call_args.kwargs["ignore_errors"])
+
+    def test_an_api_failure_is_reported_as_a_non_zero_exit(self):
+        from src.utils import HTTPCodeError
+
+        with mock.patch("src.application.Exporter") as exporter:
+            exporter.return_value.fetch.side_effect = HTTPCodeError("boom")
+            self.assertEqual(run(self.base_argv), 1)
+
+    def test_an_unknown_section_is_reported_as_a_non_zero_exit(self):
+        self.assertEqual(run(self.base_argv + ["--section", "nope"]), 1)
+
+
+class TestCliSettings(ApplicationTestCase):
+    """Every export also leaves the CLI settings next to the YAML."""
+
+    base_argv = ["--org", "acme", "--url", "http://127.0.0.1:3000"]
+
+    def export(self, argv):
+        with mock.patch("src.application.Exporter") as exporter:
+            exporter.return_value.fetch.return_value = {"adaptive_repair": {"Active": True}}
+            self.assertEqual(run(self.base_argv + argv), 0)
+
+    def test_both_files_land_in_the_org_directory(self):
+        self.export(["--cluster", "prod", "export"])
+
+        self.assertEqual(sorted(os.listdir(os.path.join(self.tmp, "exports", "acme"))),
+                         [".env.axonops", "acme.sh"])
+
+    def test_the_env_file_carries_the_connection_settings(self):
+        self.export(["--cluster", "prod", "--username", "admin", "export"])
+
+        with open(os.path.join(self.tmp, "exports", "acme", ".env.axonops"),
+                  encoding="utf-8") as handle:
+            content = handle.read()
+
+        self.assertIn("export AXONOPS_ORG=acme", content)
+        self.assertIn("export AXONOPS_CLUSTER=prod", content)
+        self.assertIn("export AXONOPS_URL=http://127.0.0.1:3000", content)
+        self.assertIn("export AXONOPS_USERNAME=admin", content)
+
+    def test_the_token_is_never_written_to_disk(self):
+        with mock.patch("src.application.Exporter"):
+            run(["--org", "acme", "--cluster", "prod", "--token", "sup3r-s3cret",
+                 "--password", "hunter2", "export"])
+
+        with open(os.path.join(self.tmp, "exports", "acme", ".env.axonops"),
+                  encoding="utf-8") as handle:
+            content = handle.read()
+
+        self.assertNotIn("sup3r-s3cret", content)
+        self.assertNotIn("hunter2", content)
+
+    def test_the_script_covers_every_exported_cluster(self):
+        discovered = [Cluster("acme", "cassandra", "prod"), Cluster("acme", "kafka", "events")]
+        with mock.patch("src.application.discover_clusters", return_value=discovered), \
+                mock.patch("src.application.Exporter") as exporter:
+            exporter.return_value.fetch.return_value = {"adaptive_repair": {"Active": True}}
+            run(self.base_argv + ["export"])
+
+        with open(os.path.join(self.tmp, "exports", "acme", "acme.sh"), encoding="utf-8") as handle:
+            script = handle.read()
+
+        self.assertIn("### cluster prod (cassandra)", script)
+        self.assertIn("### cluster events (kafka)", script)
+        self.assertIn("$AXONOPS_CLI --cluster prod repair --enabled", script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/configurations_exporter/tests/test_axonops_basic_unittest.py
+++ b/configurations_exporter/tests/test_axonops_basic_unittest.py
@@ -1,0 +1,124 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from src.axonops import AxonOps
+from src.urls import LOGIN_URL
+from src.utils import APIConnectionError, HTTPCodeError
+
+
+def response(status_code=200, body=None, text=None):
+    if text is None:
+        text = "" if body is None else json.dumps(body)
+    return SimpleNamespace(status_code=status_code, text=text, json=lambda: json.loads(text))
+
+
+class TestAxonOpsBasics(unittest.TestCase):
+    def test_get_cluster_type_default(self):
+        client = AxonOps(org_name="acme")
+        self.assertEqual(client.get_cluster_type(), "cassandra")
+
+    def test_get_cluster_type_custom(self):
+        client = AxonOps(org_name="acme", cluster_type="kafka")
+        self.assertEqual(client.get_cluster_type(), "kafka")
+
+    def test_dash_url_default_uses_org_name(self):
+        client = AxonOps(org_name="acme")
+        self.assertEqual(client.dash_url(), "https://dash.axonops.cloud/acme")
+
+    def test_dash_url_uses_given_base_url_and_strips_trailing_slash(self):
+        client = AxonOps(org_name="acme", base_url="https://example.com/")
+        self.assertEqual(client.dash_url(), "https://example.com")
+
+
+class TestBearer(unittest.TestCase):
+    def test_api_token_wins_over_username_and_password(self):
+        client = AxonOps(org_name="acme", api_token="tok", username="u", password="p")
+        self.assertEqual(client.bearer("/api/v1/orgs"), "tok")
+
+    def test_login_request_is_never_authenticated(self):
+        client = AxonOps(org_name="acme", username="u", password="p")
+        self.assertEqual(client.bearer(LOGIN_URL), "")
+
+    def test_username_and_password_are_exchanged_for_a_jwt(self):
+        client = AxonOps(org_name="acme", username="u", password="p")
+        with mock.patch.object(client, "do_request", return_value={"token": "jwt"}) as do_request:
+            self.assertEqual(client.bearer("/api/v1/orgs"), "jwt")
+            do_request.assert_called_once()
+
+    def test_no_credentials_means_no_bearer(self):
+        client = AxonOps(org_name="acme")
+        self.assertEqual(client.bearer("/api/v1/orgs"), "")
+
+
+class TestGetJWT(unittest.TestCase):
+    def test_token_is_cached_after_the_first_login(self):
+        client = AxonOps(org_name="acme", username="u", password="p")
+        with mock.patch.object(client, "do_request", return_value={"token": "jwt"}) as do_request:
+            self.assertEqual(client.get_jwt(), "jwt")
+            self.assertEqual(client.get_jwt(), "jwt")
+            self.assertEqual(do_request.call_count, 1)
+
+    def test_login_without_a_token_in_the_response_raises(self):
+        client = AxonOps(org_name="acme", username="u", password="p")
+        with mock.patch.object(client, "do_request", return_value={}):
+            with self.assertRaises(HTTPCodeError):
+                client.get_jwt()
+
+
+class TestDoRequest(unittest.TestCase):
+    def setUp(self):
+        self.client = AxonOps(org_name="acme", api_token="tok")
+
+    def test_returns_the_decoded_body(self):
+        with mock.patch("src.axonops.requests.request",
+                        return_value=response(body={"a": 1})) as request:
+            self.assertEqual(self.client.do_request("/api/v1/orgs"), {"a": 1})
+        request.assert_called_once()
+        self.assertEqual(request.call_args.args[1], "https://dash.axonops.cloud/acme/api/v1/orgs")
+        self.assertEqual(request.call_args.kwargs["headers"]["Authorization"], "Bearer tok")
+
+    def test_no_credentials_sends_no_authorization_header(self):
+        client = AxonOps(org_name="acme", base_url="http://127.0.0.1:3000")
+        with mock.patch("src.axonops.requests.request", return_value=response(body={})) as request:
+            client.do_request("/api/v1/orgs")
+        self.assertNotIn("Authorization", request.call_args.kwargs["headers"])
+
+    def test_no_content_returns_an_empty_dict(self):
+        with mock.patch("src.axonops.requests.request", return_value=response(status_code=204)):
+            self.assertEqual(self.client.do_request("/api/v1/orgs"), {})
+
+    def test_empty_body_returns_an_empty_dict(self):
+        with mock.patch("src.axonops.requests.request", return_value=response(text="   ")):
+            self.assertEqual(self.client.do_request("/api/v1/orgs"), {})
+
+    def test_unexpected_status_code_raises(self):
+        with mock.patch("src.axonops.requests.request",
+                        return_value=response(status_code=403, text="forbidden")):
+            with self.assertRaises(HTTPCodeError):
+                self.client.do_request("/api/v1/orgs")
+
+    def test_an_unreachable_server_raises_a_connection_error(self):
+        import requests
+
+        with mock.patch("src.axonops.requests.request",
+                        side_effect=requests.exceptions.ConnectionError("refused")):
+            with self.assertRaises(APIConnectionError):
+                self.client.do_request("/api/v1/orgs")
+
+    def test_non_json_body_raises(self):
+        with mock.patch("src.axonops.requests.request", return_value=response(text="<html>")):
+            with self.assertRaises(HTTPCodeError):
+                self.client.do_request("/api/v1/orgs")
+
+    def test_json_payload_is_serialised_with_a_content_type(self):
+        with mock.patch("src.axonops.requests.request", return_value=response(body={})) as request:
+            self.client.do_request("/api/v1/orgs", method="post", json_data={"k": "v"})
+        self.assertEqual(request.call_args.args[0], "POST")
+        self.assertEqual(request.call_args.kwargs["data"], b'{"k": "v"}')
+        self.assertEqual(request.call_args.kwargs["headers"]["Content-type"], "application/json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/configurations_exporter/tests/test_cli_script_unittest.py
+++ b/configurations_exporter/tests/test_cli_script_unittest.py
@@ -1,0 +1,178 @@
+import unittest
+
+from src.cli_script import render_env_file, render_script
+from src.clusters import Cluster
+
+CASSANDRA = Cluster("demo", "cassandra", "demo-cluster")
+
+ADAPTIVE_REPAIR = {
+    "Ready": True, "Active": True, "GcGraceThreshold": 86400, "SegmentsPerVnode": 1,
+    "TableParallelism": 10, "SegmentRetries": 3, "BlacklistedTables": ["ks.big", "ks.old"],
+    "FilterTWCSTables": True, "SegmentTargetSizeMB": 0, "MaxSegmentsPerTable": 0,
+    "SegmentTimeout": "30m",
+}
+
+SCHEDULED_REPAIRS = {
+    "Repairs": [],
+    "ScheduledRepairs": [{
+        "ID": "abc", "Params": [{
+            "keyspace": "system_auth", "tables": ["roles"], "blacklistedTables": [],
+            "nodes": [], "segmentsPerNode": 4, "segmented": True, "incremental": False,
+            "jobThreads": 2, "scheduleExpr": "0 3 * * *", "primaryRange": True,
+            "parallelism": "DC-Aware", "optimiseStreams": False,
+            "specificDataCenters": ["dc1", "dc2"], "tag": "nightly", "skipPaxos": True,
+            "paxosOnly": False,
+        }],
+    }],
+    "AdaptiveScheduledRepairs": None,
+}
+
+SILENCES = [
+    {"ID": "1", "Duration": "2h", "IsRecurring": True, "CronExpr": "0 1 * * *",
+     "SilenceAll": True, "DCs": []},
+    {"ID": "2", "Duration": "30m", "IsRecurring": False, "CronExpr": "0 * * * *",
+     "SilenceAll": False, "DCs": [{"Name": "dc1"}],
+     "MetricsAlerts": True, "NodeAlerts": True, "BackupAlerts": False},
+]
+
+
+class TestEnvFile(unittest.TestCase):
+    def test_the_org_is_exported(self):
+        self.assertIn("export AXONOPS_ORG=demo", render_env_file("demo"))
+
+    def test_a_given_url_is_exported_and_a_missing_one_is_left_commented(self):
+        self.assertIn("export AXONOPS_URL=http://127.0.0.1:3000",
+                      render_env_file("demo", url="http://127.0.0.1:3000"))
+        self.assertIn("# export AXONOPS_URL=http://127.0.0.1:3000", render_env_file("demo"))
+
+    def test_the_cluster_is_only_written_when_one_was_named(self):
+        self.assertIn("export AXONOPS_CLUSTER=prod", render_env_file("demo", cluster="prod"))
+        self.assertNotIn("AXONOPS_CLUSTER", render_env_file("demo"))
+
+    def test_a_given_username_is_exported(self):
+        self.assertIn("export AXONOPS_USERNAME=admin", render_env_file("demo", username="admin"))
+
+    def test_no_credential_value_is_ever_written(self):
+        """The token and the password stay commented placeholders."""
+        rendered = render_env_file("demo", url="https://dash.axonops.cloud", username="admin")
+        self.assertIn("# export AXONOPS_TOKEN=", rendered)
+        self.assertIn("# export AXONOPS_PASSWORD=", rendered)
+        for line in rendered.splitlines():
+            if line.startswith("export "):
+                self.assertNotIn("TOKEN", line)
+                self.assertNotIn("PASSWORD", line)
+
+    def test_values_needing_it_are_quoted(self):
+        self.assertIn("export AXONOPS_ORG='my org'", render_env_file("my org"))
+
+
+class ScriptTestCase(unittest.TestCase):
+    def render(self, configuration, cluster=CASSANDRA, org="demo"):
+        self.script = render_script(org, [(cluster, configuration)])
+        return self.script
+
+    def commands(self):
+        return [line for line in self.script.splitlines() if line.startswith("$AXONOPS_CLI")]
+
+
+class TestScriptShape(ScriptTestCase):
+    def test_it_is_a_bash_script_naming_the_org(self):
+        script = self.render({})
+        self.assertTrue(script.startswith("#!/usr/bin/env bash"))
+        self.assertIn("org 'demo'", script)
+        self.assertIn("set -euo pipefail", script)
+
+    def test_the_cli_to_drive_is_overridable(self):
+        self.assertIn('AXONOPS_CLI="${AXONOPS_CLI:-python3 axonops.py}"', self.render({}))
+
+    def test_every_cluster_gets_its_own_block(self):
+        script = render_script("demo", [(CASSANDRA, {}),
+                                        (Cluster("demo", "kafka", "demo-kafka"), {})])
+        self.assertIn("### cluster demo-cluster (cassandra)", script)
+        self.assertIn("### cluster demo-kafka (kafka)", script)
+
+    def test_sections_without_a_cli_command_are_listed_as_a_todo(self):
+        script = self.render({"alert_rules": [], "dashboards": {}, "adaptive_repair": {}})
+        self.assertIn("#   - alert_rules", script)
+        self.assertIn("#   - dashboards", script)
+        self.assertNotIn("#   - adaptive_repair", script)
+
+    def test_a_section_with_nothing_to_replay_says_so(self):
+        self.assertIn("# nothing to set for silences", self.render({"silences": []}))
+
+
+class TestAdaptiveRepair(ScriptTestCase):
+    def test_the_settings_become_one_repair_command(self):
+        self.render({"adaptive_repair": ADAPTIVE_REPAIR})
+        self.assertEqual(self.commands(), [
+            "$AXONOPS_CLI --cluster demo-cluster repair --enabled --gcgrace 86400 "
+            "--tableparallelism 10 --maxsegmentspertable 0 --segmentretries 3 "
+            "--segmenttargetsizemb 0 --excludedtables ks.big,ks.old "
+            "--excludetwcstables true --segmenttimeout 30m"
+        ])
+
+    def test_an_inactive_repair_is_disabled(self):
+        self.render({"adaptive_repair": dict(ADAPTIVE_REPAIR, Active=False)})
+        self.assertIn("repair --disabled", self.commands()[0])
+
+    def test_an_unset_segment_timeout_is_left_out(self):
+        self.render({"adaptive_repair": dict(ADAPTIVE_REPAIR, SegmentTimeout="0s")})
+        self.assertNotIn("--segmenttimeout", self.commands()[0])
+
+    def test_no_excluded_tables_means_no_flag(self):
+        self.render({"adaptive_repair": dict(ADAPTIVE_REPAIR, BlacklistedTables=None)})
+        self.assertNotIn("--excludedtables", self.commands()[0])
+
+
+class TestScheduledRepairs(ScriptTestCase):
+    def test_each_scheduled_repair_becomes_a_command(self):
+        self.render({"scheduled_repairs": SCHEDULED_REPAIRS})
+        command = self.commands()[0]
+
+        self.assertIn("--cluster demo-cluster scheduledrepair", command)
+        self.assertIn("--keyspace system_auth", command)
+        self.assertIn("--tables roles", command)
+        self.assertIn("--datacenters dc1,dc2", command)
+        self.assertIn("--segmentspernode 4", command)
+        self.assertIn("--jobthreads 2", command)
+        self.assertIn("--scheduleexpr '0 3 * * *'", command)
+        self.assertIn("--parallelism DC-Aware", command)
+        self.assertIn("--tags nightly", command)
+        self.assertIn("--segmented", command)
+        self.assertIn("--partitionerrange", command)
+        self.assertIn("--skippaxos", command)
+        self.assertNotIn("--incremental", command)
+        self.assertNotIn("--paxosonly", command)
+        self.assertNotIn("--excludedtables", command)
+
+    def test_a_cluster_without_scheduled_repairs_yields_no_command(self):
+        self.render({"scheduled_repairs": {"Repairs": [], "ScheduledRepairs": None}})
+        self.assertEqual(self.commands(), [])
+
+
+class TestSilences(ScriptTestCase):
+    def test_each_silence_becomes_a_create_command(self):
+        self.render({"silences": SILENCES})
+        self.assertEqual(len(self.commands()), 2)
+
+    def test_a_recurring_silence_keeps_its_cron_expression(self):
+        self.render({"silences": SILENCES})
+        self.assertIn("silence --create --duration 2h --cronexpr '0 1 * * *'", self.commands()[0])
+
+    def test_silence_all_names_no_alert_type(self):
+        self.render({"silences": SILENCES})
+        self.assertNotIn("--silence", self.commands()[0].split("silence --create")[1])
+
+    def test_a_targeted_silence_names_its_alert_types_and_dcs(self):
+        self.render({"silences": SILENCES})
+        command = self.commands()[1]
+
+        self.assertIn("--silencemetricsalerts", command)
+        self.assertIn("--silencenodealerts", command)
+        self.assertNotIn("--silencebackupalerts", command)
+        self.assertIn('--dcs \'[{"Name": "dc1"}]\'', command)
+        self.assertNotIn("--cronexpr", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/configurations_exporter/tests/test_clusters_unittest.py
+++ b/configurations_exporter/tests/test_clusters_unittest.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest import mock
+
+from src.axonops import AxonOps
+from src.clusters import Cluster, discover_clusters
+
+# The shape `/api/v1/orgs` answers with: org -> type -> cluster.
+ORGS_TREE = {
+    "children": [
+        {"name": "demo", "type": "org", "children": [
+            {"name": "cassandra", "type": "type", "children": [
+                {"name": "demo-cluster", "type": "cassandra", "status": 0},
+                {"name": "other-cluster", "type": "cassandra", "status": 1},
+            ]},
+            {"name": "kafka", "type": "type", "children": [
+                {"name": "demo-kafka", "type": "kafka", "status": 0},
+            ]},
+        ]},
+        {"name": "acme", "type": "org", "children": [
+            {"name": "cassandra", "type": "type", "children": [
+                {"name": "acme-cluster", "type": "cassandra", "status": 0},
+            ]},
+        ]},
+    ]
+}
+
+
+class TestDiscoverClusters(unittest.TestCase):
+    def setUp(self):
+        self.axonops = AxonOps(org_name="demo", base_url="http://127.0.0.1:3000")
+
+    def discover(self, tree=None, **kwargs):
+        tree = ORGS_TREE if tree is None else tree
+        with mock.patch.object(self.axonops, "do_request", return_value=tree) as do_request:
+            clusters = discover_clusters(self.axonops, **kwargs)
+        self.request = do_request
+        return clusters
+
+    def test_reads_the_orgs_endpoint(self):
+        self.discover()
+        self.request.assert_called_once_with("/api/v1/orgs")
+
+    def test_flattens_every_org_type_and_cluster(self):
+        self.assertEqual(self.discover(), [
+            Cluster("demo", "cassandra", "demo-cluster"),
+            Cluster("demo", "cassandra", "other-cluster"),
+            Cluster("demo", "kafka", "demo-kafka"),
+            Cluster("acme", "cassandra", "acme-cluster"),
+        ])
+
+    def test_org_narrows_the_result(self):
+        self.assertEqual([cluster.name for cluster in self.discover(org="acme")],
+                         ["acme-cluster"])
+
+    def test_every_cluster_keeps_the_type_the_api_reports(self):
+        self.assertEqual([(cluster.name, cluster.cluster_type)
+                          for cluster in self.discover(org="demo")],
+                         [("demo-cluster", "cassandra"), ("other-cluster", "cassandra"),
+                          ("demo-kafka", "kafka")])
+
+    def test_an_unknown_org_finds_nothing(self):
+        self.assertEqual(self.discover(org="nope"), [])
+
+    def test_the_type_falls_back_to_the_name_of_the_type_node(self):
+        tree = {"children": [{"name": "demo", "children": [
+            {"name": "cassandra", "children": [{"name": "demo-cluster"}]}]}]}
+        self.assertEqual(self.discover(tree), [Cluster("demo", "cassandra", "demo-cluster")])
+
+    def test_an_empty_tree_finds_nothing(self):
+        self.assertEqual(self.discover({}), [])
+        self.assertEqual(self.discover({"children": None}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/configurations_exporter/tests/test_exporter_unittest.py
+++ b/configurations_exporter/tests/test_exporter_unittest.py
@@ -1,0 +1,133 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import yaml
+
+from src.axonops import AxonOps
+from src.exporter import EXPORT_ROOT, Exporter
+from src.urls import SECTION_NAMES
+from src.utils import ExporterError, HTTPCodeError
+
+
+class ExporterTestCase(unittest.TestCase):
+    def setUp(self):
+        self.axonops = AxonOps(org_name="acme", api_token="tok")
+
+    def make_exporter(self, **kwargs):
+        kwargs.setdefault("sections", ["alert_rules"])
+        return Exporter(self.axonops, org="acme", cluster="prod", **kwargs)
+
+
+class TestSectionSelection(ExporterTestCase):
+    def test_no_sections_means_every_section(self):
+        self.assertEqual(self.make_exporter(sections=None).sections, SECTION_NAMES)
+
+    def test_unknown_section_is_rejected(self):
+        with self.assertRaises(ExporterError):
+            self.make_exporter(sections=["alert_rules", "nope"])
+
+
+class TestFetch(ExporterTestCase):
+    def test_requests_the_cluster_scoped_url_of_each_section(self):
+        exporter = self.make_exporter(sections=["alert_rules", "dashboards"])
+        with mock.patch.object(self.axonops, "do_request", return_value=[]) as do_request:
+            exporter.fetch()
+
+        self.assertEqual(
+            [call.args[0] for call in do_request.call_args_list],
+            ["/api/v1/alert-rules/acme/cassandra/prod",
+             "/api/v1/dashboardtemplate/acme/cassandra/prod?dashver=2.0"])
+
+    def test_cluster_type_is_part_of_the_url(self):
+        self.axonops.cluster_type = "kafka"
+        with mock.patch.object(self.axonops, "do_request", return_value=[]) as do_request:
+            self.make_exporter().fetch()
+        self.assertEqual(do_request.call_args.args[0], "/api/v1/alert-rules/acme/kafka/prod")
+
+    def test_payloads_are_keyed_by_section_name(self):
+        with mock.patch.object(self.axonops, "do_request", return_value=[{"alert": "CPU"}]):
+            self.assertEqual(self.make_exporter().fetch(), {"alert_rules": [{"alert": "CPU"}]})
+
+    def test_a_failing_section_is_skipped_by_default(self):
+        exporter = self.make_exporter(sections=["alert_rules", "dashboards"])
+        with mock.patch.object(self.axonops, "do_request",
+                               side_effect=[HTTPCodeError("boom"), {"dashboards": []}]):
+            self.assertEqual(exporter.fetch(), {"dashboards": {"dashboards": []}})
+
+        self.assertEqual(exporter.skipped, ["alert_rules"])
+
+    def test_skipped_sections_are_reset_between_fetches(self):
+        exporter = self.make_exporter()
+        with mock.patch.object(self.axonops, "do_request", side_effect=HTTPCodeError("boom")):
+            exporter.fetch()
+        with mock.patch.object(self.axonops, "do_request", return_value=[]):
+            exporter.fetch()
+
+        self.assertEqual(exporter.skipped, [])
+
+    def test_ignore_errors_off_aborts_the_export_and_names_the_section(self):
+        exporter = self.make_exporter(ignore_errors=False)
+        with mock.patch.object(self.axonops, "do_request", side_effect=HTTPCodeError("boom")):
+            with self.assertRaises(ExporterError) as raised:
+                exporter.fetch()
+
+        self.assertIn("alert_rules", str(raised.exception))
+
+
+class TestWrite(ExporterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+        cwd = os.getcwd()
+        os.chdir(self.tmp.name)
+        self.addCleanup(os.chdir, cwd)
+
+    def test_document_carries_the_export_context(self):
+        document = self.make_exporter().document({"alert_rules": []})
+        self.assertEqual(document["org"], "acme")
+        self.assertEqual(document["cluster"], "prod")
+        self.assertEqual(document["cluster_type"], "cassandra")
+        self.assertEqual(document["configuration"], {"alert_rules": []})
+
+    def test_the_output_directory_is_named_after_the_org_and_cluster(self):
+        self.assertEqual(self.make_exporter().output_directory(),
+                         os.path.join(EXPORT_ROOT, "acme", "prod"))
+
+    def test_a_cluster_name_that_is_unsafe_as_a_path_is_cleaned_up(self):
+        exporter = Exporter(self.axonops, org="acme", cluster="../prod cluster")
+        self.assertEqual(exporter.output_directory(),
+                         os.path.join(EXPORT_ROOT, "acme", "prod_cluster"))
+
+    def test_one_file_is_written_per_section(self):
+        exporter = self.make_exporter()
+        exporter.write({"alert_rules": [{"alert": "CPU"}], "dashboards": {}})
+
+        directory = exporter.output_directory()
+        self.assertEqual(sorted(os.listdir(directory)),
+                         ["alert_rules.yaml", "dashboards.yaml"])
+
+        with open(os.path.join(directory, "alert_rules.yaml"), encoding="utf-8") as handle:
+            document = yaml.safe_load(handle)
+
+        self.assertEqual(list(document["configuration"]), ["alert_rules"])
+        self.assertEqual(document["configuration"]["alert_rules"], [{"alert": "CPU"}])
+        self.assertEqual(document["cluster"], "prod")
+
+    def test_an_existing_export_directory_is_reused(self):
+        exporter = self.make_exporter()
+        exporter.write({"alert_rules": []})
+        exporter.write({"alert_rules": [{"alert": "CPU"}]})
+
+        with open(os.path.join(exporter.output_directory(), "alert_rules.yaml"),
+                  encoding="utf-8") as handle:
+            document = yaml.safe_load(handle)
+
+        self.assertEqual(document["configuration"]["alert_rules"], [{"alert": "CPU"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "axonops-ansible-collection"
+version = "0.1.0"
+description = "AxonOps Ansible Collection utilities"
+readme = "README.md"
+requires-python = ">=3.13"
+
+authors = [
+  { name = "AxonOps" }
+]
+
+dependencies = [
+  "yamllint==1.35.1",
+  "ansible-lint>=6.13.1,<25.0.0",
+  "pylint>=2.16.2,<4.0.0",
+]
+
+[project.optional-dependencies]
+dev = []
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary

Adds `configurations_exporter/`, a Python CLI that exports the AxonOps configuration of
a cluster as YAML — alert rules, dashboards, integrations, health checks, log
collectors, silences, adaptive and scheduled repairs, backups, commitlog archiving and
agent disconnection tolerance — one file per section, for backup or for replaying the
configuration on another environment.

Also broadens the `axonopscli` `--help` description (separate commit).

## What it does

- `configurations_exporter.py` is a thin front end over the `src` package; run it from
  the `configurations_exporter/` directory.
- Every global option (`--org`, `--cluster`, `--cluster-type`, `--token`,
  `--username`, `--password`, `--url`) falls back to the matching `AXONOPS_*`
  environment variable.
- Only `--org` is required. Without `--cluster`, every cluster of the organisation is
  exported, each with the type AxonOps reports for it.
- Credentials are optional, so a self-hosted instance with authentication disabled —
  the default for a local one — works out of the box.
- Sections that cannot be exported are skipped and named in the summary;
  `--fail-on-error` stops at the first one instead.
- A `sections` command lists what can be exported. Adding a section is one entry in
  `SECTIONS` in `src/urls.py`.

Output lands in `exports/<org>/<cluster>/<section>.yaml`, alongside the CLI settings in
`exports/<org>/`: a `.env.axonops` with the connection variables and an `<org>.sh` that
replays the configuration through `axonopscli`. Sections the CLI cannot set yet are
listed as a TODO comment in the script.

## Secrets

No credential is ever written to disk. `.env.axonops` carries org, cluster, url and
username; `AXONOPS_TOKEN` and `AXONOPS_PASSWORD` are left as commented placeholders,
guarded by `test_the_token_is_never_written_to_disk`. `exports/` is gitignored.

## Testing

79 unit tests (`unittest` + `unittest.mock`, matching the sibling `cli/` tool), covering
the happy path and invalid/edge input — unknown sections, an org with no clusters, an
unreachable server, credential precedence, and the temp-cwd isolation that keeps tests
from writing into the repo.

```shell
cd configurations_exporter
python3 -m unittest discover -s tests -v     # 79 passed
python3 -m pylint src configurations_exporter.py \
  --disable=C0114,C0115,C0116,C0301,R0913,R0917,R0902   # 10.00/10
```

Every endpoint was verified against a live local AxonOps instance, and the generated
`<org>.sh` was parsed by the real CLI to confirm the flags it emits.

## Notes

- `pyproject.toml` is added at the repo root (the exporter's dependencies are declared
  with the rest of the project's).
- `CHANGELOG.md` updated under `[Unreleased]` for both commits.
- `Pipfile.lock` has an unrelated dependency-refresh churn in the working tree; it was
  deliberately left out of this PR.

Assisted-by: Claude Code